### PR TITLE
A fog-openstack with a more "version less" approach

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -165,6 +165,7 @@ module OpenstackHandle
 
       if api_version == 'v2'
         opts[:openstack_tenant] = tenant if tenant
+        opts[:openstack_identity_api_version] = 'v2.0'
       else # "v3"
         opts[:openstack_project_name] = @project_name = tenant if tenant
         opts[:openstack_project_domain_id] = domain

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
@@ -43,6 +43,8 @@ module OpenstackHandle
       []
     rescue => err
       # Show any list related exception in a nice format.
+      require 'pry-byebug'
+      binding.pry
       openstack_service_name = Handle::SERVICE_NAME_MAP[self.class::SERVICE_NAME]
 
       _log.error "Unable to obtain collection: '#{collection_type}' in service: '#{openstack_service_name}' "\

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
@@ -43,8 +43,6 @@ module OpenstackHandle
       []
     rescue => err
       # Show any list related exception in a nice format.
-      require 'pry-byebug'
-      binding.pry
       openstack_service_name = Handle::SERVICE_NAME_MAP[self.class::SERVICE_NAME]
 
       _log.error "Unable to obtain collection: '#{collection_type}' in service: '#{openstack_service_name}' "\

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -35,7 +35,7 @@ module OpenstackHandle
     #
     def visible_tenants_v2
       response = Handle.try_connection(@os_handle.security_protocol) do |scheme, connection_options|
-        url = Handle.url(@os_handle.address, @os_handle.port, scheme, "/v2.0/tenants")
+        url = Handle.auth_url(@os_handle.address, @os_handle.port, scheme, "/v2.0/tenants")
         connection = Fog::Core::Connection.new(url, false, connection_options)
         response = connection.request(
           :expects => [200, 204],

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.40"
-  s.add_runtime_dependency "fog-openstack",        "~> 0.2"
+  s.add_runtime_dependency "fog-openstack",        ">= 0.2.1"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.40"
-  s.add_runtime_dependency "fog-openstack",        ">= 0.2.1"
+  s.add_runtime_dependency "fog-openstack",        ">= 0.3.7"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.2"
-  s.add_runtime_dependency "bunny",                "~>2.1.0"
-  s.add_runtime_dependency "excon",                "~>0.40"
-  s.add_runtime_dependency "fog-openstack",        "=0.1.27"
-  s.add_runtime_dependency "more_core_extensions", "~>3.2"
+  s.add_runtime_dependency "bunny",                "~> 2.1.0"
+  s.add_runtime_dependency "excon",                "~> 0.40"
+  s.add_runtime_dependency "fog-openstack",        "~> 0.2"
+  s.add_runtime_dependency "more_core_extensions", "~> 3.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -53,11 +53,10 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
-        :openstack_region            => nil,
-        :connection_options          => {:ssl_verify_peer => false}
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
+        :openstack_region               => nil,
+        :connection_options             => {:ssl_verify_peer => false}
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
@@ -67,7 +66,7 @@ describe OpenstackHandle::Handle do
 
     it "handles non ssl connections just fine" do
       fog      = double('fog')
-      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'non-ssl')
+      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'non-ssl')
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "http")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
@@ -75,9 +74,8 @@ describe OpenstackHandle::Handle do
         "dummy",
         "http://address:5000",
         "Compute",
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
         :openstack_region            => nil,
         :connection_options          => {}
       ).once do |_, _, address|
@@ -89,7 +87,7 @@ describe OpenstackHandle::Handle do
 
     it "handles ssl connections just fine, too" do
       fog            = double('fog')
-      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl')
+      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl')
       auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
@@ -97,11 +95,10 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
-        :openstack_region            => nil,
-        :connection_options          => {:ssl_verify_peer => false}
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
+        :openstack_region               => nil,
+        :connection_options             => {:ssl_verify_peer => false}
       ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -112,7 +109,7 @@ describe OpenstackHandle::Handle do
 
     it "handles ssl with validation connections just fine, too" do
       fog            = double('fog')
-      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl-with-validation')
+      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl-with-validation')
       auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
@@ -120,11 +117,10 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
-        :openstack_region            => nil,
-        :connection_options          => {:ssl_verify_peer => true}
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
+        :openstack_region               => nil,
+        :connection_options             => {:ssl_verify_peer => true}
       ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -142,11 +138,10 @@ describe OpenstackHandle::Handle do
       }
 
       expected_options = {
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
-        :openstack_region            => nil,
-        :connection_options          => {
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
+        :openstack_region               => nil,
+        :connection_options             => {
           :ssl_verify_peer => true,
           :ssl_ca_file     => "file",
           :ssl_ca_path     => "path",
@@ -154,7 +149,7 @@ describe OpenstackHandle::Handle do
         }
       }
 
-      handle           = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl-with-validation', extra_options)
+      handle           = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2',  'ssl-with-validation', extra_options)
       auth_url_ssl     = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
@@ -175,7 +170,7 @@ describe OpenstackHandle::Handle do
   context "supports regions" do
     it "handles connections with region just fine" do
       fog      = double('fog')
-      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'non-ssl', :region => 'RegionOne')
+      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'non-ssl', :region => 'RegionOne')
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "http")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
@@ -183,11 +178,10 @@ describe OpenstackHandle::Handle do
         "dummy",
         "http://address:5000",
         "Compute",
-        :openstack_project_name      => "admin",
-        :openstack_project_domain_id => nil,
-        :openstack_user_domain_id    => nil,
-        :openstack_region            => 'RegionOne',
-        :connection_options          => {}
+        :openstack_tenant               => "admin",
+        :openstack_identity_api_version =>"v2.0",
+        :openstack_region               => 'RegionOne',
+        :connection_options             => {}
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog

--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -11,8 +11,8 @@ describe OpenstackHandle::Handle do
     $fog_log = @original_log
   end
 
-  it ".url" do
-    expect(described_class.url("::1")).to eq "http://[::1]:5000"
+  it ".auth_url" do
+    expect(described_class.auth_url("::1")).to eq "http://[::1]:5000"
   end
 
   context "errors from services" do
@@ -49,62 +49,60 @@ describe OpenstackHandle::Handle do
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
-                                           "dummy",
-                                           "dummy",
-                                           "https://address:5000/v2.0/tokens",
-                                           "Compute",
-                                           {:openstack_tenant       => "admin",
-                                            :openstack_project_name => "admin",
-                                            :openstack_project_domain_id => nil,
-                                            :openstack_user_domain_id    => nil,
-                                            :openstack_region       => nil,
-                                            :connection_options     => {:ssl_verify_peer => false}})
-                                           .once do |_, _, address|
+        "dummy",
+        "dummy",
+        "https://address:5000",
+        "Compute",
+        :openstack_project_name      => "admin",
+        :openstack_project_domain_id => nil,
+        :openstack_user_domain_id    => nil,
+        :openstack_region            => nil,
+        :connection_options          => {:ssl_verify_peer => false}
+      ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
       end
-      expect(handle.connect(:tenant_name => "admin")).to eq(fog)
+      expect(handle.connect(:openstack_project_name => "admin")).to eq(fog)
     end
 
     it "handles non ssl connections just fine" do
       fog      = double('fog')
-      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'non-ssl')
+      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'non-ssl')
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "http")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
-                                           "dummy",
-                                           "dummy",
-                                           "http://address:5000/v2.0/tokens",
-                                           "Compute",
-                                           {:openstack_tenant       => "admin",
-                                            :openstack_project_name => "admin",
-                                            :openstack_project_domain_id => nil,
-                                            :openstack_user_domain_id    => nil,
-                                            :openstack_region       => nil,
-                                            :connection_options     => {}})
-                                           .once do |_, _, address|
+        "dummy",
+        "dummy",
+        "http://address:5000",
+        "Compute",
+        :openstack_project_name      => "admin",
+        :openstack_project_domain_id => nil,
+        :openstack_user_domain_id    => nil,
+        :openstack_region            => nil,
+        :connection_options          => {}
+      ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
       end
-      expect(handle.connect(:tenant_name => "admin")).to eq(fog)
+      expect(handle.connect(:openstack_project_name => "admin")).to eq(fog)
     end
 
     it "handles ssl connections just fine, too" do
       fog            = double('fog')
-      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl')
+      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl')
       auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
-                                           "dummy",
-                                           "dummy",
-                                           "https://address:5000/v2.0/tokens",
-                                           "Compute",
-                                           {:openstack_tenant       => "admin",
-                                            :openstack_project_name => "admin",
-                                            :openstack_project_domain_id => nil,
-                                            :openstack_user_domain_id    => nil,
-                                            :openstack_region       => nil,
-                                            :connection_options     => {:ssl_verify_peer => false}}) do |_, _, address|
+        "dummy",
+        "dummy",
+        "https://address:5000",
+        "Compute",
+        :openstack_project_name      => "admin",
+        :openstack_project_domain_id => nil,
+        :openstack_user_domain_id    => nil,
+        :openstack_region            => nil,
+        :connection_options          => {:ssl_verify_peer => false}
+      ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
       end
@@ -114,20 +112,20 @@ describe OpenstackHandle::Handle do
 
     it "handles ssl with validation connections just fine, too" do
       fog            = double('fog')
-      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl-with-validation')
+      handle         = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl-with-validation')
       auth_url_ssl   = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
-                                           "dummy",
-                                           "dummy",
-                                           "https://address:5000/v2.0/tokens",
-                                           "Compute",
-                                           {:openstack_tenant       => "admin",
-                                            :openstack_project_name => "admin",
-                                            :openstack_project_domain_id => nil,
-                                            :openstack_user_domain_id    => nil,
-                                            :openstack_region       => nil,
-                                            :connection_options     => {:ssl_verify_peer => true}}) do |_, _, address|
+        "dummy",
+        "dummy",
+        "https://address:5000",
+        "Compute",
+        :openstack_project_name      => "admin",
+        :openstack_project_domain_id => nil,
+        :openstack_user_domain_id    => nil,
+        :openstack_region            => nil,
+        :connection_options          => {:ssl_verify_peer => true}
+      ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
       end
@@ -143,26 +141,29 @@ describe OpenstackHandle::Handle do
         :ssl_cert_store => "store_obj"
       }
 
-      expected_options = {:openstack_tenant       => "admin",
-                          :openstack_project_name => "admin",
-                          :openstack_project_domain_id => nil,
-                          :openstack_user_domain_id    => nil,
-                          :openstack_region       => nil,
-                          :connection_options     => {:ssl_verify_peer => true,
-                                                      :ssl_ca_file     => "file",
-                                                      :ssl_ca_path     => "path",
-                                                      :ssl_cert_store  => "store_obj"}}
+      expected_options = {
+        :openstack_project_name      => "admin",
+        :openstack_project_domain_id => nil,
+        :openstack_user_domain_id    => nil,
+        :openstack_region            => nil,
+        :connection_options          => {
+          :ssl_verify_peer => true,
+          :ssl_ca_file     => "file",
+          :ssl_ca_path     => "path",
+          :ssl_cert_store  => "store_obj"
+        }
+      }
 
-      handle           = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl-with-validation', extra_options)
+      handle           = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'ssl-with-validation', extra_options)
       auth_url_ssl     = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
-                                           "dummy",
-                                           "dummy",
-                                           "https://address:5000/v2.0/tokens",
-                                           "Compute",
-                                           expected_options
-                                           ) do |_, _, address|
+        "dummy",
+        "dummy",
+        "https://address:5000",
+        "Compute",
+        expected_options
+      ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
       end
@@ -174,24 +175,24 @@ describe OpenstackHandle::Handle do
   context "supports regions" do
     it "handles connections with region just fine" do
       fog      = double('fog')
-      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'non-ssl', :region => 'RegionOne')
+      handle   = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'non-ssl', :region => 'RegionOne')
       auth_url = OpenstackHandle::Handle.auth_url("address", 5000, "http")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "dummy",
         "dummy",
-        "http://address:5000/v2.0/tokens",
+        "http://address:5000",
         "Compute",
-        :openstack_tenant       => "admin",
-        :openstack_project_name => "admin",
+        :openstack_project_name      => "admin",
         :openstack_project_domain_id => nil,
         :openstack_user_domain_id    => nil,
-        :openstack_region       => 'RegionOne',
-        :connection_options     => {}).once do |_, _, address|
-          expect(address).to eq(auth_url)
-          fog
-        end
-      expect(handle.connect(:tenant_name => "admin")).to eq(fog)
+        :openstack_region            => 'RegionOne',
+        :connection_options          => {}
+      ).once do |_, _, address|
+        expect(address).to eq(auth_url)
+        fog
+      end
+      expect(handle.connect(:openstack_project_name => "admin")).to eq(fog)
     end
   end
 end

--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -54,7 +54,7 @@ describe OpenstackHandle::Handle do
         "https://address:5000",
         "Compute",
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
+        :openstack_identity_api_version => 'v2.0',
         :openstack_region               => nil,
         :connection_options             => {:ssl_verify_peer => false}
       ).once do |_, _, address|
@@ -75,9 +75,9 @@ describe OpenstackHandle::Handle do
         "http://address:5000",
         "Compute",
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
-        :openstack_region            => nil,
-        :connection_options          => {}
+        :openstack_identity_api_version => 'v2.0',
+        :openstack_region               => nil,
+        :connection_options             => {}
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
@@ -96,7 +96,7 @@ describe OpenstackHandle::Handle do
         "https://address:5000",
         "Compute",
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
+        :openstack_identity_api_version => 'v2.0',
         :openstack_region               => nil,
         :connection_options             => {:ssl_verify_peer => false}
       ) do |_, _, address|
@@ -118,7 +118,7 @@ describe OpenstackHandle::Handle do
         "https://address:5000",
         "Compute",
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
+        :openstack_identity_api_version => 'v2.0',
         :openstack_region               => nil,
         :connection_options             => {:ssl_verify_peer => true}
       ) do |_, _, address|
@@ -139,7 +139,7 @@ describe OpenstackHandle::Handle do
 
       expected_options = {
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
+        :openstack_identity_api_version => 'v2.0',
         :openstack_region               => nil,
         :connection_options             => {
           :ssl_verify_peer => true,
@@ -149,8 +149,8 @@ describe OpenstackHandle::Handle do
         }
       }
 
-      handle           = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2',  'ssl-with-validation', extra_options)
-      auth_url_ssl     = OpenstackHandle::Handle.auth_url("address", 5000, "https")
+      handle       = OpenstackHandle::Handle.new("dummy", "dummy", "address", 5000, 'v2', 'ssl-with-validation', extra_options)
+      auth_url_ssl = OpenstackHandle::Handle.auth_url("address", 5000, "https")
 
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "dummy",
@@ -179,7 +179,7 @@ describe OpenstackHandle::Handle do
         "http://address:5000",
         "Compute",
         :openstack_tenant               => "admin",
-        :openstack_identity_api_version =>"v2.0",
+        :openstack_identity_api_version => 'v2.0',
         :openstack_region               => 'RegionOne',
         :connection_options             => {}
       ).once do |_, _, address|

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:14 GMT
+      - Thu, 25 Oct 2018 18:19:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9c2e99c9-43c2-43cb-909e-a0476654948d
+      - req-dfe2f966-1328-485f-b6b8-de577b134be3
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:14.498879", "expires":
-        "2018-09-26T19:41:14Z", "id": "6f3ac3d184034873a2d2a314caef08bf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:28.560846", "expires":
+        "2018-10-25T19:19:28Z", "id": "990191f2aff540768d3e06afc6378301", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2aP-WRoDRkqvbcDSO-LylQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bA4PEmKeRAKx6hmqSsOIUA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:41:14 GMT
+      - Thu, 25 Oct 2018 18:19:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-8f75a783-4d96-4e33-a3ba-ea1c39a7a066
+      - req-42b19087-bfdb-41b6-be0d-8015837081c5
       Date:
-      - Wed, 26 Sep 2018 18:41:14 GMT
+      - Thu, 25 Oct 2018 18:19:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:14 GMT
+      - Thu, 25 Oct 2018 18:19:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc096450-5f89-4111-8370-15ba2026d36a
+      - req-28c0465f-8b89-4324-bf76-f424c33de2f4
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:14.935360", "expires":
-        "2018-09-26T19:41:14Z", "id": "82e40f30f2b14ff698750605ef782244", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:28.998949", "expires":
+        "2018-10-25T19:19:28Z", "id": "66d4b59653ae4f3a8a0747c66b8bf73c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["l3zyhF_NRsGMPiyBkQqc3A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["nXtfVuOIQJKNhNxs5DJtrA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,34 +247,34 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0db29ef6-1f6c-457f-8a8c-4e8cb1b1765a
+      - req-b5f3daa4-3cb9-424b-bcc0-72f65bfe08cc
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-0db29ef6-1f6c-457f-8a8c-4e8cb1b1765a
+      - req-b5f3daa4-3cb9-424b-bcc0-72f65bfe08cc
       Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8e2bd586-a17c-4de3-8692-6123227bce05
+      - req-345eda1f-c216-4d1f-b88b-57aeb4ba00d9
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:15.237808", "expires":
-        "2018-09-26T19:41:15Z", "id": "11a0ad2df6e44674811f78b836511d38", "audit_ids":
-        ["lLbBTDElR-SFBt5NRuzMpA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.322728", "expires":
+        "2018-10-25T19:19:29Z", "id": "a2b5ef1f411b4aea8353fb8ded174b3a", "audit_ids":
+        ["5pTzIKx6T3a_8FYGRA4nLA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11a0ad2df6e44674811f78b836511d38
+      - a2b5ef1f411b4aea8353fb8ded174b3a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4e9fbba6-27df-43a8-a379-5da8cd9b1837
+      - req-9b4c74a6-1b89-4566-8815-ccc9ff0f2c66
       Content-Length:
       - '500'
       Connection:
@@ -352,133 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"11a0ad2df6e44674811f78b836511d38"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-928a37b1-084e-471c-80b6-b488a26c3a27
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:15.533255", "expires":
-        "2018-09-26T19:41:15Z", "id": "88e0e9ba88b045c3817f2407b1e4cd15", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["T65GzEd6RxKu3Fn3-sPybQ",
-        "lLbBTDElR-SFBt5NRuzMpA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 11a0ad2df6e44674811f78b836511d38
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-1d3af15b-2287-4725-ae7d-a313a9e7feae
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aa6e7af2-3301-4e91-96c2-bdac0c68a046
+      - req-357aba57-5dd2-4b20-925d-c20309434378
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:15.847338", "expires":
-        "2018-09-26T19:41:15Z", "id": "aa35287c9b3342e2be53cfa7d81ba75b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.699054", "expires":
+        "2018-10-25T19:19:29Z", "id": "c58e8a13f5a74f689e201a76d15d1464", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9p6TJ3_BSGWrfk_EdaW3CA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A_cZ1xgQS2CMwhVKqaElZQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
   response:
     status:
       code: 200
@@ -584,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:41:15 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f5b0b805-7264-4db1-af86-1e782cae867c
+      - req-d63d46e6-aaa4-4bc3-97ee-0c25611e8ff1
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:16.100046", "expires":
-        "2018-09-26T19:41:16Z", "id": "9eadf1492eb14bfaba0f908239d5cd30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:29.958689", "expires":
+        "2018-10-25T19:19:29Z", "id": "9e8fd7d982f24f90941bdcf1a03a7b1c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Y4q2oPFHR7y7znT5wU5DMQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fxaxJkrvR5q1eR9Dn9-v3g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
   response:
     status:
       code: 200
@@ -699,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bcad339d-b29c-460c-99b0-05ca0fe28275
+      - req-1aa2a21c-f481-4c28-b5fc-ca1f4d99b34f
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:16.352196", "expires":
-        "2018-09-26T19:41:16Z", "id": "227a0badeaf64e3eb23dd72ddcc1b781", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:30.224020", "expires":
+        "2018-10-25T19:19:30Z", "id": "8dd483cf8db54c58999e0cd4859df746", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["YJtWqeUOTSSXTCsWdMRTig"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WAXOh8PaQceovhICA_Z7lg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
   response:
     status:
       code: 200
@@ -814,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fc478156-bfa9-443b-b4dc-ab3559dc2d2e
+      - req-581ff0c8-6dc8-4ce1-878e-131e91a779cb
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6242b306-436a-4c23-b389-fdbdb8b06be4
+      - req-7a728a3c-eb56-4ddc-8072-114612826170
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-00d6b94d-ec83-4747-a811-ea861b748008
+      - req-9d8c161b-8ac6-4f29-b115-0b580fe5b5e6
       Date:
-      - Wed, 26 Sep 2018 18:41:16 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-412b4978-acce-4938-acc8-ab51c4bcf345
+      - req-1e26d446-bce4-4a0e-bf27-1ad100bcbe93
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9502e617-aad2-40c5-9a60-d85c24f965e4
+      - req-0497c70c-1391-4104-930c-cce20352c376
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6515cf8a-35f5-427a-8168-943fea5b2908
+      - req-6d616b47-67a8-46a5-80f7-4e9650c368d4
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:21.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:17.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-4dca4e21-6c77-492e-92e6-84662c933b4b
+      - req-55c8a589-c196-4ade-be1a-aa53021e79ca
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:31.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:17.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-710bc7cd-b575-4589-ba1b-db0c64183ab4
+      - req-819058a3-d075-4e36-b3c8-698b3a101dec
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:41:14.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:31.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:09.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:27.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:41:10.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:28.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:31.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:41:17.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:22.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-a2eb99ac-d384-44bb-b70f-795edbbb5edc
+      - req-371bc40f-0d48-4c04-908a-0681494daa15
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-993b0cf0-b69d-4f02-8e0d-73ad42a6457e
+      - req-b34990a2-821c-4a3b-b84f-7e26fb5e261c
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-b3628699-de19-4a35-9637-95058f1b5af2
+      - req-15072573-b1a3-4212-944d-494b120224bf
       Date:
-      - Wed, 26 Sep 2018 18:41:17 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-4e1e8933-a388-45f3-a7c2-8d4d13e8e205
+      - req-180ef6fa-966c-4be7-bae0-6d80dfaab13a
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d963e9f6-8669-4a51-9ad2-727a8b52a4f1
+      - req-b3fb3868-56c3-4808-9f81-feb42c9ef6cb
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0fbd3ecd-d049-41ac-a78d-466043461a69
+      - req-a0cd636f-e2b2-4363-8e8a-9538f4abb8d0
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:18.327265", "expires":
-        "2018-09-26T19:41:18Z", "id": "1c8ca6528f3d4773b1aa3f6202866fb6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.087749", "expires":
+        "2018-10-25T19:19:32Z", "id": "5d015f67b4dc445a85233039ce14544d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["x0sEg8aiShqDQu3HfiIk9Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["A8I85HB0TIWQp-_0ajsQfw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,46 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c8ca6528f3d4773b1aa3f6202866fb6
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.233:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.233:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a81f26d9-427c-4264-9fbb-435abef55739
+      - req-5411952e-c451-4102-882e-b2edf32e047a
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:18.615490", "expires":
-        "2018-09-26T19:41:18Z", "id": "686a3ba14f524a6cb4ab2120e268a6f7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.281562", "expires":
+        "2018-10-25T19:19:32Z", "id": "0c5533a065424f2cac14800ce74fbd51", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7Lpuuj0bTg64y7-326V8cQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uitttIXBT12odG0dCT8lxw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 686a3ba14f524a6cb4ab2120e268a6f7
+      - 0c5533a065424f2cac14800ce74fbd51
   response:
     status:
       code: 200
@@ -1634,9 +1469,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1ce88995-cd67-4d50-9731-5c3756cbb40d
+      - req-df4f3f4b-6ab4-4add-a9cd-d4404504dc66
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1513,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 686a3ba14f524a6cb4ab2120e268a6f7
+      - 0c5533a065424f2cac14800ce74fbd51
   response:
     status:
       code: 200
@@ -1704,14 +1539,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-bfeb2482-2c42-41f3-825e-2fc5be206807
+      - req-302384b7-78b6-45b6-b4ce-897f9ee74a38
       Date:
-      - Wed, 26 Sep 2018 18:41:18 GMT
+      - Thu, 25 Oct 2018 18:19:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1564,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc4a06fd-9fdb-4f61-ab91-466c9c2cf53a
+      - req-5237edf0-7307-4c6f-a33f-7d563e1f977c
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1579,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:19.095072", "expires":
-        "2018-09-26T19:41:19Z", "id": "adfdb40251c64c88a9327714f99e58cc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:32.913408", "expires":
+        "2018-10-25T19:19:32Z", "id": "1244d26528594e1294914a2f06e269c5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["bVN1wqYLSPi7ctR0KmM7qg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fCwkL8H1QVWiiYUXK3fCfA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1626,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adfdb40251c64c88a9327714f99e58cc
+      - 1244d26528594e1294914a2f06e269c5
   response:
     status:
       code: 200
@@ -1817,9 +1652,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-70e2131f-a484-4817-8b0e-f25f18f8df23
+      - req-e245297c-8bc5-4cf9-b45c-fddeb582a46c
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1696,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adfdb40251c64c88a9327714f99e58cc
+      - 1244d26528594e1294914a2f06e269c5
   response:
     status:
       code: 200
@@ -1887,14 +1722,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1cf218cf-cce6-4d02-b222-da17e93f6020
+      - req-37474057-d49f-4093-ad36-43666c826dac
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c8ca6528f3d4773b1aa3f6202866fb6
+      - 5d015f67b4dc445a85233039ce14544d
   response:
     status:
       code: 200
@@ -1920,9 +1755,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-63296ccd-1143-4412-8592-d71f5aa728bf
+      - req-0c809ad0-89c5-4def-8485-338c71091f90
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1799,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c8ca6528f3d4773b1aa3f6202866fb6
+      - 5d015f67b4dc445a85233039ce14544d
   response:
     status:
       code: 200
@@ -1990,14 +1825,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d96a89c7-3b06-4525-b43f-091adda149d4
+      - req-d8edbba8-4094-4c87-9a2a-613221647d1a
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +1850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:19 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f7647c81-b5c7-401d-ade5-7535398968ef
+      - req-828c91aa-d37d-4ef3-aaa2-eccdf6550d6c
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +1865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:20.043936", "expires":
-        "2018-09-26T19:41:20Z", "id": "cb867a3009a048f885d5b8c2aaa5ddf7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:33.796802", "expires":
+        "2018-10-25T19:19:33Z", "id": "243929abf8a64a7f8be41114f3bd9606", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4I1p0WT1RWS6NzBD89CGYQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5FjpT4WKSRKBft24ilO3iw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +1912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb867a3009a048f885d5b8c2aaa5ddf7
+      - 243929abf8a64a7f8be41114f3bd9606
   response:
     status:
       code: 200
@@ -2103,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e474f50d-375b-42db-85f4-4a8ea2ae1f5c
+      - req-45e6b0a7-d13a-489d-a9fe-6d655464aa98
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb867a3009a048f885d5b8c2aaa5ddf7
+      - 243929abf8a64a7f8be41114f3bd9606
   response:
     status:
       code: 200
@@ -2173,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e45f3725-5921-48e6-bb16-79da4ca54bf0
+      - req-1f16e7d6-1931-4360-9ee8-91d650a77b95
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-92928427-643f-4652-a907-4912999b3011
+      - req-63792062-2982-4cd2-9e6d-73af82cc8991
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-40eef711-d0f9-40fc-8492-63e9bf9f9121
+      - req-da2094a6-6e50-4560-ad29-f0fb5fbd0653
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-18d8e9db-4433-4a24-9a98-b81cd80c76e9
+      - req-02ee77bb-c5a4-4d9f-8805-72e78dd123f6
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8e2853ee-05d4-46ad-b583-b5fbb9b99668
+      - req-bfc167d1-694c-48f7-b6b6-306664c25b87
       Date:
-      - Wed, 26 Sep 2018 18:41:20 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8cd72def-fe03-4a64-9188-31b2d41ec078
+      - req-5fa092ce-c119-499f-80ab-936f94e2fcf0
       Date:
-      - Wed, 26 Sep 2018 18:41:21 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c5684b0c-7dc9-4613-9e45-98a02758048c
+      - req-726b8dbc-3acc-4785-a6f3-a2fcf192e8ae
       Date:
-      - Wed, 26 Sep 2018 18:41:21 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d4ea8fcb-12a1-4224-940a-cb894d74cfcd
+      - req-07528758-0f07-4537-b908-aabb8bc18217
       Date:
-      - Wed, 26 Sep 2018 18:41:21 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5b0c4140-3099-4ce5-9bfe-9ae4c2daf16e
+      - req-9d4fbb9a-d8a4-414a-bd33-931ca367e9ee
       Date:
-      - Wed, 26 Sep 2018 18:41:21 GMT
+      - Thu, 25 Oct 2018 18:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:22 GMT
+      - Thu, 25 Oct 2018 18:19:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-78856185-2fff-4232-96b9-7c79c76c4a79
+      - req-166c8f95-45f9-47ee-9ed1-7b067e400551
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:22.770269", "expires":
-        "2018-09-26T19:41:22Z", "id": "7847afc6592a4483a6e3cb60eb2d11b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.173024", "expires":
+        "2018-10-25T19:19:35Z", "id": "73a30794b94e48a9923a774aeb9c6cda", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hXdxktcOTjGoG-trkBqxMw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gW8w3I0TT1KuYRtJhDLDzA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:22 GMT
+      - Thu, 25 Oct 2018 18:19:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ebf3a6be-290d-4b10-af76-521597bf26c5
+      - req-28e95448-3ba4-48f5-8062-017e8760a204
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:22.949994", "expires":
-        "2018-09-26T19:41:22Z", "id": "16e270447c384ec48a89114cb54aec83", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.365316", "expires":
+        "2018-10-25T19:19:35Z", "id": "c94e2e913e964a9eb171c6cb4ee2ef93", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Rnr04_TiQ0aidtMqFzLurA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PxKJJx20QviK6JVY-hYp9w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -2687,9 +2522,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-45a58286-a732-4107-836e-b08da035bf60
+      - req-33ac45f4-ea1f-4047-a0ad-d13cafa186ca
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2558,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -2749,14 +2584,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a1b09a07-39fb-4671-b49e-8e7ffc18f21f
+      - req-dd38b4a5-d4df-4076-a11f-6de3c29a4bc5
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0bd4f043-471e-4223-a64c-62d1318a17e0
+      - req-8516f588-316a-4d4b-a158-4bd4248635b9
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:23.517796", "expires":
-        "2018-09-26T19:41:23Z", "id": "4b72607e0af74276b4fb3712d65d3995", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:35.848824", "expires":
+        "2018-10-25T19:19:35Z", "id": "bbe5d86d541645189779118e8123c59d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8GyU3YkhQrK6dTAtfI4xwQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5SUF8aZoSRaXF5bqomkxlg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2671,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b72607e0af74276b4fb3712d65d3995
+      - bbe5d86d541645189779118e8123c59d
   response:
     status:
       code: 200
@@ -2862,14 +2697,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-84e5d4c3-8c5d-4672-a68e-ff1e6d133d2e
+      - req-d8e5fa2c-e16c-4d23-b9da-445f5d569c46
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7847afc6592a4483a6e3cb60eb2d11b9
+      - 73a30794b94e48a9923a774aeb9c6cda
   response:
     status:
       code: 200
@@ -2895,14 +2730,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c4664d70-525f-4b0d-b40d-ba1c6248adc2
+      - req-8761b290-e56a-445e-9ab4-9b52ef3def0d
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:23 GMT
+      - Thu, 25 Oct 2018 18:19:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ab3031c6-a9cd-46f9-976d-68f9212171fb
+      - req-2ac50de9-6f60-4f14-921f-24dcedb25a9a
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:24.033628", "expires":
-        "2018-09-26T19:41:24Z", "id": "908f2e2aa3604883844304755ea768be", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:36.338316", "expires":
+        "2018-10-25T19:19:36Z", "id": "3f633ada54f74d3eb444ae900a7b38bf", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["w4cjd60bSayRstx7a3jxoA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AUCaDI95SMesmfuFg6YkFA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2817,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 908f2e2aa3604883844304755ea768be
+      - 3f633ada54f74d3eb444ae900a7b38bf
   response:
     status:
       code: 200
@@ -3008,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7320a706-643b-4e78-9f44-cfa1878cd79c
+      - req-035ccb77-a4b1-4eba-8468-49e5cbb1b516
       Date:
-      - Wed, 26 Sep 2018 18:41:24 GMT
+      - Thu, 25 Oct 2018 18:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3041,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1d31171a-fd02-49f8-9c8b-bc73029d4306
+      - req-0812159c-8b4b-497f-a19d-fa9dd2bdf512
       Date:
-      - Wed, 26 Sep 2018 18:41:24 GMT
+      - Thu, 25 Oct 2018 18:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3096,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-713badc0-bf13-4565-aea0-213d862709c6
+      - req-1320fc76-7a0f-4c0c-a595-c89eac23495e
       Date:
-      - Wed, 26 Sep 2018 18:41:24 GMT
+      - Thu, 25 Oct 2018 18:19:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3151,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-45bc0a10-c81a-4ea3-aed8-b04d32d706d1
+      - req-ee9e445b-d9ab-4542-b025-6398f24108c2
       Date:
-      - Wed, 26 Sep 2018 18:41:25 GMT
+      - Thu, 25 Oct 2018 18:19:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3206,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-41ee4065-a851-4973-acc2-9271bc9cea65
+      - req-285f4204-4f39-45aa-842f-d0cf9fb3899f
       Date:
-      - Wed, 26 Sep 2018 18:41:25 GMT
+      - Thu, 25 Oct 2018 18:19:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3290,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b5f7161e-e11d-4c6d-9080-b444fb200879
+      - req-cc4418c5-bd71-4ee9-b0d5-43f072117b06
       Date:
-      - Wed, 26 Sep 2018 18:41:25 GMT
+      - Thu, 25 Oct 2018 18:19:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,13 +3167,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-a21bc1fe-1e2e-4492-8c3c-c475874e4645
+      - req-cac7a0db-7444-4fa7-a918-8d1da041e9cf
       Date:
-      - Wed, 26 Sep 2018 18:41:25 GMT
+      - Thu, 25 Oct 2018 18:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -3380,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-8261e269-8d71-4c09-9b93-a75840f6e436
+      - req-188c4a1e-517e-4745-88f9-5bc74526a2b4
       Date:
-      - Wed, 26 Sep 2018 18:41:26 GMT
+      - Thu, 25 Oct 2018 18:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3434,7 +3269,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:41:33Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -3456,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,13 +3319,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-5736ebf1-950f-4ac8-8b61-a055afbd019d
+      - req-e46bb008-8a45-4dd2-af01-373c1a62a7bf
       Date:
-      - Wed, 26 Sep 2018 18:41:26 GMT
+      - Thu, 25 Oct 2018 18:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:24Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -3511,7 +3346,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -3534,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-2613ce83-3b68-4a8d-8c93-94c862f351be
+      - req-eba19b30-4c5c-469e-9b0f-c02143726015
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-26a52055-ae2d-4b51-bfcb-061e6015e28c
+      - req-c8917590-2478-49cf-ac5f-e92c012de40e
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-a43f4bc2-c342-4f50-a58e-575efc27d094
+      - req-516dcab1-b95d-439c-836e-94e4e6681a37
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-59ffb479-48f8-4a96-bf52-fe2c20db47a5
+      - req-777342bf-be2e-4519-85c9-748ded077a87
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e5e5ceda-d86e-47ac-a4ee-1d71b3f2fca0
+      - req-4e7f0eba-7465-494e-867a-13430c700e53
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3790,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-93214eaa-931e-482a-aa2e-4b62949ef6b2
+      - req-fa10b37d-ed58-4e0f-bcf6-3273c9d78105
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3874,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1674e7b4-4204-40c2-99d6-5d4c1823cc4e
+      - req-aa087ae0-8b4a-498f-a5cd-dd53cb54828d
       Date:
-      - Wed, 26 Sep 2018 18:41:27 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3914,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-705b119b-7453-4a18-86a6-a4b004c07a9e
+      - req-4459128f-b487-46f5-a5ed-da2ced4b34bf
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16e270447c384ec48a89114cb54aec83
+      - c94e2e913e964a9eb171c6cb4ee2ef93
   response:
     status:
       code: 200
@@ -3998,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c6df60fe-2b22-4261-815f-b5137a98b7ce
+      - req-948f5d1f-b7b1-4e2f-99b8-8b422b8567da
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d7f1873f-e902-446d-9d2d-9fe0d8f1c611
+      - req-b98be6c3-1f74-449d-b12b-f788d9927935
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9eadf1492eb14bfaba0f908239d5cd30
+      - 9e8fd7d982f24f90941bdcf1a03a7b1c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d36ead8f-3877-4e4b-8a9a-6814e47ad0cc
+      - req-cfc9e33a-fcbc-475c-8a39-359f9616f29c
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-54e7ff76-77a1-4023-b77f-a2e5b8d80fbf
+      - req-7c325ac4-4c3e-4a86-abb0-5da83f690443
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 227a0badeaf64e3eb23dd72ddcc1b781
+      - 8dd483cf8db54c58999e0cd4859df746
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b9742701-c86b-4f69-9083-fa7073ddd621
+      - req-82f6752a-aa61-4371-9eeb-18cfbdb44cf0
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:28 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74afe401-3fe4-4dde-b309-91255ba6942a
+      - req-1440da09-fb6c-4fd7-add0-fcc0b710dbee
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:28.698985", "expires":
-        "2018-09-26T19:41:28Z", "id": "189d4967f35143b5ace53d0c8aa93e9b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:40.492811", "expires":
+        "2018-10-25T19:19:40Z", "id": "1429ef77659a4dc4bcc8501f33cc22a0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4VpbKg3QS8O-1CIseLMVjQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FkyJBp8dSGi8YJVE020d8A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4098,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cceecffa-597c-4124-8a6d-7391c87016f8
+      - req-d5874ef9-9be5-4c32-8263-a3d21b96c39e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cceecffa-597c-4124-8a6d-7391c87016f8
+      - req-d5874ef9-9be5-4c32-8263-a3d21b96c39e
       Date:
-      - Wed, 26 Sep 2018 18:41:29 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4123,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4141,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:29 GMT
+      - Thu, 25 Oct 2018 18:19:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-43580f02-4e07-4918-beb6-cd20bbd1b6ee
+      - req-ae8dc2b1-bc85-4878-912a-afef857bc435
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4156,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:29.484511", "expires":
-        "2018-09-26T19:41:29Z", "id": "ca99e45f7ba14aa9bf6ff56a3af8bee3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:40.960276", "expires":
+        "2018-10-25T19:19:40Z", "id": "3d10dad5175141b2b112b02b6c6e3df2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pU12F5RnQNKF2h1G90suBQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LzYxvDIBQWWOiFppkoeXVA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4203,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4218,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca99e45f7ba14aa9bf6ff56a3af8bee3
+      - 3d10dad5175141b2b112b02b6c6e3df2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-66d64a0d-6f4b-4f6a-a2a6-e188d0665996
+      - req-3afe987a-827f-48e8-9668-2ed89a1995c1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-66d64a0d-6f4b-4f6a-a2a6-e188d0665996
+      - req-3afe987a-827f-48e8-9668-2ed89a1995c1
       Date:
-      - Wed, 26 Sep 2018 18:41:29 GMT
+      - Thu, 25 Oct 2018 18:19:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4243,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d91448c4-56a3-4e95-905b-30012d1dc900
+      - req-1225e5bd-4aa9-4a3d-8f8b-5626c27f17d7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d91448c4-56a3-4e95-905b-30012d1dc900
+      - req-1225e5bd-4aa9-4a3d-8f8b-5626c27f17d7
       Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
+      - Thu, 25 Oct 2018 18:19:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4301,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
+      - Thu, 25 Oct 2018 18:19:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-300f60b2-eebe-4f84-92b6-c7f1e2b1618e
+      - req-0de16fba-b5a9-40f8-86b6-8b816d0ea943
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4316,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:30.267046", "expires":
-        "2018-09-26T19:41:30Z", "id": "479b2f315911497ca2d483c4b883b893", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:41.709364", "expires":
+        "2018-10-25T19:19:41Z", "id": "847db75874ae4d699f138892ed5706bd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["d4NVhRecTV64-4BDKDkMNw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g-Ou0t9QQ0SRvqBhKaHAew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4363,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479b2f315911497ca2d483c4b883b893
+      - 847db75874ae4d699f138892ed5706bd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eeb8db8c-5c73-4390-bad6-c0862846015d
+      - req-8f760f38-9ef8-4994-8c81-7111ae5865f9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-eeb8db8c-5c73-4390-bad6-c0862846015d
+      - req-8f760f38-9ef8-4994-8c81-7111ae5865f9
       Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bdee87d8-de25-408e-8e54-1e3da74656ad
+      - req-dfcea7f5-def7-4a4e-a611-a52d7794d735
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:30.775884", "expires":
-        "2018-09-26T19:41:30Z", "id": "a2ebd7573efe4b11ad41ac7c76dac3eb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.184342", "expires":
+        "2018-10-25T19:19:42Z", "id": "9848bf5762a04482936bd84eaf59ba8c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nPyqNPFQRf2lG03pz4v2Pg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["TqNjcZXvQNOBraeUuzZaNQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,39 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a2ebd7573efe4b11ad41ac7c76dac3eb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:30 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-da262085-e020-4c13-8ec9-26bdbbf4185d
+      - req-6211a279-557b-4058-9a13-95349330a7ae
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:31.045612", "expires":
-        "2018-09-26T19:41:31Z", "id": "3d5ec5a14a3f4c5484032aa350a537ba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.364199", "expires":
+        "2018-10-25T19:19:42Z", "id": "417ff1e09d39416cae1bccc3d85a4fab", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["iUsCl8sgR1mWljs7Nkri5Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["72V5VFspQ2KZTxK9WAnvBw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3d5ec5a14a3f4c5484032aa350a537ba
+      - 417ff1e09d39416cae1bccc3d85a4fab
   response:
     status:
       code: 200
@@ -4787,16 +4590,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-068b6bba-2871-4e5d-bf20-db60ee8bdd92
+      - req-8aeebe31-3912-430d-bea9-2f276a5368ec
       Date:
-      - Wed, 26 Sep 2018 18:41:31 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4617,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:31 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3d588e67-ef22-4806-9a9f-5d0e3657bdba
+      - req-c1ac610d-5d79-4644-8d28-c48c4fb15d0e
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4632,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:31.653081", "expires":
-        "2018-09-26T19:41:31Z", "id": "c39dd1e752bc4d9a8dbbb31db11b8e31", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:42.700075", "expires":
+        "2018-10-25T19:19:42Z", "id": "27da6f029ffe43909fc07629b24aab7a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JG3A_IGLT2-Y-GxkiPBC8g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qtgDSMvWSCaAYrJG5nz8nw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4679,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c39dd1e752bc4d9a8dbbb31db11b8e31
+      - 27da6f029ffe43909fc07629b24aab7a
   response:
     status:
       code: 200
@@ -4902,16 +4705,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b8d5374b-f125-4551-a336-67ae0f770c93
+      - req-b5c867e2-2d8e-4014-9893-603b7c7d3010
       Date:
-      - Wed, 26 Sep 2018 18:41:31 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2ebd7573efe4b11ad41ac7c76dac3eb
+      - 9848bf5762a04482936bd84eaf59ba8c
   response:
     status:
       code: 200
@@ -4937,16 +4740,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c4ba21f8-0b1c-4291-9d8d-b2aa6556769e
+      - req-89de824f-7b27-4293-8f6d-121ee35e8ef0
       Date:
-      - Wed, 26 Sep 2018 18:41:31 GMT
+      - Thu, 25 Oct 2018 18:19:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4767,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:32 GMT
+      - Thu, 25 Oct 2018 18:19:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6d3272f3-2176-44cf-9a05-8bad51b37afb
+      - req-240dff17-34e7-40ea-84b8-408c5ea7cfdf
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4782,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:32.146270", "expires":
-        "2018-09-26T19:41:32Z", "id": "47d2e09f59684b68b1066c9607973c95", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:43.194472", "expires":
+        "2018-10-25T19:19:43Z", "id": "f710da17d1ef48bd9e1f5a20889bba6a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QjCLboFJReSjkUY7f3NHBg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oZms89HFSiCKyOxBDZaWBg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +4829,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 47d2e09f59684b68b1066c9607973c95
+      - f710da17d1ef48bd9e1f5a20889bba6a
   response:
     status:
       code: 200
@@ -5052,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9f106fd2-22f1-4969-a2bd-c3b57ab9e06e
+      - req-04521a33-6b0b-444d-a7d5-b48245be0522
       Date:
-      - Wed, 26 Sep 2018 18:41:32 GMT
+      - Thu, 25 Oct 2018 18:19:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +4892,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0ea6c332-b82e-4a1d-8340-5528301ddf52
+      - req-bc521be6-c510-4ef2-bcd8-812b949b4f96
       Date:
-      - Wed, 26 Sep 2018 18:41:32 GMT
+      - Thu, 25 Oct 2018 18:19:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +4917,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +4932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +4945,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-332a1601-d9bc-4938-98bd-51d82bbd44fd
+      - req-b68990dd-40d7-4d26-b40a-985699f4ba32
       Date:
-      - Wed, 26 Sep 2018 18:41:32 GMT
+      - Thu, 25 Oct 2018 18:19:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +4970,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +4998,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-185ff5f8-8d2b-4afc-8a85-16c426a9a6a1
+      - req-fcdc6369-35b7-42a1-8e28-54f986a82d88
       Date:
-      - Wed, 26 Sep 2018 18:41:32 GMT
+      - Thu, 25 Oct 2018 18:19:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5023,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5051,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-2be1e376-5abc-4fb2-a869-46b5a5e4dd0b
+      - req-2e9826a7-8d97-4958-ae39-19b3ec61f6e3
       Date:
-      - Wed, 26 Sep 2018 18:41:33 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5076,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5104,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-b35f0325-fecd-473e-bf09-20c312720890
+      - req-0df84143-a043-4e21-b04f-b46ddc14151d
       Date:
-      - Wed, 26 Sep 2018 18:41:33 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5129,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5157,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-ae9188c1-0712-4893-b9f3-a533855500df
+      - req-42900de8-6694-47c7-ac5c-697a512c275b
       Date:
-      - Wed, 26 Sep 2018 18:41:33 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5193,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ed8a51ab-e232-4906-951f-980a35a75b07
+      - req-0b9ba3be-bb7a-488b-b6d0-9644fb12e69a
       Date:
-      - Wed, 26 Sep 2018 18:41:33 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5218,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5246,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-f31d1b22-5ad7-4e61-975d-89536a3c5531
+      - req-1ec94ce0-3507-4ba1-8597-9d5fc619f56c
       Date:
-      - Wed, 26 Sep 2018 18:41:33 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-ce944b14-8293-4f78-82db-365fa7cf2ac8
+      - req-d1ddbef0-0251-41b6-982c-e044a4418f90
       Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
+      - Thu, 25 Oct 2018 18:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5307,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5335,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-b9323ad3-2bbd-45c2-8fbc-af5fa7573254
+      - req-123cd4be-0005-474c-b635-3ff083a15389
       Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
+      - Thu, 25 Oct 2018 18:19:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5360,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa35287c9b3342e2be53cfa7d81ba75b
+      - c58e8a13f5a74f689e201a76d15d1464
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5388,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-03da0562-d78c-48ab-9975-794c402d3ed5
+      - req-312a92c9-3b57-475c-9554-5385937535b2
       Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
+      - Thu, 25 Oct 2018 18:19:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5413,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
+      - Thu, 25 Oct 2018 18:19:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c7505f8-fbd9-48bc-91ed-d060ccaa41eb
+      - req-9acb7212-3143-4aad-a5d1-32513aebcfd4
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:34.581687", "expires":
-        "2018-09-26T19:41:34Z", "id": "a3a6288ee7244c55b91e197e00722f2b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:45.574470", "expires":
+        "2018-10-25T19:19:45Z", "id": "47f1898e7b6f4276a3cbbf888e1bb040", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pvIpWaa0QSqH7Orl0GnTYA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["i6N4YH0uSBOcinppNCpmMA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,88 +5494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"a3a6288ee7244c55b91e197e00722f2b"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-4fbf197c-7810-4797-97c4-99d4f7e0812c
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:34.762240", "expires":
-        "2018-09-26T19:41:34Z", "id": "e02fc2dc9c644d2cb7abad485134aaf0", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1X049y0KSEKJna6UwBiPWQ", "pvIpWaa0QSqH7Orl0GnTYA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:34 GMT
+      - Thu, 25 Oct 2018 18:19:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-afb6bd37-0dd6-477b-aa09-39a121e2e6fb
+      - req-7b7590c3-d23c-4e3a-b55d-2cd20c020161
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:34.943685", "expires":
-        "2018-09-26T19:41:34Z", "id": "d56dce0c214245d9b288c6ab513bb220", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:45.754274", "expires":
+        "2018-10-25T19:19:45Z", "id": "9154d25fb7e04f4b9067367a5b5b661e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fbAol3JIQHm-8975STcC1A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["InChE46TRmKIFL3OCXdA-g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,88 +5575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:34 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"d56dce0c214245d9b288c6ab513bb220"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-0d91b30d-5ee5-46c4-9b26-2d50ff4f7b38
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:35.113183", "expires":
-        "2018-09-26T19:41:34Z", "id": "ce697267d42d49678b682543c6081aa2", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["5sXefl_ORFek2Z02Jwolug", "fbAol3JIQHm-8975STcC1A"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f3ac3d184034873a2d2a314caef08bf
+      - 990191f2aff540768d3e06afc6378301
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5603,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-5a09f4b1-dc7b-445f-838c-c045327ed2c6
+      - req-8ab9c33f-4599-4508-ad7e-cf649e24ef58
       Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
+      - Thu, 25 Oct 2018 18:19:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49e2b4e0-4369-43a4-b582-ba7b4aa71219
+      - req-f040d3f6-7fda-4b23-a0c4-0f3ecd9f4795
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-49e2b4e0-4369-43a4-b582-ba7b4aa71219
+      - req-f040d3f6-7fda-4b23-a0c4-0f3ecd9f4795
       Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +5673,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +5688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f7ecc02-4cc5-4323-bf52-090f0973ef63
+      - req-29b87bea-1d2f-400f-87ca-b7d484c655ac
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-0f7ecc02-4cc5-4323-bf52-090f0973ef63
+      - req-29b87bea-1d2f-400f-87ca-b7d484c655ac
       Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +5720,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +5735,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca99e45f7ba14aa9bf6ff56a3af8bee3
+      - 3d10dad5175141b2b112b02b6c6e3df2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9396cd01-1274-4c11-a097-e07a87151439
+      - req-b6e9fea7-b0f3-4b63-91c1-64f258efc31e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9396cd01-1274-4c11-a097-e07a87151439
+      - req-b6e9fea7-b0f3-4b63-91c1-64f258efc31e
       Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +5770,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8409f581-50f1-4cf2-9bfd-ab7d2ac13100
+      - req-165ce7c8-f25e-4450-89a8-d7e8f61adab8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8409f581-50f1-4cf2-9bfd-ab7d2ac13100
+      - req-165ce7c8-f25e-4450-89a8-d7e8f61adab8
       Date:
-      - Wed, 26 Sep 2018 18:41:35 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +5805,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479b2f315911497ca2d483c4b883b893
+      - 847db75874ae4d699f138892ed5706bd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf56940f-d8b0-4485-b526-7d8c8ad8fcc1
+      - req-bcd500a8-3b85-4e41-b9d5-7c2787718a34
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bf56940f-d8b0-4485-b526-7d8c8ad8fcc1
+      - req-bcd500a8-3b85-4e41-b9d5-7c2787718a34
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +5840,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7eb39cf7-1e25-4e26-899c-ad97a4d9cb60
+      - req-ff68979a-80bb-4d9d-abf6-210493b78331
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7eb39cf7-1e25-4e26-899c-ad97a4d9cb60
+      - req-ff68979a-80bb-4d9d-abf6-210493b78331
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +5870,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +5885,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-067780e6-9605-4ac0-851a-89da869e3b8c
+      - req-2e7e0463-058a-4196-9402-0dfb71785ea6
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-067780e6-9605-4ac0-851a-89da869e3b8c
+      - req-2e7e0463-058a-4196-9402-0dfb71785ea6
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +5915,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca99e45f7ba14aa9bf6ff56a3af8bee3
+      - 3d10dad5175141b2b112b02b6c6e3df2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd343396-a1e8-45cf-b1d2-656c713a0c92
+      - req-3a8b84e2-82ee-495a-9f05-f5b2ff723af1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fd343396-a1e8-45cf-b1d2-656c713a0c92
+      - req-3a8b84e2-82ee-495a-9f05-f5b2ff723af1
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +5965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca99e45f7ba14aa9bf6ff56a3af8bee3
+      - 3d10dad5175141b2b112b02b6c6e3df2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d5bf643-3c3b-4b87-a214-f0902c84d1a7
+      - req-5c4d610f-a542-4072-8317-692f554678a4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5d5bf643-3c3b-4b87-a214-f0902c84d1a7
+      - req-5c4d610f-a542-4072-8317-692f554678a4
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0da17423-934e-46f5-93c3-55e5499d6762
+      - req-e19d5267-202a-471d-850c-f9fd840fde83
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0da17423-934e-46f5-93c3-55e5499d6762
+      - req-e19d5267-202a-471d-850c-f9fd840fde83
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49c16f6f-ead0-4f7a-b4fc-dfb6f6b9eee9
+      - req-e7a7210a-62d9-4de5-84a6-78b9b7699775
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-49c16f6f-ead0-4f7a-b4fc-dfb6f6b9eee9
+      - req-e7a7210a-62d9-4de5-84a6-78b9b7699775
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6070,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479b2f315911497ca2d483c4b883b893
+      - 847db75874ae4d699f138892ed5706bd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e6c8a6d7-71e7-43f0-94fc-8c1739fc6f76
+      - req-2af5e7cd-8190-4a8d-9aa7-e5e840998398
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e6c8a6d7-71e7-43f0-94fc-8c1739fc6f76
+      - req-2af5e7cd-8190-4a8d-9aa7-e5e840998398
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6105,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479b2f315911497ca2d483c4b883b893
+      - 847db75874ae4d699f138892ed5706bd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0a3020e-fe86-42d9-9e00-a33fc44fa391
+      - req-29d1928a-6513-42b5-8ee3-f7285dd1d465
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c0a3020e-fe86-42d9-9e00-a33fc44fa391
+      - req-29d1928a-6513-42b5-8ee3-f7285dd1d465
       Date:
-      - Wed, 26 Sep 2018 18:41:36 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6140,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-34463f61-fd69-4326-a4fe-bfda588764aa
+      - req-7bd55177-bb96-4bf5-938b-a53f9b936dd5
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-34463f61-fd69-4326-a4fe-bfda588764aa
+      - req-7bd55177-bb96-4bf5-938b-a53f9b936dd5
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6188,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6203,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-056b7fe2-74e1-4716-8e91-1a6e5ee4b5ff
+      - req-117bdd00-6a7a-47f5-8446-09be01b3f360
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-056b7fe2-74e1-4716-8e91-1a6e5ee4b5ff
+      - req-117bdd00-6a7a-47f5-8446-09be01b3f360
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6259,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6274,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07be915b-ccac-4c6f-ba25-6e33385106b6
+      - req-39d4b8e0-3c70-450d-be7e-1480c794d9ad
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-07be915b-ccac-4c6f-ba25-6e33385106b6
+      - req-39d4b8e0-3c70-450d-be7e-1480c794d9ad
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6323,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6338,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 189d4967f35143b5ace53d0c8aa93e9b
+      - 1429ef77659a4dc4bcc8501f33cc22a0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8504b47e-ee85-49e3-8fe1-d027538d2ca8
+      - req-2ea19b36-e72e-4831-9d9a-73f6d72b2c9b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8504b47e-ee85-49e3-8fe1-d027538d2ca8
+      - req-2ea19b36-e72e-4831-9d9a-73f6d72b2c9b
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6373,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca99e45f7ba14aa9bf6ff56a3af8bee3
+      - 3d10dad5175141b2b112b02b6c6e3df2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b89c4de6-a602-4585-a465-76aa4cf495d4
+      - req-69c22ddd-607b-4be9-a013-fe9c3f5f686a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b89c4de6-a602-4585-a465-76aa4cf495d4
+      - req-69c22ddd-607b-4be9-a013-fe9c3f5f686a
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6408,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82e40f30f2b14ff698750605ef782244
+      - 66d4b59653ae4f3a8a0747c66b8bf73c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e0d76ab-ba4c-4e8a-a4d7-8d498b3ff6c2
+      - req-dd473d98-b9e3-4f11-b9de-d71d9ed7d0af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1e0d76ab-ba4c-4e8a-a4d7-8d498b3ff6c2
+      - req-dd473d98-b9e3-4f11-b9de-d71d9ed7d0af
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6443,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479b2f315911497ca2d483c4b883b893
+      - 847db75874ae4d699f138892ed5706bd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5c1f774b-499f-4dc4-ba84-877e2f7eafcc
+      - req-8a3d4058-bddd-4e0a-973d-7acab3f6a4b6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5c1f774b-499f-4dc4-ba84-877e2f7eafcc
+      - req-8a3d4058-bddd-4e0a-973d-7acab3f6a4b6
       Date:
-      - Wed, 26 Sep 2018 18:41:37 GMT
+      - Thu, 25 Oct 2018 18:19:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6481,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:38 GMT
+      - Thu, 25 Oct 2018 18:19:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-77a742d3-74e3-4ece-82c1-c7ed07facf22
+      - req-706ab195-1133-49a5-93df-754688904412
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6496,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:38.855410", "expires":
-        "2018-09-26T19:41:38Z", "id": "d4acd785fc33473da5bbe3992a38a74e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:49.633596", "expires":
+        "2018-10-25T19:19:49Z", "id": "c710bf5a31284eed950c2975bd5accf8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["JDHVSF6vRyS7bNM2SK9quw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iSi0RhTsSAyuh_-O04JGXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6544,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6562,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:38 GMT
+      - Thu, 25 Oct 2018 18:19:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e0bcec7f-3297-4ae1-8fe5-8318a6493269
+      - req-17c6d2d4-3bee-4b88-9ca1-39a1d3fe482d
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6577,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:39.038512", "expires":
-        "2018-09-26T19:41:39Z", "id": "9e463ee146644bcc85835fabda46a35c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:49.820691", "expires":
+        "2018-10-25T19:19:49Z", "id": "c00676f2a36b4711afb2e2883cf4f448", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["4dYnlGlkT_WiZMJl-X2KDw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["84aEVbnJS0GwAyDROTg2QQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6625,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -7010,79 +6651,79 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-86eaaa83-0650-49ea-acba-2a587825a983
+      - req-dbb430f9-28e1-4d68-88db-09ab24ff3d3e
       Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
+      - Thu, 25 Oct 2018 18:19:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
+        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
+        54}, {"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
         "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
         "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
-        "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
-        null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +6741,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-054426b4-bf9d-4172-a988-21f79afa19cc
+      - req-6f171535-ab54-4d7b-9393-f1aab731e954
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +6756,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:39.400677", "expires":
-        "2018-09-26T19:41:39Z", "id": "c4455538dab34a3fb345739da221fb4d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.167206", "expires":
+        "2018-10-25T19:19:50Z", "id": "515b816976994cc883878b5f57d3ca9f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kWTlbYNxQ7mhfPu0lSbxqg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YGZFPvPCRryapxW7vnDcqA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,13 +6804,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7181,13 +6822,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c7935bb3-8a82-413c-ac5b-f73d3cb2851c
+      - req-827a96c7-db72-4567-ab8d-c1ff405491f1
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +6837,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:39.565636", "expires":
-        "2018-09-26T19:41:39Z", "id": "081c4d3003bd419f959a80052cd4661b", "audit_ids":
-        ["caEWI511RIK6Ng1Jr_Qwyg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.338461", "expires":
+        "2018-10-25T19:19:50Z", "id": "1afae9d4979a4dcc8a5c9963d393e875", "audit_ids":
+        ["wVu9KUfiTuqSaV2ThvYayA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +6858,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '081c4d3003bd419f959a80052cd4661b'
+      - 1afae9d4979a4dcc8a5c9963d393e875
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ffc6fad-fecb-4235-8e81-418c4ba56b17
+      - req-769503c2-d4cd-4642-9a08-adb6e2aac6d3
       Content-Length:
       - '500'
       Connection:
@@ -7247,133 +6888,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"081c4d3003bd419f959a80052cd4661b"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-091865cc-8a82-439e-8586-ce375c6d7189
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:39.865759", "expires":
-        "2018-09-26T19:41:39Z", "id": "1a8a0850a3604a8da597fb711309f520", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kLWzBdNwSAO_jq1YxWvAGA",
-        "caEWI511RIK6Ng1Jr_Qwyg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:39 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '081c4d3003bd419f959a80052cd4661b'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:39 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-5130fc6b-b02e-4392-bdf3-a314516545fb
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +6906,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:40 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-64471e3a-8953-4abc-b3a0-4791530dc6ba
+      - req-746fe68a-d6f1-4dd4-893c-2d5fc07a3c12
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +6921,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:40.174060", "expires":
-        "2018-09-26T19:41:40Z", "id": "3e4a614a793f47999939985018abc706", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.640027", "expires":
+        "2018-10-25T19:19:50Z", "id": "2e5730110bca4db18e5fdb3fa3e97031", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["C1dxn6CATraiydy7pEuG8g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sWyfOqydRq6pOmpMpZpLFw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +6968,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +6986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:40 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49e16bcb-55c8-42ed-b3d4-9072312d8b78
+      - req-86571cd1-7dc4-4cae-a1fc-0aaac07482ad
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:40.363950", "expires":
-        "2018-09-26T19:41:40Z", "id": "c1f89964b2c942f7acd27574feb7ed30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:50.839234", "expires":
+        "2018-10-25T19:19:50Z", "id": "7f9846d0695b499eba361131cc233a7e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gjRVdUp1Tru9QIe7sfn8Pw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FXd9UtR_SBmhFuVFc35Fhw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:40 GMT
+      - Thu, 25 Oct 2018 18:19:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-030e05a5-2151-48b9-8726-b43e72ec7ea6
+      - req-9145744a-0607-4503-86e4-3fda11213a04
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7081,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:40.548318", "expires":
-        "2018-09-26T19:41:40Z", "id": "028f3390c7864fdc86155e9a42bfc643", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.012569", "expires":
+        "2018-10-25T19:19:50Z", "id": "40da4be3ef4f4f5787bc3612db63aaf2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-LN9a-2eSOqUGJpXKLZwAg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1B_D2mHrS9Ck65QuqshFlQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7128,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7146,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:40 GMT
+      - Thu, 25 Oct 2018 18:19:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c3c610a6-fc32-4d4c-bc74-b8eac4c66502
+      - req-ca6d7cb9-a08a-42c9-bbe2-a440082a3bfa
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7161,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:40.731028", "expires":
-        "2018-09-26T19:41:40Z", "id": "e92c537a65644e24a1ff2038e65fb3bb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.206661", "expires":
+        "2018-10-25T19:19:51Z", "id": "c0b5a41f987844e9b2e595b1426af26f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wBzl1QsPQX284MDezYIRyg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["B653Hiz8Sby-PGtgcu5cZw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7208,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -7719,9 +7234,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-96860946-155a-484c-a42a-b5a7ba6715b6
+      - req-c1f927a3-799b-4d23-9b91-bec09b23b584
       Date:
-      - Wed, 26 Sep 2018 18:41:40 GMT
+      - Thu, 25 Oct 2018 18:19:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7270,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -7781,14 +7296,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-76846675-208f-4e4d-823a-0a6130ba4a37
+      - req-088beae6-16a1-4de0-a2cb-4b5f0956aeab
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7321,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ebb7197d-4b1b-4036-96a3-54cdfa4e17a5
+      - req-04cafaea-3881-4e20-affb-1724bbb47d77
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7336,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:41.232548", "expires":
-        "2018-09-26T19:41:41Z", "id": "dc014525ffa8471ab87e582dab26c478", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:51.695623", "expires":
+        "2018-10-25T19:19:51Z", "id": "1e65171cf4dd41648a2a879bf1465e2b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9gWyvGb8RPmmWST045mBWg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["D1snxlNqSUi7Bp1CjiGOKA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7383,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc014525ffa8471ab87e582dab26c478
+      - 1e65171cf4dd41648a2a879bf1465e2b
   response:
     status:
       code: 200
@@ -7894,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-24a1f97b-68df-4599-95bf-f0263cb1a51c
+      - req-6ea27e57-9078-4279-a266-44bc3471aa35
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4455538dab34a3fb345739da221fb4d
+      - 515b816976994cc883878b5f57d3ca9f
   response:
     status:
       code: 200
@@ -7927,14 +7442,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-83acba90-dbfe-4560-8d62-7b05473a8c9c
+      - req-05bb874d-d6bf-4646-9b22-e83d8f81af7a
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a82a0e81-8b61-4dfe-9824-f0ce282ea3c8
+      - req-2873bdf2-0be4-4c99-94f9-ba54f9edc5be
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7482,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:41.744651", "expires":
-        "2018-09-26T19:41:41Z", "id": "e305ffd14c6b4fd5980e13737828d356", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:52.202145", "expires":
+        "2018-10-25T19:19:52Z", "id": "a4cdc680cfe944cabb1a7ccc0d372a29", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WUEjVQ9ISHW8-OVOILZn8g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["35bQ-PsnSTaZ35DtKJI1Vg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +7529,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +7544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e305ffd14c6b4fd5980e13737828d356
+      - a4cdc680cfe944cabb1a7ccc0d372a29
   response:
     status:
       code: 200
@@ -8040,14 +7555,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a687bbb9-6152-47c2-96f3-377718f4613e
+      - req-8217e89b-b8bb-41ba-8a5c-b9368c4f702d
       Date:
-      - Wed, 26 Sep 2018 18:41:41 GMT
+      - Thu, 25 Oct 2018 18:19:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +7577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8073,9 +7588,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d11e859d-76d9-49b5-a143-9bc6d4ff9a62
+      - req-7327f1d6-d68a-4bc0-a44e-913ac83c843c
       Date:
-      - Wed, 26 Sep 2018 18:41:42 GMT
+      - Thu, 25 Oct 2018 18:19:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +7617,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +7632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8128,9 +7643,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-cd833ac7-0856-482a-8e46-e81fe0164c16
+      - req-e899aeb8-0e8e-48dd-a9ae-d924571d7812
       Date:
-      - Wed, 26 Sep 2018 18:41:42 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +7672,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +7687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8183,9 +7698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ae2c26fa-fb3b-4979-b72c-9e6a4da6ff87
+      - req-40bc8db4-3c04-49e6-ac45-7a77d78b1d64
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +7727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +7742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8238,9 +7753,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5004a7de-718e-42df-bcec-cbdb07a9dfc5
+      - req-edee0b0a-22fc-41c5-9f81-ba94f32215c4
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +7767,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +7782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8278,9 +7793,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-75fb8c3c-f2b3-4228-8413-b1723d197632
+      - req-48f512d4-a8dd-4531-be32-fc37c348506f
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +7807,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +7822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e92c537a65644e24a1ff2038e65fb3bb
+      - c0b5a41f987844e9b2e595b1426af26f
   response:
     status:
       code: 200
@@ -8318,9 +7833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-eb8cfd9d-c2ac-4681-b7c8-bd568c7124b7
+      - req-219018b4-7c2f-486d-90b9-2cb1d96ba196
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +7847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +7865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0bdc2459-527d-4ad9-b53f-3f93bd4477c2
+      - req-4d3960b3-234d-4a3d-8506-4a32c54c4c70
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +7880,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:43.730093", "expires":
-        "2018-09-26T19:41:43Z", "id": "571a7286f0b540ad9633d95575e3608b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:53.903407", "expires":
+        "2018-10-25T19:19:53Z", "id": "b14072875c534709aa7e0b490b9bb464", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W33qIOwiT0WzQyKgxpynLg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0AwPuKr2S0ma4TtD_tourw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +7927,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +7942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -8438,52 +7953,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ef5d96ad-4e17-43c2-9c59-7d8da0ef1070
+      - req-f36f29e3-bcc2-44f8-abd1-49aadf7ec33e
       Date:
-      - Wed, 26 Sep 2018 18:41:43 GMT
+      - Thu, 25 Oct 2018 18:19:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8531,20 +8011,187 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b14072875c534709aa7e0b490b9bb464
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c737967a-264e-4d35-9cd0-c3b4983b4e4a
+      Date:
+      - Thu, 25 Oct 2018 18:19:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -8559,7 +8206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -8570,28 +8217,166 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0a92d3e1-8a0d-4d0f-bc36-d8c214e9b817
+      - req-a75cd3b8-ed60-49e4-a3a1-0a09da1656d6
       Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
+      - Thu, 25 Oct 2018 18:19:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b14072875c534709aa7e0b490b9bb464
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0c0d9616-01ab-4a15-9e06-a59f19947f18
+      Date:
+      - Thu, 25 Oct 2018 18:19:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8657,12 +8442,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8676,7 +8455,271 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b14072875c534709aa7e0b490b9bb464
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-98645e4e-70c2-43b4-9251-c34efbe9e941
+      Date:
+      - Thu, 25 Oct 2018 18:19:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b14072875c534709aa7e0b490b9bb464
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d1ac5085-dc64-4f63-a4b9-91f97734ae93
+      Date:
+      - Thu, 25 Oct 2018 18:19:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8694,13 +8737,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
+      - Thu, 25 Oct 2018 18:19:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-491ad4e0-8da6-4826-83f4-3827ec33f338
+      - req-1dc3ef0b-af91-4815-b296-29123a73a6ca
       Content-Length:
       - '4131'
       Connection:
@@ -8709,10 +8752,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:44.273235", "expires":
-        "2018-09-26T19:41:44Z", "id": "e78944463dd142ab959ea584649e4e3a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:55.160109", "expires":
+        "2018-10-25T19:19:55Z", "id": "05b69b73edb74f5f90b6052c63aed25f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kNdLcxYrRIqO8W7duz5bjA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XcX_b2VdRwiw1X4prQlzyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8756,7 +8799,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8771,7 +8814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -8782,52 +8825,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-89f329bb-4beb-444a-8427-10cef963f96a
+      - req-9a068cbd-aa68-4cc0-804f-562f545414c9
       Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
+      - Thu, 25 Oct 2018 18:19:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8858,200 +8866,6 @@ http_interactions:
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-17b0a371-6621-43dc-9eab-88a4a768c1ad
-      Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9ec05afd-3552-4993-bc9d-840d32321c8c
-      Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -9098,64 +8912,29 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -9167,7 +8946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -9178,39 +8957,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-acee3567-cf94-4a82-8f05-3918e14abb92
+      - req-446492fb-2442-4bdb-8d96-c7861666471b
       Date:
-      - Wed, 26 Sep 2018 18:41:44 GMT
+      - Thu, 25 Oct 2018 18:19:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -9219,6 +8975,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -9271,20 +9033,301 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c00676f2a36b4711afb2e2883cf4f448
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7dffae33-e074-4efc-b0f7-db085ca2728d
+      Date:
+      - Thu, 25 Oct 2018 18:19:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - c00676f2a36b4711afb2e2883cf4f448
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-400bf2ff-d98d-4c47-a538-b83da158a40d
+      Date:
+      - Thu, 25 Oct 2018 18:19:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9302,13 +9345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:45 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32a9d4d4-b4ad-48d7-abcf-98120328af09
+      - req-067f65cb-d092-45f0-9702-771a640b86a0
       Content-Length:
       - '4118'
       Connection:
@@ -9317,10 +9360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:45.149794", "expires":
-        "2018-09-26T19:41:45Z", "id": "b97402dbd23d4e1684da0c554d1adb8a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:56.089454", "expires":
+        "2018-10-25T19:19:56Z", "id": "32c84fe7b8934b1ab14b2edd8e75269b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ufYGZX2QSOKX6OV2lwo2Iw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yT5RIpZhRJ2prS1189dYag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9364,7 +9407,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9379,7 +9422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -9390,276 +9433,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cf5167e4-39e2-4962-afbc-3ba9626578c2
+      - req-23b6ddbc-66fd-40d2-bbe5-d66ea8f59799
       Date:
-      - Wed, 26 Sep 2018 18:41:45 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e2062dc5-4d24-4510-8d4b-ab60fe6b64a9
-      Date:
-      - Wed, 26 Sep 2018 18:41:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0bf14831-86a5-4f16-a504-f3deb879d8c6
-      Date:
-      - Wed, 26 Sep 2018 18:41:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -9741,12 +9526,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
@@ -9760,7 +9539,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -9775,7 +9554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -9786,157 +9565,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8826d1ba-fbae-46d8-be43-d2c4257afa9e
+      - req-bca64676-ef58-428a-8ac1-cbd6cab9caca
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-59d67c00-4f4f-4b04-9526-436732e49a8f
-      Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -10011,120 +9646,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2f504baa-23e8-4daf-a776-f2f06936dcb3
-      Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
@@ -10137,12 +9658,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -10156,7 +9671,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10171,7 +9686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -10182,9 +9697,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-15ac3289-379d-421a-b3f8-0747b0f1a6cf
+      - req-669d20ec-b3eb-41b9-9aaa-d9651a983244
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10226,7 +9741,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10241,7 +9756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -10252,9 +9767,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6196f1c9-9d50-47e1-8870-3a12d7ef4cf8
+      - req-482ee67d-03c9-47d2-8810-c8a04d2432d1
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10296,7 +9811,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10311,7 +9826,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -10322,9 +9837,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0c55953c-36e4-4f9f-a67d-a53b7124d37a
+      - req-e08da2ea-93df-4249-98ed-a0397d7b862a
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10366,7 +9881,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10381,7 +9896,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -10392,9 +9907,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-71e68753-66ab-43df-bb94-a53b436c606b
+      - req-ec6ed3b7-9358-4b91-9bfb-94e15619cb22
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10436,7 +9951,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10451,7 +9966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -10462,9 +9977,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2acec505-3933-4b20-b80b-0fe9491043bf
+      - req-1d3baa5b-56e2-468b-bb70-7101f0dc546d
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10506,7 +10021,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10521,7 +10036,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -10532,9 +10047,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-043123a2-77f3-4268-bdb7-863cf124f819
+      - req-2e409eee-6640-41f2-9eec-a0371ce3296e
       Date:
-      - Wed, 26 Sep 2018 18:41:46 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10576,7 +10091,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10591,7 +10106,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -10602,9 +10117,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-49abe973-4dc9-4d7d-b80f-0a0238a82287
+      - req-edb4a9fa-5ec9-4bb5-8589-35fdd99e5960
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10646,7 +10161,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10661,7 +10176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -10672,9 +10187,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e4deeb89-bcc7-40ae-958f-a13c11bd8bb9
+      - req-edbd9ef5-4017-4da5-9092-5cdb746af183
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10716,7 +10231,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10731,7 +10246,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -10742,9 +10257,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bd11cac7-e70f-40ee-abcc-23b91cdb008f
+      - req-fa2d88d3-121a-409e-855d-d9b7077c5a82
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11147,7 +10662,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11162,7 +10677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -11173,9 +10688,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-26672ed9-cfa4-4955-8eb7-22fbece8de36
+      - req-6fdbb830-46a2-4994-94ee-68e6c3e42da8
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11578,7 +11093,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11593,7 +11108,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -11604,9 +11119,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-503bbdb1-31da-4230-9dd7-14828c239f45
+      - req-72a92c85-eecc-44e2-8416-975470c735a9
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12009,7 +11524,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12024,7 +11539,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -12035,9 +11550,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b69e1f8c-2653-425e-8229-843dc7dfa9dc
+      - req-c714a13e-32b8-46cf-8ecc-8897c7f1aab6
       Date:
-      - Wed, 26 Sep 2018 18:41:47 GMT
+      - Thu, 25 Oct 2018 18:19:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12440,7 +11955,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12455,7 +11970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -12466,9 +11981,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-20289bc9-89e8-4542-9eac-dee115d841bf
+      - req-dd27990d-945e-4a50-ac9b-e694e2a935a5
       Date:
-      - Wed, 26 Sep 2018 18:41:48 GMT
+      - Thu, 25 Oct 2018 18:19:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12871,7 +12386,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12886,7 +12401,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -12897,9 +12412,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3dd3dc49-f296-4032-ab38-244f23f607b5
+      - req-a88f9555-e355-4320-bd31-b6bb28d3b880
       Date:
-      - Wed, 26 Sep 2018 18:41:48 GMT
+      - Thu, 25 Oct 2018 18:19:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13302,7 +12817,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13317,7 +12832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -13328,9 +12843,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-24dcea55-a9ff-4256-90f0-ffe95ad55f88
+      - req-ce486ac3-4aa2-4671-bf6a-01a475feba70
       Date:
-      - Wed, 26 Sep 2018 18:41:48 GMT
+      - Thu, 25 Oct 2018 18:19:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13733,7 +13248,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13748,7 +13263,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -13759,9 +13274,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f4c23955-7d72-49e3-b912-af61372b8b91
+      - req-3137a566-9038-4e84-8bc3-5113165679f8
       Date:
-      - Wed, 26 Sep 2018 18:41:48 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14164,7 +13679,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14179,7 +13694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14190,9 +13705,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-aef7b749-124b-4783-99fb-cc33e1fc86ef
+      - req-3171b301-1333-4ff5-b5de-16d5038e6c1e
       Date:
-      - Wed, 26 Sep 2018 18:41:48 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14224,7 +13739,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14239,7 +13754,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14250,9 +13765,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-489f0311-d35b-41e8-9286-fbdfbd9c2d3e
+      - req-35684edf-cbbf-4603-b0e1-e0c6973ace13
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14284,7 +13799,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14299,7 +13814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -14310,9 +13825,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-68cbc980-1c69-4c9f-b4f9-2ecd1d15ba3c
+      - req-f845a0e0-8600-41bf-a751-11d8c1551c53
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14344,7 +13859,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14359,7 +13874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -14370,9 +13885,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-aca86581-0417-4720-baa0-ad00b8f06c1b
+      - req-ef2605d2-71e6-47b7-bdb4-757cc7b385af
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14404,7 +13919,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14419,7 +13934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -14430,9 +13945,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2d5b385d-2be7-44b0-b257-41b21e1004c7
+      - req-1c5cbd5c-e6c0-4455-8688-65bb779491ce
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14464,7 +13979,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14479,7 +13994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -14490,9 +14005,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f96e89a2-8102-4863-8144-b6466d334043
+      - req-a9de086a-512f-4cc3-8333-054755540c53
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14524,7 +14039,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14539,7 +14054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -14550,9 +14065,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a22cf8e8-bfc7-442a-848f-43d56fb6cc37
+      - req-80557530-9ffa-471c-b7d9-f5ab6d79af3e
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:19:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14584,7 +14099,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14599,7 +14114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -14610,9 +14125,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cb9e3b4c-ce13-4016-923b-36db658347cb
+      - req-b47d3514-692f-4d18-b08a-d1f799f3db89
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14644,7 +14159,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14659,7 +14174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14670,9 +14185,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6db921e7-f559-4ede-b11f-b0d031d42159
+      - req-7beea1a2-7de9-4f2f-a95c-2d70ad3d03e4
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14714,7 +14229,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14729,7 +14244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14740,9 +14255,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d80f47d8-ef99-4183-b228-5628693937f7
+      - req-d7ab0aab-e4bb-4b96-b1e7-a1f68a84bce3
       Date:
-      - Wed, 26 Sep 2018 18:41:49 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14785,7 +14300,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14800,7 +14315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14811,9 +14326,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b91d209d-ad04-47b9-b987-c3016f104794
+      - req-65b6407b-cfb0-4a88-aaf1-21e7090478a1
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14848,7 +14363,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14863,7 +14378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 571a7286f0b540ad9633d95575e3608b
+      - b14072875c534709aa7e0b490b9bb464
   response:
     status:
       code: 200
@@ -14874,9 +14389,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-2232948f-107e-4387-8485-62d9c6006cf3
+      - req-884f56d9-948e-456c-8c36-33153e798585
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14963,7 +14478,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14978,7 +14493,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -14989,9 +14504,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-5e0e30ec-08e0-43e5-90ac-3ace5e2e3da0
+      - req-4d5ab7b2-edec-4b8f-92b1-da2634293742
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15033,7 +14548,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15048,7 +14563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -15059,9 +14574,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7d5c5f89-492a-43ff-a27f-700f05d545d4
+      - req-74feb4f4-5c80-4977-8240-889dafe0fa3b
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15104,7 +14619,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15119,7 +14634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -15130,9 +14645,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-59b53ff2-26e1-4c5a-bcc2-24eebbc6eeea
+      - req-a25d288d-6c6d-4919-98a1-9fc19c8ae940
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15167,7 +14682,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15182,7 +14697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e78944463dd142ab959ea584649e4e3a
+      - 05b69b73edb74f5f90b6052c63aed25f
   response:
     status:
       code: 200
@@ -15193,9 +14708,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-5a5ce946-f40c-41d5-8300-59ace53890b7
+      - req-495db763-8c92-4687-b696-3108bac831a7
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15282,7 +14797,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15297,7 +14812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -15308,9 +14823,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6a7a46f1-4874-4230-9284-825a26cd9fee
+      - req-6b0fe4fe-1d46-4a56-9811-976bd36f3aa9
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15352,7 +14867,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15367,7 +14882,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -15378,9 +14893,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e42e8bd4-4a2c-42e1-be23-22eaae216cac
+      - req-1c039fc9-9077-4d8b-a9d1-b142345bffc3
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15423,7 +14938,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15438,7 +14953,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -15449,9 +14964,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-0ba38416-dec8-47ef-88d5-60dd41d65734
+      - req-e1b891c0-0e0b-4e22-a8a8-c0742b061dc3
       Date:
-      - Wed, 26 Sep 2018 18:41:50 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15486,7 +15001,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15501,7 +15016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e463ee146644bcc85835fabda46a35c
+      - c00676f2a36b4711afb2e2883cf4f448
   response:
     status:
       code: 200
@@ -15512,9 +15027,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-ffcee2eb-8321-4b3a-bdc8-e98b84c52dfa
+      - req-5d7cd456-f3e1-4c4f-87a3-9331c4de633f
       Date:
-      - Wed, 26 Sep 2018 18:41:51 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15601,7 +15116,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15616,7 +15131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -15627,9 +15142,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-721a3f3b-4a20-4368-bd46-d66aa4175a75
+      - req-a5639366-e668-4c38-b838-607f630cd06a
       Date:
-      - Wed, 26 Sep 2018 18:41:51 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15671,7 +15186,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15686,7 +15201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -15697,9 +15212,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-74c811e8-fcdd-47a9-89ca-317e863c2a06
+      - req-cbea2104-b0d1-4272-9469-fdc9e0aec6a0
       Date:
-      - Wed, 26 Sep 2018 18:41:51 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15742,7 +15257,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15757,7 +15272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -15768,9 +15283,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b363da9f-d1e3-4315-8f65-419751a401f1
+      - req-7fdc58da-ee12-4bdb-a675-614a9e00e1ec
       Date:
-      - Wed, 26 Sep 2018 18:41:51 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15805,7 +15320,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15820,7 +15335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b97402dbd23d4e1684da0c554d1adb8a
+      - 32c84fe7b8934b1ab14b2edd8e75269b
   response:
     status:
       code: 200
@@ -15831,9 +15346,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-0eb6d09e-fbc0-461a-9797-9699f0f37dee
+      - req-c8f041aa-0cb4-44d6-a075-bfba62d2d8a9
       Date:
-      - Wed, 26 Sep 2018 18:41:51 GMT
+      - Thu, 25 Oct 2018 18:20:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15920,7 +15435,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15938,13 +15453,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
+      - Thu, 25 Oct 2018 18:20:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0d338a0-b9a9-423c-b79a-fc6434fe3358
+      - req-ddfb9a49-3b58-43e9-9914-ec13e35ba6ff
       Content-Length:
       - '4170'
       Connection:
@@ -15953,10 +15468,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:52.112883", "expires":
-        "2018-09-26T19:41:52Z", "id": "b447cb12402c40cf93ee82e77f99210e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.375868", "expires":
+        "2018-10-25T19:20:02Z", "id": "4ba95255bff440f886e14ed6c6584868", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mDl2H07RQMKY_qVunq6ZbQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["oKd6qb8SRR-bA0a-hxoXwg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16001,7 +15516,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16019,13 +15534,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
+      - Thu, 25 Oct 2018 18:20:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb022ac4-8cb7-44fd-a55c-4f40a4c9bfe4
+      - req-d9226080-d166-488b-a09c-80ad579917cd
       Content-Length:
       - '4170'
       Connection:
@@ -16034,10 +15549,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:52.294477", "expires":
-        "2018-09-26T19:41:52Z", "id": "62c145a8768b4b439232ffd6418ce2bc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.558463", "expires":
+        "2018-10-25T19:20:02Z", "id": "c77da5f543fa41b79305756854f0596f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8BRxnlnwSbCShrKDMJ7dmg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QPSyKX5BR4uaONPhYP6d_w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16082,13 +15597,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16100,13 +15615,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
+      - Thu, 25 Oct 2018 18:20:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06fba0e5-fd79-4f61-8c1b-36c23bc4af76
+      - req-216b62d0-1eb7-4b24-a668-d2becd551cf6
       Content-Length:
       - '370'
       Connection:
@@ -16115,13 +15630,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:52.468520", "expires":
-        "2018-09-26T19:41:52Z", "id": "87109511509f4fc0905bfafe2de7a11a", "audit_ids":
-        ["ebvXU_eFQwWnd8XfvbeIIQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:02.707911", "expires":
+        "2018-10-25T19:20:02Z", "id": "f5e26a602b3549f6a19e760c860d2cb8", "audit_ids":
+        ["0N9q07wSTNGnm8VNeMZDeQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16136,20 +15651,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87109511509f4fc0905bfafe2de7a11a
+      - f5e26a602b3549f6a19e760c860d2cb8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
+      - Thu, 25 Oct 2018 18:20:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c8f2c6f-101c-47e1-abd8-4e61579f1a39
+      - req-54230161-0b5c-404b-a9c2-74410b034ac5
       Content-Length:
       - '500'
       Connection:
@@ -16166,133 +15681,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"87109511509f4fc0905bfafe2de7a11a"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-1f855a4d-01a8-42cd-b8d3-978f48aa93c1
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:52.764919", "expires":
-        "2018-09-26T19:41:52Z", "id": "a856f98cffab4b34bab26959b655f22f", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hrni3mU0RguPkiWMtNp6FQ",
-        "ebvXU_eFQwWnd8XfvbeIIQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 87109511509f4fc0905bfafe2de7a11a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:52 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a4868599-f368-4dcf-95de-2ad30d327f97
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16310,13 +15699,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-85a3e8af-3320-4b66-a385-ec2a4f6eed12
+      - req-a2f7bdbd-8b5d-4c7d-929e-91b03bcf7630
       Content-Length:
       - '4117'
       Connection:
@@ -16325,10 +15714,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:53.088478", "expires":
-        "2018-09-26T19:41:53Z", "id": "44298707ae354f8a9e27b4b8bf9cd405", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.018099", "expires":
+        "2018-10-25T19:20:03Z", "id": "756f037c0c8f490caa3259e6cc1c0db8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_-mei67yScamcJdLm9_5Lg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4UfbOF12RIeM0i37Z8N91A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16372,7 +15761,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16390,13 +15779,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00dbec6d-a248-4d82-8d82-eef15e6d9d93
+      - req-675b4a24-b216-4c0c-bc15-1ff722aeb11d
       Content-Length:
       - '4131'
       Connection:
@@ -16405,10 +15794,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:53.262629", "expires":
-        "2018-09-26T19:41:53Z", "id": "a1a0046eda1f44959ed3f24af9b85066", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.202304", "expires":
+        "2018-10-25T19:20:03Z", "id": "9f9f337b8fd4447eb97b59ccbc0d77f3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ja2vpd1RSpixU9ASQkKDIw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vgnMznEdQmCNVMywBH0bng"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16452,7 +15841,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16470,13 +15859,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-73a58a5b-4631-44a1-9b27-93cd06018bcd
+      - req-517d50f0-6403-4bac-a103-b799e177077f
       Content-Length:
       - '4118'
       Connection:
@@ -16485,10 +15874,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:53.439377", "expires":
-        "2018-09-26T19:41:53Z", "id": "fbd52e325c014cfc840ee7172c55a95c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.387316", "expires":
+        "2018-10-25T19:20:03Z", "id": "663085c875fc44118b1e370d6a77209a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gUuUV1R3TeGY5rDEMThhnQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5alg6UjtQiGG6_m6v2BqTw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16532,7 +15921,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16550,13 +15939,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1522bd59-903e-47f1-928d-2055259200b5
+      - req-cae31ab5-2274-4c01-8820-02754d5c1c8f
       Content-Length:
       - '4117'
       Connection:
@@ -16565,10 +15954,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:53.619510", "expires":
-        "2018-09-26T19:41:53Z", "id": "78904c37dc034beab480e79fcb750f02", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:03.564540", "expires":
+        "2018-10-25T19:20:03Z", "id": "c75bff773d9e4bb2858839789339749c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uyNmDkggQ0KISjsGTm3D3A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W0f4am1NRVCijGhcoN49sw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16612,7 +16001,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16627,22 +16016,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25566c3b-c0db-4047-894d-f331a5aa5bb9
+      - req-47e38866-1283-4340-8860-9099a8d841b0
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-25566c3b-c0db-4047-894d-f331a5aa5bb9
+      - req-47e38866-1283-4340-8860-9099a8d841b0
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16675,7 +16064,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16690,22 +16079,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2dd9eb90-83d9-4af1-a5dd-7f8280e7d7f3
+      - req-b6e1b5a4-2d53-4741-a4a6-7c08b196442f
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-2dd9eb90-83d9-4af1-a5dd-7f8280e7d7f3
+      - req-b6e1b5a4-2d53-4741-a4a6-7c08b196442f
       Date:
-      - Wed, 26 Sep 2018 18:41:53 GMT
+      - Thu, 25 Oct 2018 18:20:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16746,7 +16135,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16761,22 +16150,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5851a37b-8455-4958-9830-64d285cf2d40
+      - req-1b882b90-414b-48e2-bb33-da34224e121a
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-5851a37b-8455-4958-9830-64d285cf2d40
+      - req-1b882b90-414b-48e2-bb33-da34224e121a
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16810,7 +16199,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16825,27 +16214,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f137fe5-8648-4f54-ae31-0e3ed247c2b3
+      - req-a0c8f07e-5eb2-45f1-bf97-d10c652fd41f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9f137fe5-8648-4f54-ae31-0e3ed247c2b3
+      - req-a0c8f07e-5eb2-45f1-bf97-d10c652fd41f
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16863,13 +16252,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-738d0885-e619-4fa7-a7b8-448aeba421bd
+      - req-36686746-f1cc-44f6-a4d1-f7697d07f457
       Content-Length:
       - '4131'
       Connection:
@@ -16878,10 +16267,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:54.490808", "expires":
-        "2018-09-26T19:41:54Z", "id": "44d184c413264e59b59bdbf51c4c0898", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:04.408704", "expires":
+        "2018-10-25T19:20:04Z", "id": "88b62c8f2d0c48b2aaa00404076323fa", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VB4lYxwBS8K8S78RXpIfWw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MGP1kXIKQZyE3Lp8PgxKug"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16925,7 +16314,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16940,27 +16329,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8100391c-315e-4bc0-89aa-18bf4d82a840
+      - req-fbb48d08-cfb4-44fd-a0ca-340496e84f17
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8100391c-315e-4bc0-89aa-18bf4d82a840
+      - req-fbb48d08-cfb4-44fd-a0ca-340496e84f17
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16975,27 +16364,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e68954f-8aee-4099-b4dc-d9ac752a250a
+      - req-9e4912c1-dde4-4bfa-8b85-d8e095de49c3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2e68954f-8aee-4099-b4dc-d9ac752a250a
+      - req-9e4912c1-dde4-4bfa-8b85-d8e095de49c3
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17013,13 +16402,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:54 GMT
+      - Thu, 25 Oct 2018 18:20:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-118516dc-3536-449b-8467-e65faff7b8e0
+      - req-00e628a6-9f3d-459c-9138-40964330baaa
       Content-Length:
       - '4118'
       Connection:
@@ -17028,10 +16417,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:55.048137", "expires":
-        "2018-09-26T19:41:55Z", "id": "fe4621711f62474394e2b62d08268e54", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:04.963404", "expires":
+        "2018-10-25T19:20:04Z", "id": "1090e54eb1c34cdd884890c1352aef8e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-cc9o-FXTVGk4HxStnf6Fw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["2-z-AoPwTSCTgI2Qe0jCUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17075,7 +16464,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -17090,27 +16479,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73608247-dc99-41b0-b9ca-463ab86b5fb9
+      - req-de9634eb-2c19-42b9-a905-291ebacb55c8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-73608247-dc99-41b0-b9ca-463ab86b5fb9
+      - req-de9634eb-2c19-42b9-a905-291ebacb55c8
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -17125,22 +16514,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-241047ae-fa0f-46e9-b98a-8c4b9bf1ffed
+      - req-c4dd1987-aba4-46ce-ad21-1152d4c3d2fa
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-241047ae-fa0f-46e9-b98a-8c4b9bf1ffed
+      - req-c4dd1987-aba4-46ce-ad21-1152d4c3d2fa
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17155,7 +16544,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -17170,22 +16559,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76bd8a65-21d3-4d68-a3c0-0335fbe64477
+      - req-63988c5d-abcc-4e00-9650-fbbfc99ee3d9
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-76bd8a65-21d3-4d68-a3c0-0335fbe64477
+      - req-63988c5d-abcc-4e00-9650-fbbfc99ee3d9
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17200,7 +16589,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -17215,27 +16604,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-db85498a-02fa-4d1e-a99e-f7d64cde30fd
+      - req-ad2acffd-488a-4bc6-abf1-a04a3f030f3f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-db85498a-02fa-4d1e-a99e-f7d64cde30fd
+      - req-ad2acffd-488a-4bc6-abf1-a04a3f030f3f
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -17250,27 +16639,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-10cdb736-9b4e-4c89-b342-4793f395158f
+      - req-9c656468-7282-4c69-820e-a9ae23f3483a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-10cdb736-9b4e-4c89-b342-4793f395158f
+      - req-9c656468-7282-4c69-820e-a9ae23f3483a
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -17285,27 +16674,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e165f8a-36b4-4159-9507-6f47f6ced70e
+      - req-190dad8b-1530-403e-9a74-5dc7345be64e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7e165f8a-36b4-4159-9507-6f47f6ced70e
+      - req-190dad8b-1530-403e-9a74-5dc7345be64e
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -17320,27 +16709,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1d06c19-7dc7-41ea-9159-3ee901d809dd
+      - req-888fb413-b32e-4a96-9aaa-e630d6c600c5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e1d06c19-7dc7-41ea-9159-3ee901d809dd
+      - req-888fb413-b32e-4a96-9aaa-e630d6c600c5
       Date:
-      - Wed, 26 Sep 2018 18:41:55 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -17355,27 +16744,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf3ad9a7-db3c-4d35-9913-4326105745ac
+      - req-8b9192ae-042c-43b5-aa71-9492676a7c92
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bf3ad9a7-db3c-4d35-9913-4326105745ac
+      - req-8b9192ae-042c-43b5-aa71-9492676a7c92
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -17390,27 +16779,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7bf091e-9408-449a-9117-6b26f42d7d29
+      - req-9aaab778-21f9-42c1-8238-987dd1fcf03a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e7bf091e-9408-449a-9117-6b26f42d7d29
+      - req-9aaab778-21f9-42c1-8238-987dd1fcf03a
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -17425,27 +16814,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c81b68ec-333f-47cd-8458-87db5edae01d
+      - req-64df119b-64af-43df-9996-6b0ae75373fc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c81b68ec-333f-47cd-8458-87db5edae01d
+      - req-64df119b-64af-43df-9996-6b0ae75373fc
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -17460,27 +16849,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19f80085-7916-4daf-9d5c-222bf06aacb8
+      - req-7e3ddbf4-1f96-42c6-b092-26510bf72ea6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-19f80085-7916-4daf-9d5c-222bf06aacb8
+      - req-7e3ddbf4-1f96-42c6-b092-26510bf72ea6
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -17495,27 +16884,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46745724-0dc3-4810-a651-8d533c596f1b
+      - req-197bda6a-7d5a-4c8e-9f7c-cbb0bf3979e4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-46745724-0dc3-4810-a651-8d533c596f1b
+      - req-197bda6a-7d5a-4c8e-9f7c-cbb0bf3979e4
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17530,27 +16919,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-865a0c66-caee-4eae-8599-2c5c013cc96c
+      - req-84432365-4b87-4261-b284-55d9d09cb0f5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-865a0c66-caee-4eae-8599-2c5c013cc96c
+      - req-84432365-4b87-4261-b284-55d9d09cb0f5
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17565,27 +16954,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2555c2d-12ba-48da-bd74-6690c3f2e566
+      - req-68c14337-e0d7-49f7-b622-fec014590e1a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c2555c2d-12ba-48da-bd74-6690c3f2e566
+      - req-68c14337-e0d7-49f7-b622-fec014590e1a
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17600,27 +16989,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c7376a8-06ca-4d4e-8f0f-881af43b561e
+      - req-6149056a-0ae8-4128-aff4-1ebce015c015
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c7376a8-06ca-4d4e-8f0f-881af43b561e
+      - req-6149056a-0ae8-4128-aff4-1ebce015c015
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17635,27 +17024,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e96afe4-17c1-4c2f-909e-4e13b4e6b6e7
+      - req-496ceebd-e95b-434a-8cff-1c95d5ac9802
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7e96afe4-17c1-4c2f-909e-4e13b4e6b6e7
+      - req-496ceebd-e95b-434a-8cff-1c95d5ac9802
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17670,27 +17059,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21bf4f69-662d-4268-a0e0-a4909433d181
+      - req-27964a2d-4a99-4085-a13f-e4657de79c3e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-21bf4f69-662d-4268-a0e0-a4909433d181
+      - req-27964a2d-4a99-4085-a13f-e4657de79c3e
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17705,22 +17094,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c36c3f6f-b342-41e4-9463-6ac8326cefe6
+      - req-d292f469-5e21-4bec-bbf9-becda6576c26
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c36c3f6f-b342-41e4-9463-6ac8326cefe6
+      - req-d292f469-5e21-4bec-bbf9-becda6576c26
       Date:
-      - Wed, 26 Sep 2018 18:41:56 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17732,7 +17121,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17747,22 +17136,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 78904c37dc034beab480e79fcb750f02
+      - c75bff773d9e4bb2858839789339749c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b88793c0-6946-4aa7-aaf7-303fd63a7c75
+      - req-f208aadc-7dcd-4933-94ca-e6f180b20c76
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b88793c0-6946-4aa7-aaf7-303fd63a7c75
+      - req-f208aadc-7dcd-4933-94ca-e6f180b20c76
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17774,7 +17163,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17789,22 +17178,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b943391-61c3-4cbb-a852-43105fbf65a8
+      - req-c7ca38b4-81b2-4f0f-9cd3-3df98be5b890
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4b943391-61c3-4cbb-a852-43105fbf65a8
+      - req-c7ca38b4-81b2-4f0f-9cd3-3df98be5b890
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17816,7 +17205,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17831,22 +17220,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44d184c413264e59b59bdbf51c4c0898
+      - 88b62c8f2d0c48b2aaa00404076323fa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e14f1b08-745a-4248-b780-3227bf68cc6c
+      - req-12ba3af7-be15-4664-8d31-a1e86a0cf121
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e14f1b08-745a-4248-b780-3227bf68cc6c
+      - req-12ba3af7-be15-4664-8d31-a1e86a0cf121
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17858,7 +17247,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17873,22 +17262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38d333b9-d89e-451f-b629-644e4bbca361
+      - req-918473c6-c60f-4614-9c2d-06bbaffea3d2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-38d333b9-d89e-451f-b629-644e4bbca361
+      - req-918473c6-c60f-4614-9c2d-06bbaffea3d2
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17900,7 +17289,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17915,22 +17304,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c145a8768b4b439232ffd6418ce2bc
+      - c77da5f543fa41b79305756854f0596f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41f38c40-3b07-487f-a414-eb596ee895b9
+      - req-9aec9c15-9c11-4f7d-adff-a2a64a27c6ab
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-41f38c40-3b07-487f-a414-eb596ee895b9
+      - req-9aec9c15-9c11-4f7d-adff-a2a64a27c6ab
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17942,7 +17331,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17957,22 +17346,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd669543-2a9e-4c33-abd9-49dd92a21124
+      - req-4cc51750-6721-49a0-99cc-a89813b1be16
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-bd669543-2a9e-4c33-abd9-49dd92a21124
+      - req-4cc51750-6721-49a0-99cc-a89813b1be16
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17984,7 +17373,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17999,22 +17388,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4621711f62474394e2b62d08268e54
+      - 1090e54eb1c34cdd884890c1352aef8e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1521767e-7941-42a9-b4ca-6ca6a58770e0
+      - req-71e2ff90-061a-4891-ae04-727316fcf113
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1521767e-7941-42a9-b4ca-6ca6a58770e0
+      - req-71e2ff90-061a-4891-ae04-727316fcf113
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18026,7 +17415,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18044,13 +17433,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-be1d0c21-b338-4105-9b4b-96f28b8e2a1a
+      - req-7bd1e04c-5e38-4754-89d4-d8d6609a9f1c
       Content-Length:
       - '4170'
       Connection:
@@ -18059,10 +17448,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:57.837580", "expires":
-        "2018-09-26T19:41:57Z", "id": "72af413dc1204447acfc44812cd9ca59", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:07.990830", "expires":
+        "2018-10-25T19:20:07Z", "id": "33220baeabfc4108b1ed6af68c15ce4b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WieLqnVWSM6nP8D9vjkQEg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_iDnarn9QlC-_uAmklzMeA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18107,7 +17496,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18125,13 +17514,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:57 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-383279d3-fa4c-4f90-a840-f3fb1eb57554
+      - req-2553bb8f-1c11-49ba-adee-589cbf98e3be
       Content-Length:
       - '4170'
       Connection:
@@ -18140,10 +17529,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:58.014655", "expires":
-        "2018-09-26T19:41:57Z", "id": "b878dc8069a14d86a5e6131d2868badd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.177226", "expires":
+        "2018-10-25T19:20:08Z", "id": "bccac69028e8432f861b9103fea8df39", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Yf-GgvDVT7a7jmUPaW5QGw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["LRw3wZfQTx-PFp-W9I5OzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18188,13 +17577,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18206,13 +17595,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a37685fe-29be-4ae2-a3d7-960b0a89946d
+      - req-ea019f32-405c-4105-b58e-604d2da2b321
       Content-Length:
       - '370'
       Connection:
@@ -18221,13 +17610,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:58.164660", "expires":
-        "2018-09-26T19:41:58Z", "id": "23bf7cc0c53b41789e53fc97e86dc42c", "audit_ids":
-        ["PGQ9rCxIRaK2_NW67EbjbQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.329334", "expires":
+        "2018-10-25T19:20:08Z", "id": "245c5bb42ead4781a333211c41c5a705", "audit_ids":
+        ["96a7vH4qRbSY0q5yig_TcA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18242,20 +17631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23bf7cc0c53b41789e53fc97e86dc42c
+      - 245c5bb42ead4781a333211c41c5a705
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-722c0f74-ce47-4590-a391-864f849986fe
+      - req-0df66463-f70a-44f9-ba08-985137d923ad
       Content-Length:
       - '500'
       Connection:
@@ -18272,133 +17661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"23bf7cc0c53b41789e53fc97e86dc42c"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-eb467474-3562-491a-bb5a-14c9f586ca64
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:58.453950", "expires":
-        "2018-09-26T19:41:58Z", "id": "95c672f982da4d1fa18e4aab36d06163", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7wJNfjMbTICzp4FMh66OQw",
-        "PGQ9rCxIRaK2_NW67EbjbQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 23bf7cc0c53b41789e53fc97e86dc42c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-07466737-d759-4664-8ce0-db5b3a308ebf
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18416,13 +17679,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-705f242f-b0cc-4126-b549-7cfbabb499d9
+      - req-7771800d-7f6e-450b-8f8d-a2d328487fcf
       Content-Length:
       - '4117'
       Connection:
@@ -18431,10 +17694,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:58.762926", "expires":
-        "2018-09-26T19:41:58Z", "id": "5323c6b827564e07839cd3764cc6dac0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.635128", "expires":
+        "2018-10-25T19:20:08Z", "id": "e33b73b552ef45a8a0bc63d84ebcbb61", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jObZwXl5T-CShKmz6wawBQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OzVVmkHmQAie5G8dTN-AdA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18478,7 +17741,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18496,13 +17759,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:58 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52416cad-e0af-4d55-9a3c-c84b84cb65be
+      - req-cbf1ad54-7980-4433-acd5-63b67bddb456
       Content-Length:
       - '4131'
       Connection:
@@ -18511,10 +17774,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:58.943822", "expires":
-        "2018-09-26T19:41:58Z", "id": "653d0a7914284bd7be60ccccd736bd7a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:08.830872", "expires":
+        "2018-10-25T19:20:08Z", "id": "7758aa6420c94742a0241910bd3fec1f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Yy6CJVV3SeauuLqY5D9Mmg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ufXYkTh0T4CFWgVdcWet3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18558,7 +17821,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18576,13 +17839,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cdf0c3d4-10c3-440e-90b9-ea2985fe94b4
+      - req-41d4c645-c2c3-45a8-bea5-da83f964d1fa
       Content-Length:
       - '4118'
       Connection:
@@ -18591,10 +17854,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:59.140194", "expires":
-        "2018-09-26T19:41:59Z", "id": "76e3527cdf2e4ffebae4733002d5f876", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.015203", "expires":
+        "2018-10-25T19:20:08Z", "id": "61bac17a64f04423bbcc7767a4eac9c8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["TkoKpcMVQJWdOFuftlsvJg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gAA0ZtLoSwC81D0DW6Uf9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18638,7 +17901,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18656,13 +17919,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52665659-034a-43f3-a603-62e3090eebb6
+      - req-d082669e-17be-44df-a9b5-9fa9c4a7511a
       Content-Length:
       - '4117'
       Connection:
@@ -18671,10 +17934,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:59.337270", "expires":
-        "2018-09-26T19:41:59Z", "id": "62e676583bc84a7faa7dd82e717ffda7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.212575", "expires":
+        "2018-10-25T19:20:09Z", "id": "9256c11a79724e05af605de6f1f69e72", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FIV1EaurTvi1aku-vZ2f2Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VrQYF_lYS4eaFvcesBY-Rg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18718,7 +17981,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18733,7 +17996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e676583bc84a7faa7dd82e717ffda7
+      - 9256c11a79724e05af605de6f1f69e72
   response:
     status:
       code: 200
@@ -18762,15 +18025,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx7fd82de434c14219999cc-005babd2f7
+      - tx5318a84fb1ce4b0bae3d6-005bd20959
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18785,7 +18048,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e676583bc84a7faa7dd82e717ffda7
+      - 9256c11a79724e05af605de6f1f69e72
   response:
     status:
       code: 200
@@ -18814,14 +18077,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb4eebbce4b1d4011accd9-005babd2f7
+      - txe965f49fcf644c6da85f9-005bd20959
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18839,13 +18102,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52bc125d-6a4f-4619-9bdf-c0f87e6e7da5
+      - req-b30044db-a701-4443-9403-5e07096a0366
       Content-Length:
       - '4131'
       Connection:
@@ -18854,10 +18117,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:59.778820", "expires":
-        "2018-09-26T19:41:59Z", "id": "75b12a1ea8174e5aba0503fb3812dfb1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:09.640716", "expires":
+        "2018-10-25T19:20:09Z", "id": "f8c3789898a44a5db359c2b7570c8b9e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["c12dpOOLSXyYneVb6vlnOA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jG3dhi3sRP-5O1vD4cRIiw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18901,7 +18164,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18916,7 +18179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75b12a1ea8174e5aba0503fb3812dfb1
+      - f8c3789898a44a5db359c2b7570c8b9e
   response:
     status:
       code: 200
@@ -18929,22 +18192,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987319.94264'
+      - '1540491609.80645'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987319.94264'
+      - '1540491609.80645'
       X-Trans-Id:
-      - tx5575218fc2684e249d32e-005babd2f7
+      - txc63bb348a29f4096aa755-005bd20959
       Date:
-      - Wed, 26 Sep 2018 18:41:59 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18959,7 +18222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b878dc8069a14d86a5e6131d2868badd
+      - bccac69028e8432f861b9103fea8df39
   response:
     status:
       code: 200
@@ -18972,22 +18235,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987320.08817'
+      - '1540491609.95514'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987320.08817'
+      - '1540491609.95514'
       X-Trans-Id:
-      - tx6041608ec3c84f7c8ccef-005babd2f8
+      - tx1754d1c3e33d4394b8373-005bd20959
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19005,13 +18268,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-274ccac7-908a-4d1a-951b-f6d297124c93
+      - req-096dabf9-a20d-47f0-9d42-05f1805a53f0
       Content-Length:
       - '4118'
       Connection:
@@ -19020,10 +18283,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:00.262987", "expires":
-        "2018-09-26T19:42:00Z", "id": "7233d3ad47864bfb9c04047dbcc4f348", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:10.133220", "expires":
+        "2018-10-25T19:20:10Z", "id": "6a396c6a2b21454d84bde20cbbd67352", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["s18e78QNQ36qKgzVfyNPlA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MjQDwvtbTB6zW9O9-f5irQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -19067,7 +18330,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -19082,7 +18345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7233d3ad47864bfb9c04047dbcc4f348
+      - 6a396c6a2b21454d84bde20cbbd67352
   response:
     status:
       code: 200
@@ -19095,22 +18358,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987320.41627'
+      - '1540491610.29686'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987320.41627'
+      - '1540491610.29686'
       X-Trans-Id:
-      - txc477894d4792446d93eec-005babd2f8
+      - tx91ad9403799d481ca6676-005bd2095a
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -19125,7 +18388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e676583bc84a7faa7dd82e717ffda7
+      - 9256c11a79724e05af605de6f1f69e72
   response:
     status:
       code: 200
@@ -19146,9 +18409,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txa0877a7ce40042c789201-005babd2f8
+      - tx4ab34f2f5a964d669986e-005bd2095a
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -19158,7 +18421,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -19173,7 +18436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e676583bc84a7faa7dd82e717ffda7
+      - 9256c11a79724e05af605de6f1f69e72
   response:
     status:
       code: 200
@@ -19194,14 +18457,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbf98c525c8bb46b7b0ab4-005babd2f8
+      - tx837da472430a453fb710a-005bd2095a
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -19216,7 +18479,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e676583bc84a7faa7dd82e717ffda7
+      - 9256c11a79724e05af605de6f1f69e72
   response:
     status:
       code: 200
@@ -19237,12 +18500,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txe424654dd452482b828a5-005babd2f8
+      - tx81d3a2fdda504aaba0933-005bd2095a
       Date:
-      - Wed, 26 Sep 2018 18:42:00 GMT
+      - Thu, 25 Oct 2018 18:20:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:43 GMT
+      - Thu, 25 Oct 2018 18:21:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e0b8f03b-d5fd-4197-985f-c5ce75337169
+      - req-33443050-5f42-4e45-b594-b7dc7fe9d261
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:43.657211", "expires":
-        "2018-09-26T19:43:43Z", "id": "ca5276d099c7481f9a75c83d7f2b5b0c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:44.538125", "expires":
+        "2018-10-25T19:21:44Z", "id": "374009d19f954a2d8b1de1a56b39e97d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NQbsiqJ6R1K6xPdlf4FBfw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["q7FmTaD_TGG8UyXRW8mxnw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:43 GMT
+      - Thu, 25 Oct 2018 18:21:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-7cede09e-d421-4c12-99ea-5564779eaa83
+      - req-168504ab-340a-405f-bdf4-b8bf676760b4
       Date:
-      - Wed, 26 Sep 2018 18:43:43 GMT
+      - Thu, 25 Oct 2018 18:21:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e1cebb7-7066-497a-add0-35764ac25ae7
+      - req-ba7dd181-9a2f-47e3-ae13-4d6379b3a531
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:44.113167", "expires":
-        "2018-09-26T19:43:44Z", "id": "89a2da6b534849feb6fb5b8f1109b0f7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:44.968388", "expires":
+        "2018-10-25T19:21:44Z", "id": "31a100b4e77e4d8cbda2b3abf0a3d069", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["IX9Spy45SD23b-IEQzcefA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["l1DRaEfMRhGzFKVPstblEg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9865dde6-a646-427a-853f-5801fc3c2e4a
+      - req-550dd436-f59f-4087-9aec-58a4f50da742
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-9865dde6-a646-427a-853f-5801fc3c2e4a
+      - req-550dd436-f59f-4087-9aec-58a4f50da742
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-620c1a76-7c5c-41b3-a92b-94699de03c29
+      - req-4942d4ed-4fa2-4e32-b9b1-84dbb6fec923
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:43:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:21:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:43:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:21:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:43:40.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:21:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:43:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:21:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:43:37.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:21:42.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c1b97c25-3419-4896-a539-d409c493b78f
+      - req-f041594c-b1b0-4dba-a5cc-27c1f129e546
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:43:34.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:21:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:43:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:21:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:43:40.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:21:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:43:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:21:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:43:37.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:21:42.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-16a92d68-5a04-4a5d-8806-ecd387767ce2
+      - req-b203a531-af99-4bd5-a460-e6fc1e24d82e
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-6aaacd7f-67ff-44f8-8ea9-832f270d6b36
+      - req-0e894291-48a6-4bd0-9db2-5c1f33ca15d6
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-b67917ac-5702-46e3-a9c9-4913b72078c4
+      - req-afedc1dc-e7b8-458d-9ac2-5565dc43b9ac
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-9d6187ba-2a81-447e-b741-e99f1db28f70
+      - req-40870cda-cdd3-4c2b-a53a-6746feaf9e6f
       Date:
-      - Wed, 26 Sep 2018 18:43:44 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:45 GMT
+      - Thu, 25 Oct 2018 18:21:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8648a6f3-05ea-45fe-830b-0c721f8c8c85
+      - req-4c6e2a21-cbcf-41c7-a200-fe631d03ad0e
       Content-Length:
       - '4170'
       Connection:
@@ -568,10 +568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:45.164433", "expires":
-        "2018-09-26T19:43:45Z", "id": "9a781722f5e945c88bc15515c1d2d7d8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:45.997911", "expires":
+        "2018-10-25T19:21:45Z", "id": "314b2f10e623463ba33f21e329ee6b7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["S654VSYXTuudBVZiwk7VHQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["UAqNZuihSKieRQPbFm6I5g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -616,7 +616,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -631,20 +631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a781722f5e945c88bc15515c1d2d7d8
+      - 314b2f10e623463ba33f21e329ee6b7f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:45 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-226486c6-bb2f-4c04-b74a-e69d62aa1fdc
+      - req-3f131a86-acae-4004-9efa-d33c4b854d38
       Content-Length:
       - '500'
       Connection:
@@ -661,7 +661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -676,7 +676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -689,15 +689,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-5b97b356-3349-4532-bf18-197dd46bff7e
+      - req-2db5b4e5-fb15-49b1-90c8-4744bf45aea4
       Date:
-      - Wed, 26 Sep 2018 18:43:45 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -715,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:45 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbc06aeb-3e8d-4e4c-8018-3a0e7503889d
+      - req-b9b8d9da-3ff1-457d-bcc5-94dab6d3633e
       Content-Length:
       - '4170'
       Connection:
@@ -730,10 +730,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:45.636867", "expires":
-        "2018-09-26T19:43:45Z", "id": "e0ece8082b1a403db2e66921cec1dbd2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:46.410346", "expires":
+        "2018-10-25T19:21:46Z", "id": "2993cdfdae83436193a319a558c60daa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9tP6UqCtSqaLOHC3Fr-7mQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["G8k7TQn1QvGNH09XCfpQqQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -778,46 +778,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e0ece8082b1a403db2e66921cec1dbd2
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:43:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.233:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.233:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -832,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0ece8082b1a403db2e66921cec1dbd2
+      - 2993cdfdae83436193a319a558c60daa
   response:
     status:
       code: 200
@@ -843,9 +804,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-82983114-d354-47dc-b361-9b42ec5952cf
+      - req-818c0a20-8e09-4050-ae66-d35c5d0e8f7b
       Date:
-      - Wed, 26 Sep 2018 18:43:47 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -887,7 +848,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -902,7 +863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0ece8082b1a403db2e66921cec1dbd2
+      - 2993cdfdae83436193a319a558c60daa
   response:
     status:
       code: 200
@@ -913,14 +874,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d2f7dd13-10a6-4a44-97a0-70b216835748
+      - req-0ba093e4-101a-4852-a93f-cb82d287a517
       Date:
-      - Wed, 26 Sep 2018 18:43:47 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -935,7 +896,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -948,9 +909,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-94eb0b68-4a25-408a-995b-c9d486cf1a04
+      - req-dc8a74d3-3b39-4f73-9421-6205f4c78fdd
       Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -960,7 +921,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -975,7 +936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -988,9 +949,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2daaccdf-bf58-470a-989d-9aa9ddfcc6ae
+      - req-ed829455-e719-4b56-b07c-526b3a0f2c85
       Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
+      - Thu, 25 Oct 2018 18:21:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1000,7 +961,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +979,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-beff6687-6dc5-4ecd-8d2b-7d80efb0f003
+      - req-6aaab10b-b948-4f13-b524-766310b2f645
       Content-Length:
       - '4170'
       Connection:
@@ -1033,10 +994,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:48.341418", "expires":
-        "2018-09-26T19:43:48Z", "id": "a7f67099166e4921ac6b3c8d6a32d841", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.141468", "expires":
+        "2018-10-25T19:21:47Z", "id": "27cc04e96ab3401dbbdc240d5a399e6d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2r62PqevRvOo4si7l4upYw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["zRarSxS0S7anQYAwnjjsZw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1081,13 +1042,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1099,13 +1060,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9a1c6713-115f-4f50-b1a1-cb773b22e40b
+      - req-344e4627-0ab6-4476-9336-852f6f593974
       Content-Length:
       - '370'
       Connection:
@@ -1114,13 +1075,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:48.491206", "expires":
-        "2018-09-26T19:43:48Z", "id": "aa6ac19a63024bf0899322d9595500a1", "audit_ids":
-        ["R5z40bBuSfKGbTLsk0vL3w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.315605", "expires":
+        "2018-10-25T19:21:47Z", "id": "e7d03da584a44b20a44dc39cd0cf4f4e", "audit_ids":
+        ["nOtnWf7iTz6tGmW1KFAhEg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1135,20 +1096,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa6ac19a63024bf0899322d9595500a1
+      - e7d03da584a44b20a44dc39cd0cf4f4e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-40aaf532-07ca-4830-a0a2-0c13c59ff787
+      - req-e5bca8c8-249a-4e94-b1b4-777dfaf4d6df
       Content-Length:
       - '500'
       Connection:
@@ -1165,133 +1126,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"aa6ac19a63024bf0899322d9595500a1"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-9b2db074-69a1-4fcd-9d3e-780506b4421b
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:48.792250", "expires":
-        "2018-09-26T19:43:48Z", "id": "2dc7e6ba3b46411087c344e80308dc53", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VZYpP52GSwO-WHTwHEwiPQ",
-        "R5z40bBuSfKGbTLsk0vL3w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aa6ac19a63024bf0899322d9595500a1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:48 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-89fb021c-413e-496b-ba02-1c1eec7bca9f
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1309,13 +1144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7cde7c43-0c6e-4f95-af02-116005c9481d
+      - req-165390bb-ac4c-4018-8bc7-35a7dd4816c7
       Content-Length:
       - '4117'
       Connection:
@@ -1324,10 +1159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:49.097121", "expires":
-        "2018-09-26T19:43:49Z", "id": "89ab06725b75444599a37cce817d9c3e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.623559", "expires":
+        "2018-10-25T19:21:47Z", "id": "59bdf2d92cc9422996b2578739f2ba8c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hPR4UZL_QKWaKBeAzRdkEw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CZgQPIFaTBGRDtAEYjhIXQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1371,7 +1206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1386,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89ab06725b75444599a37cce817d9c3e
+      - 59bdf2d92cc9422996b2578739f2ba8c
   response:
     status:
       code: 200
@@ -1397,7 +1232,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1406,7 +1241,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1424,13 +1259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e87b18d6-e876-49de-9b66-a71605151c0b
+      - req-32b6bb81-043a-4bff-84d2-85ae36e0c992
       Content-Length:
       - '4131'
       Connection:
@@ -1439,10 +1274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:49.356743", "expires":
-        "2018-09-26T19:43:49Z", "id": "f8f8d13393474f3b858428d74a6254f1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:47.884554", "expires":
+        "2018-10-25T19:21:47Z", "id": "9279da89caed4ba08613476e7f4c5622", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qYwTF1vATu-j1yDWCOnKgA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dh_K0k9IRZ2TAGjUCl1GQw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1486,7 +1321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1501,7 +1336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8f8d13393474f3b858428d74a6254f1
+      - 9279da89caed4ba08613476e7f4c5622
   response:
     status:
       code: 200
@@ -1512,7 +1347,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1521,7 +1356,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1539,13 +1374,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c1d8c37-e825-4958-b93c-c154fef4195e
+      - req-2255ae32-db1d-4bb2-80f9-f0e2c8bffb81
       Content-Length:
       - '4118'
       Connection:
@@ -1554,10 +1389,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:49.624512", "expires":
-        "2018-09-26T19:43:49Z", "id": "a1db143024184988a73350ced9dde6e0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.142379", "expires":
+        "2018-10-25T19:21:48Z", "id": "7f7cafd5301545f1814f68dc40fcb64f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["C762jFt_QwWrv4Y6uPUbGw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7944VoHTQ4mz9GP8BIfOPg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1601,7 +1436,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1616,7 +1451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1db143024184988a73350ced9dde6e0
+      - 7f7cafd5301545f1814f68dc40fcb64f
   response:
     status:
       code: 200
@@ -1627,7 +1462,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1636,7 +1471,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1654,13 +1489,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:49 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7bc6af82-a28a-4f5b-8e7f-251371a13972
+      - req-86e24925-b18b-4507-81fe-0ce5e2e344e8
       Content-Length:
       - '4117'
       Connection:
@@ -1669,10 +1504,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:49.876727", "expires":
-        "2018-09-26T19:43:49Z", "id": "e235c0c9efdd4398950922eeb2d9ab40", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.398311", "expires":
+        "2018-10-25T19:21:48Z", "id": "e5a79af6c3fc4433bfbbbcc61c24b317", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["cZ2tsQL9QRasctlN6nKKGQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lOAhQ9vSShaIQrS-KVyt2g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1716,7 +1551,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1731,7 +1566,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -1742,9 +1577,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-23455f00-6c20-4c2c-a104-a6faaa5c70dc
+      - req-f3a1161a-0b28-47f2-b5eb-cb838432411d
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1778,7 +1613,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1793,7 +1628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -1804,14 +1639,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d0f4dfeb-3544-469a-9b9d-018558887eb6
+      - req-d56d641d-7d9c-4cb2-b0ff-9699ca30a201
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1829,13 +1664,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-629e7b02-a53f-495d-8c42-838d23fb3f85
+      - req-2d66e76a-7a05-48e1-ad36-0ca5765b0d15
       Content-Length:
       - '4131'
       Connection:
@@ -1844,10 +1679,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:50.352982", "expires":
-        "2018-09-26T19:43:50Z", "id": "7bfad454ceb74bef964503897282fca9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:48.859219", "expires":
+        "2018-10-25T19:21:48Z", "id": "3abb6524eac54039abc5681a7ee24992", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rSgA8udlRmCIeZbXeKExNw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["V4b4QFoZQnGIQfftyIhF-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1891,7 +1726,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1906,7 +1741,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bfad454ceb74bef964503897282fca9
+      - 3abb6524eac54039abc5681a7ee24992
   response:
     status:
       code: 200
@@ -1917,14 +1752,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4766051a-f34d-4cf3-a378-a56a44de5e2f
+      - req-0e5b9df2-fa32-460f-8125-a84d642e1faf
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1939,7 +1774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7f67099166e4921ac6b3c8d6a32d841
+      - 27cc04e96ab3401dbbdc240d5a399e6d
   response:
     status:
       code: 200
@@ -1950,14 +1785,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a3660c5d-3a6d-4b11-9496-4c1ae92ccd10
+      - req-8b9179ba-8608-47aa-b2a9-5d7e99e9a28b
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1975,13 +1810,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:50 GMT
+      - Thu, 25 Oct 2018 18:21:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-375c070a-0780-4e51-a392-cddc7cbf1e13
+      - req-c3456ebd-d6a1-4d1c-b805-0a2b57196174
       Content-Length:
       - '4118'
       Connection:
@@ -1990,10 +1825,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:50.867368", "expires":
-        "2018-09-26T19:43:50Z", "id": "482458d8a93b45788f5a8e691a9a7fb4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:49.389601", "expires":
+        "2018-10-25T19:21:49Z", "id": "d4a581e1433645b6b84eefe9ac60ba3b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Uh14-HQfQsC1LC0SchwRzA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EXZ4m5hjQgGQS_-MZtWSOA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2037,7 +1872,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2052,7 +1887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 482458d8a93b45788f5a8e691a9a7fb4
+      - d4a581e1433645b6b84eefe9ac60ba3b
   response:
     status:
       code: 200
@@ -2063,14 +1898,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-78f0635a-1d67-40e4-b64d-364e31a80217
+      - req-103f84f1-70d0-4a1d-847e-7c7068f28ca9
       Date:
-      - Wed, 26 Sep 2018 18:43:51 GMT
+      - Thu, 25 Oct 2018 18:21:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2085,7 +1920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2096,9 +1931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9c50973f-e347-45f8-ae72-975b68a3d1ff
+      - req-576602b9-47ff-403c-8b7d-92edaa4dcd82
       Date:
-      - Wed, 26 Sep 2018 18:43:51 GMT
+      - Thu, 25 Oct 2018 18:21:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2125,7 +1960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2140,7 +1975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2151,9 +1986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8590e7f5-882f-467a-aacf-52409c247f9f
+      - req-e4333c73-0a19-45fc-8faf-a7381a5352db
       Date:
-      - Wed, 26 Sep 2018 18:43:51 GMT
+      - Thu, 25 Oct 2018 18:21:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2180,7 +2015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2195,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2206,9 +2041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-aa3c5303-a4ac-4953-98dd-7dcacaa0ccce
+      - req-09063e4f-16b6-4b5c-b43a-b99913603271
       Date:
-      - Wed, 26 Sep 2018 18:43:52 GMT
+      - Thu, 25 Oct 2018 18:21:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2235,7 +2070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -2250,7 +2085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2261,9 +2096,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-74317706-660a-44fe-8d94-9f82d83ad38e
+      - req-ce2e281e-0c26-496a-b946-ccd49fdb1ace
       Date:
-      - Wed, 26 Sep 2018 18:43:52 GMT
+      - Thu, 25 Oct 2018 18:21:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2319,7 +2154,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -2334,7 +2169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2345,9 +2180,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b08a7980-8d51-4c87-ab11-dd7c9d872df0
+      - req-aba39358-70c5-44a3-9c77-398b6138c966
       Date:
-      - Wed, 26 Sep 2018 18:43:52 GMT
+      - Thu, 25 Oct 2018 18:21:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2359,7 +2194,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -2374,7 +2209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2387,13 +2222,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-dedefd34-a361-4e32-b11a-37bf43061198
+      - req-5ff8231d-a152-40d0-98a9-45e59e126e38
       Date:
-      - Wed, 26 Sep 2018 18:43:52 GMT
+      - Thu, 25 Oct 2018 18:21:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -2435,7 +2270,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -2450,7 +2285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2463,9 +2298,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-845f9b91-cd50-4521-9c52-c5eeaa5ed4d0
+      - req-b4db3a05-3740-4b9f-8354-384032480298
       Date:
-      - Wed, 26 Sep 2018 18:43:52 GMT
+      - Thu, 25 Oct 2018 18:21:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -2489,7 +2324,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:41:33Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -2511,7 +2346,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -2526,7 +2361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2539,13 +2374,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-07aea007-e9e5-444c-ad10-82d67ec5df63
+      - req-68a40955-934f-417e-a353-eff6aa687604
       Date:
-      - Wed, 26 Sep 2018 18:43:53 GMT
+      - Thu, 25 Oct 2018 18:21:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:24Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -2566,7 +2401,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -2589,7 +2424,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -2604,7 +2439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2617,9 +2452,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-e38f4f9e-4a03-497c-a4ee-508d909beeaf
+      - req-c938489e-f93b-4dfc-8aa3-51e270a6782b
       Date:
-      - Wed, 26 Sep 2018 18:43:53 GMT
+      - Thu, 25 Oct 2018 18:21:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2661,7 +2496,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2676,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2689,9 +2524,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-42d2eda3-00c2-4254-bd5c-a2adcd4a6860
+      - req-bd2ca756-ad79-4622-9679-5ec4b677b842
       Date:
-      - Wed, 26 Sep 2018 18:43:53 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2714,7 +2549,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2729,7 +2564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2740,9 +2575,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-b7e75b06-5ee2-407f-b92c-34db30365049
+      - req-234fe85f-76cf-4481-9e3f-e8efd32a3b97
       Date:
-      - Wed, 26 Sep 2018 18:43:53 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2798,7 +2633,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2813,7 +2648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2824,9 +2659,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0f4ffc12-36ef-4382-858e-87d839e1c795
+      - req-e0d4c128-b587-451e-8489-8d9be3d6b2c6
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2838,7 +2673,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2853,7 +2688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2864,9 +2699,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f9f3becb-7668-4de7-b1fa-bc57a68e01ae
+      - req-09bb5641-fdc2-43cb-991b-13aa46c6b6a7
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2922,7 +2757,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2937,7 +2772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e235c0c9efdd4398950922eeb2d9ab40
+      - e5a79af6c3fc4433bfbbbcc61c24b317
   response:
     status:
       code: 200
@@ -2948,9 +2783,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3ca13175-8be4-4bae-aa00-03fc5d66956f
+      - req-1bc9ba60-4adb-4d09-bdc1-2cb1b3e4e41d
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2962,7 +2797,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2977,7 +2812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89ab06725b75444599a37cce817d9c3e
+      - 59bdf2d92cc9422996b2578739f2ba8c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2990,9 +2825,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-50af1fa2-4d20-49b2-8dd8-a3daf5758a09
+      - req-3a96e4a5-8597-4562-b4c4-2a1f0d108219
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3001,7 +2836,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3016,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8f8d13393474f3b858428d74a6254f1
+      - 9279da89caed4ba08613476e7f4c5622
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3029,9 +2864,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5163c2ed-886a-46b0-8935-e286e40ed28b
+      - req-2685ba93-5898-4c29-b772-f8bdec453582
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3040,7 +2875,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3055,7 +2890,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3068,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-acdbc775-fc29-4c8c-8d2c-437621917793
+      - req-9e15092d-e2c2-4d08-a9dc-60cbe7cf8f8a
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3079,7 +2914,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3094,7 +2929,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1db143024184988a73350ced9dde6e0
+      - 7f7cafd5301545f1814f68dc40fcb64f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3107,9 +2942,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-328d032a-e5a8-4111-846e-7b117262b8ce
+      - req-e400ad04-6885-4f2c-bd72-3a57f8cbad21
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3118,7 +2953,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3136,13 +2971,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:54 GMT
+      - Thu, 25 Oct 2018 18:21:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f503342-8639-49f7-b67a-85d54b60e5c6
+      - req-5cfa7f16-e428-4b40-a745-8fc9650b0c51
       Content-Length:
       - '4117'
       Connection:
@@ -3151,10 +2986,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:55.033678", "expires":
-        "2018-09-26T19:43:55Z", "id": "50032d1ffb4542808ae2e41425af55a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:53.367120", "expires":
+        "2018-10-25T19:21:53Z", "id": "a104e5847238444bb8a8adaa78d1108d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-aBJpTdHRXqsG7gg-n6Opg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IQi7wRFFQLi457BFaPY6VA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3198,7 +3033,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3213,22 +3048,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50032d1ffb4542808ae2e41425af55a0
+      - a104e5847238444bb8a8adaa78d1108d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07cd0d78-ca45-484a-a7fe-f118d166b64f
+      - req-9269cf97-388c-4a96-a236-be63e8e17ddd
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-07cd0d78-ca45-484a-a7fe-f118d166b64f
+      - req-9269cf97-388c-4a96-a236-be63e8e17ddd
       Date:
-      - Wed, 26 Sep 2018 18:43:55 GMT
+      - Thu, 25 Oct 2018 18:21:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3238,7 +3073,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3256,13 +3091,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:55 GMT
+      - Thu, 25 Oct 2018 18:21:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5e10e817-a37e-4e4d-a450-b804620973e2
+      - req-b9a699a6-9186-4475-9d64-b8c0adf40ece
       Content-Length:
       - '4131'
       Connection:
@@ -3271,10 +3106,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:55.524878", "expires":
-        "2018-09-26T19:43:55Z", "id": "ec69888e22c44776b2c0a7cf93db7854", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:53.854864", "expires":
+        "2018-10-25T19:21:53Z", "id": "00d5243ff75c4829b3766828f2c20e83", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["57Bgro8MRFmcNFURsK-cnA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CRdbeHGGR16NO6HWnpg7XQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3318,7 +3153,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3333,22 +3168,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec69888e22c44776b2c0a7cf93db7854
+      - 00d5243ff75c4829b3766828f2c20e83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed40ab6b-57a9-48ae-b8f7-d6de2999a44a
+      - req-c424cb74-7811-4ecb-816c-6cb4675ea240
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ed40ab6b-57a9-48ae-b8f7-d6de2999a44a
+      - req-c424cb74-7811-4ecb-816c-6cb4675ea240
       Date:
-      - Wed, 26 Sep 2018 18:43:55 GMT
+      - Thu, 25 Oct 2018 18:21:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3358,7 +3193,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3373,22 +3208,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dde915ac-419d-4a01-bdab-d398e2b71dbf
+      - req-c4a40e76-2998-464e-aaaa-8d27a05bc9d6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-dde915ac-419d-4a01-bdab-d398e2b71dbf
+      - req-c4a40e76-2998-464e-aaaa-8d27a05bc9d6
       Date:
-      - Wed, 26 Sep 2018 18:43:56 GMT
+      - Thu, 25 Oct 2018 18:21:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3398,7 +3233,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3416,13 +3251,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:56 GMT
+      - Thu, 25 Oct 2018 18:21:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d209cd9-aeb2-4329-bcce-9c9b4c8f0dfb
+      - req-8459c8ff-8865-497a-a9db-3d2a41a0ba5e
       Content-Length:
       - '4118'
       Connection:
@@ -3431,10 +3266,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:56.357727", "expires":
-        "2018-09-26T19:43:56Z", "id": "8c26c0bc15b4428a845115db6a327ce4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:54.582989", "expires":
+        "2018-10-25T19:21:54Z", "id": "832a14367cc3401dacbf9bd609f630ea", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["85r0P9ecQnChbA5fHiDqkg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["E_BeDUeJQMmQuBvdH4W1yQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3478,7 +3313,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3493,22 +3328,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c26c0bc15b4428a845115db6a327ce4
+      - 832a14367cc3401dacbf9bd609f630ea
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8740c885-0dd1-4907-9a35-ec727668911b
+      - req-e22efc3b-3ff6-407a-a44f-ffb0dd8d3e2c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-8740c885-0dd1-4907-9a35-ec727668911b
+      - req-e22efc3b-3ff6-407a-a44f-ffb0dd8d3e2c
       Date:
-      - Wed, 26 Sep 2018 18:43:56 GMT
+      - Thu, 25 Oct 2018 18:21:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3518,7 +3353,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3536,13 +3371,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:56 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e4a9e933-7681-422a-b75a-b098bf6c00f4
+      - req-1e1b85ef-2572-43b9-8b0a-7deb3d1ac1bc
       Content-Length:
       - '4170'
       Connection:
@@ -3551,10 +3386,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:56.848878", "expires":
-        "2018-09-26T19:43:56Z", "id": "9e5f499093b34af6b2a0a38e1a22720f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.064690", "expires":
+        "2018-10-25T19:21:55Z", "id": "f8b4cdfad19149cba575d2e18ae194ef", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vdD_eAJDSEuHLWkmtju_kg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_7q4StL0Qx2lUfNGEvPFtg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3599,39 +3434,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:56 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9e5f499093b34af6b2a0a38e1a22720f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:43:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3649,13 +3452,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ba9bd5a4-047f-4a90-ba5c-c69f0c505218
+      - req-f22c5074-0ba1-4f33-ad7d-2cda4e86d78c
       Content-Length:
       - '4117'
       Connection:
@@ -3664,10 +3467,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:57.115676", "expires":
-        "2018-09-26T19:43:57Z", "id": "ec0ffedb53924d0d9e4be79ca1ad3af9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.259844", "expires":
+        "2018-10-25T19:21:55Z", "id": "8682288d4dfc4b9886bfd646e212f37b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SiwSgtfBQGyLTtA082renA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mSB7Q-qVTlufNd_QfiMNeQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3711,7 +3514,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3726,7 +3529,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec0ffedb53924d0d9e4be79ca1ad3af9
+      - 8682288d4dfc4b9886bfd646e212f37b
   response:
     status:
       code: 200
@@ -3737,16 +3540,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d7329087-7c49-4be5-878a-c874fe6c185f
+      - req-c1bfc241-80cd-4129-ab85-5cefd626ddd8
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3764,13 +3567,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b8949b45-ecc4-4d80-b2a8-2401c7b736f9
+      - req-2c6937ba-ebc4-451d-9c43-d77c385187f9
       Content-Length:
       - '4131'
       Connection:
@@ -3779,10 +3582,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:57.460520", "expires":
-        "2018-09-26T19:43:57Z", "id": "fccb690e86054ef687bb26c57a0fdb65", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:55.590840", "expires":
+        "2018-10-25T19:21:55Z", "id": "6afe6276dff14ca9bfbbdcb8dd118500", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BPH5R-jUSXyfEFQdX-4Byg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sSCI25S8R1SthQh10Xj9UQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3826,7 +3629,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3841,7 +3644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fccb690e86054ef687bb26c57a0fdb65
+      - 6afe6276dff14ca9bfbbdcb8dd118500
   response:
     status:
       code: 200
@@ -3852,16 +3655,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d584bbfd-0de3-4777-b8a8-8a6a6c80213f
+      - req-fc50c9bb-633a-4b2c-bcc6-05bb038504a0
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3876,7 +3679,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e5f499093b34af6b2a0a38e1a22720f
+      - f8b4cdfad19149cba575d2e18ae194ef
   response:
     status:
       code: 200
@@ -3887,16 +3690,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ed1bb84b-a71f-45f2-aa90-e2e82b08dcea
+      - req-10eb4e61-c5ad-4346-b34b-b8097f82ff16
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3914,13 +3717,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:57 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b6fc78d5-44fc-4771-92f7-893ee3955d3b
+      - req-7d2851ac-1627-49b6-8894-2abc4818095d
       Content-Length:
       - '4118'
       Connection:
@@ -3929,10 +3732,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:57.995479", "expires":
-        "2018-09-26T19:43:57Z", "id": "32dd61d352c9467fa1053e6baf0e93ab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:56.075933", "expires":
+        "2018-10-25T19:21:56Z", "id": "42c079e30b744af6b9c11ced8f577e81", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Bped_q8YTEuSgUV1qeh1zw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ziYNY1v-QqCt19GKDOb0Ow"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3976,7 +3779,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3991,7 +3794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32dd61d352c9467fa1053e6baf0e93ab
+      - 42c079e30b744af6b9c11ced8f577e81
   response:
     status:
       code: 200
@@ -4002,16 +3805,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-eb04c2cb-81b9-4384-a307-5560e4b2f1ff
+      - req-98ad0fef-cead-4759-a172-a9e8cca65412
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4026,7 +3829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4039,14 +3842,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-68b063a7-814c-44d3-8642-9f20d28611ca
+      - req-73c49171-c1d0-449d-95d3-0a8b323fe4eb
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4061,7 +3864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4074,14 +3877,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c05afb0d-96fd-4b72-8cb8-c10b0f01ec73
+      - req-b5baa1ab-001b-480e-b794-1a75a0d59006
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4096,7 +3899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4109,14 +3912,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e95480c3-e77a-4245-92b6-f21e76baf7a5
+      - req-7cbb8c07-6376-43be-a227-e3bcc825480c
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4131,7 +3934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4144,14 +3947,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-88cdcd85-9731-45b8-a32f-044d376d5c43
+      - req-bb8009ab-3f8e-4b4b-a7fe-2ef0e9df225d
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4166,7 +3969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4179,14 +3982,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b4d206cc-8fc4-46d7-ae59-0d8f75033bd3
+      - req-4737eae5-f4f2-4278-b2d4-8b4e7b390c82
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4201,7 +4004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4214,15 +4017,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-0f0695dc-8559-451f-be50-3ebece26cbae
+      - req-80e897da-3b92-4d98-9f4c-cfd689715283
       Date:
-      - Wed, 26 Sep 2018 18:43:58 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4237,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4250,14 +4053,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b167607e-3aaf-4f14-8da8-020541deabe4
+      - req-c7fbb0c5-5c25-48ec-8605-99240341b1af
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4272,7 +4075,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4285,15 +4088,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-9f210055-e0db-460f-97e2-a814b2bd33f5
+      - req-6302f3d1-efb4-4d50-90a9-3e81a55df33b
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4308,7 +4111,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4321,14 +4124,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-95384c03-30bf-47d5-9097-1b6581217235
+      - req-0ac8f660-6a04-4fbb-971f-15cd05c282df
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4343,7 +4146,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4356,14 +4159,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2a59c891-0208-433f-9110-aa3633420283
+      - req-d3bc389a-dcc9-4a9a-8351-1fa7fadef0d7
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4378,7 +4181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4391,14 +4194,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-164b7bfe-c086-4b19-afb3-09deb4baef52
+      - req-d8daec8d-050b-47d7-8840-027e956cad88
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4416,13 +4219,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
+      - Thu, 25 Oct 2018 18:21:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4df44271-5989-4bab-b713-4c5b2e44bba6
+      - req-c092d697-e55c-4ec0-9794-67c2073b8eee
       Content-Length:
       - '4170'
       Connection:
@@ -4431,10 +4234,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:59.855226", "expires":
-        "2018-09-26T19:43:59Z", "id": "28bc9da66ec349b1ad76f39ccc80d0ab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:58.011134", "expires":
+        "2018-10-25T19:21:57Z", "id": "f8677356e2c841f7b63dd744739ade07", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qxqRL8bvSUWOLGXh0gbyBA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["RL30h1R9QZKKtvr-4-acqg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4479,88 +4282,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:59 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"28bc9da66ec349b1ad76f39ccc80d0ab"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:59 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-698d99a4-8305-40d3-8b38-c81f007e0db9
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:00.034974", "expires":
-        "2018-09-26T19:43:59Z", "id": "9271fd227bfb4131b837b1b88badb8a2", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hYziCRVHTlakQG22T7WDZA", "qxqRL8bvSUWOLGXh0gbyBA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4578,13 +4300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5994a039-a3a2-4fca-85ca-0d71cdad08b0
+      - req-10f43867-ee3d-4b6e-a5b1-5e547958e0ac
       Content-Length:
       - '4170'
       Connection:
@@ -4593,10 +4315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:00.227629", "expires":
-        "2018-09-26T19:44:00Z", "id": "ba06a283164545e9b197fe786d5e3147", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:58.197491", "expires":
+        "2018-10-25T19:21:58Z", "id": "6e4ffc50fc43453b9b1f7a8b07673823", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3T3igRaRSfu4tn7nn6GZLA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_HTFxLreT9G-kvoU6EQbwg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4641,88 +4363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"ba06a283164545e9b197fe786d5e3147"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-62fd1d64-8dc6-4490-af77-c88091fc7da1
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:00.405851", "expires":
-        "2018-09-26T19:44:00Z", "id": "b3470342cd8a4ad5b51c05fad26d408a", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["72NB_mfZSvmnup-lY1vqrw", "3T3igRaRSfu4tn7nn6GZLA"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -4737,7 +4378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca5276d099c7481f9a75c83d7f2b5b0c
+      - 374009d19f954a2d8b1de1a56b39e97d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4750,14 +4391,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-ea36ac8e-fef1-4a16-8311-2af301177aba
+      - req-d181cecf-0117-47e6-be6c-1b2303c9e145
       Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -4772,22 +4413,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-605d3d87-78a8-4d60-bc7f-73efd160cca2
+      - req-ab8ab383-4b56-4978-98b4-98ae2e243417
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-605d3d87-78a8-4d60-bc7f-73efd160cca2
+      - req-ab8ab383-4b56-4978-98b4-98ae2e243417
       Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4820,7 +4461,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4835,22 +4476,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3e980a11-1e65-48ca-8333-4fd77148032f
+      - req-de132cb3-998b-4ec3-8ff3-c03fbadaac55
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-3e980a11-1e65-48ca-8333-4fd77148032f
+      - req-de132cb3-998b-4ec3-8ff3-c03fbadaac55
       Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4867,7 +4508,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -4882,27 +4523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d6d28c0-1355-40ec-a8d8-7ce58495804a
+      - req-0d6e9b4c-843e-4ec0-b975-d800d98c9f8e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9d6d28c0-1355-40ec-a8d8-7ce58495804a
+      - req-0d6e9b4c-843e-4ec0-b975-d800d98c9f8e
       Date:
-      - Wed, 26 Sep 2018 18:44:00 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -4917,22 +4558,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-338f2bd4-d269-4384-bce3-f2cb61c4bb19
+      - req-903acaf8-8fb1-4bff-bba2-d4dfc2613e54
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-338f2bd4-d269-4384-bce3-f2cb61c4bb19
+      - req-903acaf8-8fb1-4bff-bba2-d4dfc2613e54
       Date:
-      - Wed, 26 Sep 2018 18:44:01 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4947,7 +4588,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -4962,22 +4603,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e662bc1-62e9-4091-a549-e904adb45b32
+      - req-91037f16-490d-4a26-97d0-39a528775565
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-8e662bc1-62e9-4091-a549-e904adb45b32
+      - req-91037f16-490d-4a26-97d0-39a528775565
       Date:
-      - Wed, 26 Sep 2018 18:44:01 GMT
+      - Thu, 25 Oct 2018 18:21:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5010,7 +4651,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5025,22 +4666,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e1a0f7d-837c-4421-997f-5e5599700dba
+      - req-8d61a941-0f13-47e4-9c93-32ec9da557f5
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-5e1a0f7d-837c-4421-997f-5e5599700dba
+      - req-8d61a941-0f13-47e4-9c93-32ec9da557f5
       Date:
-      - Wed, 26 Sep 2018 18:44:01 GMT
+      - Thu, 25 Oct 2018 18:21:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5081,7 +4722,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5096,22 +4737,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1db2dd5c-6e0c-462b-bad0-bdb8cbfceef5
+      - req-d1ca28b1-ac96-4b8d-bab8-72c0284948a4
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-1db2dd5c-6e0c-462b-bad0-bdb8cbfceef5
+      - req-d1ca28b1-ac96-4b8d-bab8-72c0284948a4
       Date:
-      - Wed, 26 Sep 2018 18:44:01 GMT
+      - Thu, 25 Oct 2018 18:21:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5145,7 +4786,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5160,27 +4801,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89a2da6b534849feb6fb5b8f1109b0f7
+      - 31a100b4e77e4d8cbda2b3abf0a3d069
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5725f27-aaae-4914-8fc1-4d3ef56de4a8
+      - req-f4e5f39c-69a6-4878-b7a7-3b80f0c94606
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b5725f27-aaae-4914-8fc1-4d3ef56de4a8
+      - req-f4e5f39c-69a6-4878-b7a7-3b80f0c94606
       Date:
-      - Wed, 26 Sep 2018 18:44:01 GMT
+      - Thu, 25 Oct 2018 18:21:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5198,13 +4839,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:02 GMT
+      - Thu, 25 Oct 2018 18:22:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94c95fcd-9a45-4001-a9e0-d16886500eaf
+      - req-b1ffd685-d9a5-4ce3-af6c-5ec99d3f59ec
       Content-Length:
       - '4170'
       Connection:
@@ -5213,10 +4854,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:02.619915", "expires":
-        "2018-09-26T19:44:02Z", "id": "9308fbf5c75d49cb8cf4de8b9e1132cd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:00.718380", "expires":
+        "2018-10-25T19:22:00Z", "id": "d559d641642e4f8988f3db4e402863b6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["caOW9kyQShGDKTjzA9gPyQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tFbQ8UgDSFqw6bnEj2lERA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5261,7 +4902,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5279,13 +4920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:02 GMT
+      - Thu, 25 Oct 2018 18:22:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55d3f8ba-9a12-465a-9d0e-0b6d990e8344
+      - req-7dd8fe7f-7a16-4507-98a7-f9c8969cf872
       Content-Length:
       - '4170'
       Connection:
@@ -5294,10 +4935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:02.802610", "expires":
-        "2018-09-26T19:44:02Z", "id": "2dac420623764d2bb5b12e4e4f5e4abb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:00.899293", "expires":
+        "2018-10-25T19:22:00Z", "id": "0ed9a3aba33d4553aadce38156cee447", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["RpjOJX8PSiSzzKuTOeX3QQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["1UDaVH11RXeBjZGB3i0zDQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5342,7 +4983,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5357,7 +4998,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -5368,12 +5009,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-9e56516b-bee6-4e35-aed6-98c1d29d5440
+      - req-67cdca60-31a4-4abf-b12e-49d3b8d5a8a7
       Date:
-      - Wed, 26 Sep 2018 18:44:02 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -5428,11 +5074,6 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5440,7 +5081,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5458,13 +5099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ef16bd9-33e0-4d60-95a7-3f8947272919
+      - req-f94dee84-666b-4c7e-a478-c21c2040cc8b
       Content-Length:
       - '4170'
       Connection:
@@ -5473,10 +5114,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:03.152470", "expires":
-        "2018-09-26T19:44:03Z", "id": "3cb033d64daf49ef8fc8842c66347afd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.282157", "expires":
+        "2018-10-25T19:22:01Z", "id": "b83f3bae09974b8f90f0cc72e80c1564", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2K5qOHrITI69pM5WvGzg6g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["D3QV6ti1QhW64b4ze1lwaA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5521,13 +5162,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5539,13 +5180,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8933d1ee-2d36-4409-8258-973ecac5474a
+      - req-720a6e07-cb22-4bb3-a7eb-9a929a2c0780
       Content-Length:
       - '370'
       Connection:
@@ -5554,13 +5195,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:03.302042", "expires":
-        "2018-09-26T19:44:03Z", "id": "f7f653189d924d52a89d613dc49215f0", "audit_ids":
-        ["f7_p9nYTSbeLcyOuVf-E_Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.434234", "expires":
+        "2018-10-25T19:22:01Z", "id": "f9badf0a407d48cf8c9070512b828210", "audit_ids":
+        ["UOW9-_k8SLKi0TCAE79aOg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5575,20 +5216,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7f653189d924d52a89d613dc49215f0
+      - f9badf0a407d48cf8c9070512b828210
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9bd37472-37e6-4de9-90bd-5d409c38d90d
+      - req-2d7a5bdb-d63e-4448-8cf6-ecf982b55366
       Content-Length:
       - '500'
       Connection:
@@ -5605,133 +5246,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"f7f653189d924d52a89d613dc49215f0"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-05de339a-edeb-42af-a938-e9715b08df36
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:03.641965", "expires":
-        "2018-09-26T19:44:03Z", "id": "ce49c39722ba4ac3ab31eecf1582dc66", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vONNUVJzQ3Ob_8bIdQ7Yvg",
-        "f7_p9nYTSbeLcyOuVf-E_Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f7f653189d924d52a89d613dc49215f0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-5c15429a-feba-476c-b587-c4cfbf8fb98f
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5749,13 +5264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:03 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-98e2c17f-34c8-46a6-8957-77a30211fb99
+      - req-fbd1edfa-0423-40e3-9f5b-448d9e3e6aad
       Content-Length:
       - '4117'
       Connection:
@@ -5764,10 +5279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:03.943764", "expires":
-        "2018-09-26T19:44:03Z", "id": "253d4bf3925043e7a5641f3b920a6c1b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.744661", "expires":
+        "2018-10-25T19:22:01Z", "id": "e3788a94e2a04eebb664ec878aee2ace", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["48JhniezQVelgnX9oT9GSg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JjNIOd4dS6iDlcz8it9ckA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5811,7 +5326,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5829,13 +5344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c1ede185-9806-4b4f-9a15-a6eef6c1750a
+      - req-d636c0c6-952a-4f08-a089-b4d41c827b3c
       Content-Length:
       - '4131'
       Connection:
@@ -5844,10 +5359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:04.117204", "expires":
-        "2018-09-26T19:44:04Z", "id": "5686ce3d892646fc9f66742c2d02f6a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:01.924033", "expires":
+        "2018-10-25T19:22:01Z", "id": "124a11c2cd124da1b3a7dcbff1b9f381", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PFt0wsb6RtC2ty9Dido1HQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gL4ksq-zQrCq8rwF-N8u8Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -5891,7 +5406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5909,13 +5424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6e2df1b0-c236-4d5a-8186-fa3b0b18ecf4
+      - req-24dde1d1-b2c2-4ccc-b0e3-d01cd9bdbfc0
       Content-Length:
       - '4118'
       Connection:
@@ -5924,10 +5439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:04.294295", "expires":
-        "2018-09-26T19:44:04Z", "id": "02519f4830e54c63a6c05240555ef62b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.109178", "expires":
+        "2018-10-25T19:22:02Z", "id": "52a09656b9554b45a5826254ba9023ec", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xJTcovbIQ9K1YL1P0VnaNg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lUUs-t6OSxGt3VTSBVmk4w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5971,7 +5486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5989,13 +5504,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13f26bf2-8a5b-41b6-9785-d08b04611cbf
+      - req-16a97239-57e9-4ea6-b615-eb05fdbc08f9
       Content-Length:
       - '4117'
       Connection:
@@ -6004,10 +5519,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:04.461005", "expires":
-        "2018-09-26T19:44:04Z", "id": "4c737e3753a0445ab5fba3a6cd8022f5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.298073", "expires":
+        "2018-10-25T19:22:02Z", "id": "81b1f5a3cfff42f5a4749d06bc72f482", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JEBHjIIlRDWtJIYNY7L-KA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XJZ7q5gPQFKcG0pMJ86pyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6051,7 +5566,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6066,7 +5581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6077,9 +5592,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-3f6fb996-8b0c-4088-9620-b2aa62364985
+      - req-249f6ce9-3630-489d-9a8a-7d1c3f1fca6a
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6113,7 +5628,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6128,7 +5643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6139,14 +5654,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1c741c99-fa91-4467-8d3d-0ff3b448dcd4
+      - req-800c83e7-2e29-4373-9c50-f42b5e9e6ac5
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6164,13 +5679,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:04 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ff3376ed-baae-409f-8a5b-aac07bab8581
+      - req-10fb2987-7932-44e6-88c2-776a30f8733d
       Content-Length:
       - '4131'
       Connection:
@@ -6179,10 +5694,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:04.920911", "expires":
-        "2018-09-26T19:44:04Z", "id": "2e0985882d2648c98fd17f254eb57a36", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:02.773419", "expires":
+        "2018-10-25T19:22:02Z", "id": "b9de25f845374d529bdef4d07eb7c9df", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["a6_Blv7WTxKpWuTQjyNCvw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DNglwAA3Q0C0zmPMNTXinw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6226,7 +5741,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6241,7 +5756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e0985882d2648c98fd17f254eb57a36
+      - b9de25f845374d529bdef4d07eb7c9df
   response:
     status:
       code: 200
@@ -6252,14 +5767,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d3b08f06-9857-4996-a54e-2bf661405e06
+      - req-ff2b95de-c186-4187-83c2-85ef826ae27f
       Date:
-      - Wed, 26 Sep 2018 18:44:05 GMT
+      - Thu, 25 Oct 2018 18:22:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6274,7 +5789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3cb033d64daf49ef8fc8842c66347afd
+      - b83f3bae09974b8f90f0cc72e80c1564
   response:
     status:
       code: 200
@@ -6285,14 +5800,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-17c39268-0592-4258-b6f2-db49a1630cd9
+      - req-f79053b3-0e8c-4efb-8b72-46895ac5fb6d
       Date:
-      - Wed, 26 Sep 2018 18:44:05 GMT
+      - Thu, 25 Oct 2018 18:22:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6310,13 +5825,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:05 GMT
+      - Thu, 25 Oct 2018 18:22:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d0f0751-cbc0-421c-b9b8-a056d732d5e7
+      - req-71894746-14e4-44ce-8ba4-1491a3add4c6
       Content-Length:
       - '4118'
       Connection:
@@ -6325,10 +5840,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:05.409541", "expires":
-        "2018-09-26T19:44:05Z", "id": "a8083e596e4e4da18d4a8accfb33af93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:03.275358", "expires":
+        "2018-10-25T19:22:03Z", "id": "2e64cc4f9ecf4685bb47a090231bed61", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["UxxJTPxkRWKDJ2NrCmyocw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vPg1hqWsTsaUWVyIPlVAAg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6372,7 +5887,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6387,7 +5902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a8083e596e4e4da18d4a8accfb33af93
+      - 2e64cc4f9ecf4685bb47a090231bed61
   response:
     status:
       code: 200
@@ -6398,14 +5913,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1ae87b8f-bbce-4ee3-b7c8-fab4a02c279e
+      - req-d6b4d709-ddef-48ba-a736-66ccc6970841
       Date:
-      - Wed, 26 Sep 2018 18:44:05 GMT
+      - Thu, 25 Oct 2018 18:22:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6420,7 +5935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6431,9 +5946,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-03358288-5d52-418d-b3f6-f7ca4b0ad8d4
+      - req-17d9643d-8feb-4b67-85c7-fcaccc93cb72
       Date:
-      - Wed, 26 Sep 2018 18:44:05 GMT
+      - Thu, 25 Oct 2018 18:22:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6460,7 +5975,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6475,7 +5990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6486,9 +6001,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2ad91912-ce2e-4a89-af51-33f2f0ac8efe
+      - req-7f593e43-1764-43d4-b497-c7b0d0d3091e
       Date:
-      - Wed, 26 Sep 2018 18:44:06 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6515,7 +6030,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6530,7 +6045,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6541,9 +6056,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bead15d8-2993-4cbe-b9d6-6479dc71d7eb
+      - req-f0ac3f75-19cd-4646-872f-4a94734ffaa9
       Date:
-      - Wed, 26 Sep 2018 18:44:06 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6570,7 +6085,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -6585,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6596,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e82889ff-2a2a-4db6-9b59-37764524bae0
+      - req-25f38973-5c85-4146-aa98-aa3d2bd0bdef
       Date:
-      - Wed, 26 Sep 2018 18:44:06 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6610,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -6625,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6636,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-54af7d7e-494c-4f0b-97e7-9d523a217e2a
+      - req-1c4d44c2-ad37-43d7-b64d-1d1b84bcf0b2
       Date:
-      - Wed, 26 Sep 2018 18:44:06 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6650,7 +6165,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -6665,7 +6180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c737e3753a0445ab5fba3a6cd8022f5
+      - 81b1f5a3cfff42f5a4749d06bc72f482
   response:
     status:
       code: 200
@@ -6676,9 +6191,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-8d70ba8a-6552-4775-a916-fce4bdcf74e0
+      - req-fefc64f6-94b1-4c37-ba4a-9ebcf1d4ee69
       Date:
-      - Wed, 26 Sep 2018 18:44:06 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6690,7 +6205,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -6705,7 +6220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -6716,12 +6231,42 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5de1eae6-f6c2-4929-912d-0dc893b53d8e
+      - req-0362e04f-8dc0-4a82-bbc6-e2d022b2c943
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -6768,12 +6313,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
@@ -6785,30 +6324,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6822,7 +6337,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6837,7 +6352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -6848,27 +6363,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-16a7751d-842a-4348-b3be-f784010268d0
+      - req-63255bd1-10a5-4502-9099-b37ceac62c71
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -6917,30 +6450,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6954,7 +6469,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6969,7 +6484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -6980,9 +6495,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-32aadb7e-0d01-4dc7-917e-141121dd1c3b
+      - req-5bee0512-2a36-4e06-8957-061a8bcb2bda
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7024,7 +6539,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -7039,7 +6554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -7050,9 +6565,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bf6266c5-324b-4f9b-bec4-0dbbfd27d4a3
+      - req-56d08ec3-2ef8-4996-be21-361bebc2262d
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7094,7 +6609,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -7109,7 +6624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -7120,9 +6635,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8836c780-415b-4bc8-8741-e24faf8619ca
+      - req-3d4a343f-b83a-4981-8508-a70a20f8681d
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7525,7 +7040,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -7540,7 +7055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -7551,9 +7066,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-736eb760-3295-458f-8db1-de468ee2cf26
+      - req-4a8b4f1f-8e9c-4351-8783-7c4b7cd93716
       Date:
-      - Wed, 26 Sep 2018 18:44:07 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7956,7 +7471,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -7971,7 +7486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -7982,9 +7497,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d69e40f3-ba23-402d-b20b-47afe41fbb51
+      - req-59026bbf-e484-4e65-9e47-639f77aa4434
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8016,7 +7531,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -8031,7 +7546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -8042,9 +7557,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-c1bce86a-9d04-49fc-a1a1-81873f5b291e
+      - req-f53f3109-5335-4f10-bd9e-d0bfd79606b1
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8076,7 +7591,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -8091,7 +7606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -8102,9 +7617,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-73ad0b46-b3eb-48c6-b241-cc8e989ed4e9
+      - req-d4f04f23-66e7-4fc2-967a-65125715209c
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -8146,7 +7661,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -8161,7 +7676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -8172,9 +7687,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-6273dc4f-db71-463d-b0d4-a5643fd1e3e8
+      - req-515b5c35-5905-4e73-b110-552abafde889
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -8217,7 +7732,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -8232,7 +7747,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -8243,9 +7758,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-df9ea137-d868-40bc-ab28-27e56aae73fb
+      - req-bae36b1a-3d99-4e11-91b2-5abe3c0f2eb5
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -8280,7 +7795,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -8295,7 +7810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dac420623764d2bb5b12e4e4f5e4abb
+      - 0ed9a3aba33d4553aadce38156cee447
   response:
     status:
       code: 200
@@ -8306,9 +7821,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-585d2ec8-4d83-489f-ba89-b018f2dff555
+      - req-52cd4bd3-2877-4e01-b2fd-8963c07c9761
       Date:
-      - Wed, 26 Sep 2018 18:44:08 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -8395,7 +7910,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8413,13 +7928,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:09 GMT
+      - Thu, 25 Oct 2018 18:22:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-05ef874a-52c4-4d17-92be-c5cfcb0028df
+      - req-f582f747-768d-4d3f-9081-3adf9f15ff8a
       Content-Length:
       - '4170'
       Connection:
@@ -8428,10 +7943,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:09.239063", "expires":
-        "2018-09-26T19:44:09Z", "id": "3dc0d1d7c66a40988eb3467146261c42", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.009338", "expires":
+        "2018-10-25T19:22:06Z", "id": "f30099fa62aa49cb9b12ebf81c346667", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["OwPWcIwEQrm9G6-Xi8kkxg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Dpggue_YRpyrRONNKJSp5w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8476,7 +7991,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8494,13 +8009,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:09 GMT
+      - Thu, 25 Oct 2018 18:22:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb612d0a-cd69-42f6-b7fa-c4714610750b
+      - req-37571635-6ee0-4cc6-ab9c-4c43c3a1ac91
       Content-Length:
       - '4170'
       Connection:
@@ -8509,10 +8024,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:09.435598", "expires":
-        "2018-09-26T19:44:09Z", "id": "b104c609e1984e219b24c8c3e5b922da", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.217316", "expires":
+        "2018-10-25T19:22:07Z", "id": "35f284e8281d419c910a0b906151c422", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Zezf3nhCTi6s67Q5amjUpQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["QFoWV-YoR8enQeMNgJixhA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8557,13 +8072,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8575,13 +8090,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:09 GMT
+      - Thu, 25 Oct 2018 18:22:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aba569f8-0de5-4cdc-bff1-a3ef61ef76d6
+      - req-e3934b4f-40c1-4fbd-ad83-08174e07b418
       Content-Length:
       - '370'
       Connection:
@@ -8590,13 +8105,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:09.605473", "expires":
-        "2018-09-26T19:44:09Z", "id": "20ef0a44ac3a49c0ad5f8ea9ef1a23b7", "audit_ids":
-        ["Z6Ob6yhjTIuzFhTrRzAuFA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.387029", "expires":
+        "2018-10-25T19:22:07Z", "id": "87b9b1dafd184049b1421a449a7ee269", "audit_ids":
+        ["C6KS9Eh_TkSshX1Zof7Rdw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8611,20 +8126,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 20ef0a44ac3a49c0ad5f8ea9ef1a23b7
+      - 87b9b1dafd184049b1421a449a7ee269
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:09 GMT
+      - Thu, 25 Oct 2018 18:22:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e687e1a-4dce-48bf-9347-cb2dd73e8213
+      - req-a56795eb-61ac-4f9b-aecf-188f0289d7ee
       Content-Length:
       - '500'
       Connection:
@@ -8641,133 +8156,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:09 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"20ef0a44ac3a49c0ad5f8ea9ef1a23b7"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:09 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-5686d750-d5c0-4d44-b807-2c9bfad8075a
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:09.925317", "expires":
-        "2018-09-26T19:44:09Z", "id": "a1d5b02ed00a46c18a2bca0dc9eff798", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3HaKTDupTfSdotBJ2-GzIw",
-        "Z6Ob6yhjTIuzFhTrRzAuFA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:09 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 20ef0a44ac3a49c0ad5f8ea9ef1a23b7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-58dcbffd-2a7a-40a8-8d1f-29eaef8034a9
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8785,13 +8174,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
+      - Thu, 25 Oct 2018 18:22:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-014c6357-fff9-4381-a19f-9e10a187b08e
+      - req-58c46a28-7ce0-4572-8a09-9f852d3953ed
       Content-Length:
       - '4117'
       Connection:
@@ -8800,10 +8189,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:10.258065", "expires":
-        "2018-09-26T19:44:10Z", "id": "df5c9a2294e540588d2983e73ed07623", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.709394", "expires":
+        "2018-10-25T19:22:07Z", "id": "fa9ccd306ef24c8aa4d72c12d3d1a4b9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["64TLDDTDTiCCaFeO_nCWMw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xeoI1BScTIu52ToKqJevfQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8847,7 +8236,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8865,13 +8254,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
+      - Thu, 25 Oct 2018 18:22:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f531660d-d2ca-42b7-b064-af61c38560e9
+      - req-91ee1fab-f925-43ac-a1cf-66e695177ddd
       Content-Length:
       - '4131'
       Connection:
@@ -8880,10 +8269,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:10.442053", "expires":
-        "2018-09-26T19:44:10Z", "id": "d88241cf759b4518a7608f8c47396b95", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:07.894804", "expires":
+        "2018-10-25T19:22:07Z", "id": "9c3bae55f68a4731a0b4e1e47aa36a2b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nv-DBDwpTLeVYp_qrM6UTA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nvpbF0OKQhG5BNbv3pSpuQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8927,7 +8316,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8945,13 +8334,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fced6e17-9dd6-4a65-b06c-3fd83b32b80c
+      - req-ee06f0a1-8f7d-4f72-95f9-23c12f08980d
       Content-Length:
       - '4118'
       Connection:
@@ -8960,10 +8349,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:10.619878", "expires":
-        "2018-09-26T19:44:10Z", "id": "82274d26d81e44e1aa313ca2f103b81c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:08.081710", "expires":
+        "2018-10-25T19:22:08Z", "id": "4dcb5a3ba50144d58cba3e3aa2b5e25c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5r-yOsP-QASYVGxxsZQJiQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wtBdHaMKR8OedWxK14GwxA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9007,7 +8396,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9025,13 +8414,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-82fe9c7c-10d7-4c64-b522-03b78b79c16e
+      - req-ec0fa6d9-af75-442a-8d56-927436be1796
       Content-Length:
       - '4117'
       Connection:
@@ -9040,10 +8429,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:10.797236", "expires":
-        "2018-09-26T19:44:10Z", "id": "eef075e5b9504e21816ba75ba0e47d74", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:08.259661", "expires":
+        "2018-10-25T19:22:08Z", "id": "23637d656704468c944d32fa43493eff", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hKN4KDo-QNWS14cpd64UsA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hh-29SVSTBOJvxWL1qbyKQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9087,7 +8476,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -9102,22 +8491,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b199ada-f05d-4311-b8a2-8bdbd24e5fd2
+      - req-86913854-c856-42c7-bd13-2d62101844b7
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-5b199ada-f05d-4311-b8a2-8bdbd24e5fd2
+      - req-86913854-c856-42c7-bd13-2d62101844b7
       Date:
-      - Wed, 26 Sep 2018 18:44:10 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -9150,7 +8539,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -9165,22 +8554,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-570ab2c9-60d6-4cea-879d-df68f161f3b9
+      - req-2ddc233a-376d-4d2e-9fe8-8498e0535d7d
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-570ab2c9-60d6-4cea-879d-df68f161f3b9
+      - req-2ddc233a-376d-4d2e-9fe8-8498e0535d7d
       Date:
-      - Wed, 26 Sep 2018 18:44:11 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -9221,7 +8610,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -9236,22 +8625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-83a3a71b-3490-4aec-a31e-dcf2b5f43ad4
+      - req-d9c42910-f0ef-40b6-b6a1-86a054a3d5a8
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-83a3a71b-3490-4aec-a31e-dcf2b5f43ad4
+      - req-d9c42910-f0ef-40b6-b6a1-86a054a3d5a8
       Date:
-      - Wed, 26 Sep 2018 18:44:11 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -9285,7 +8674,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -9300,27 +8689,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8525c106-4d0c-4ee7-9329-41649e777d71
+      - req-89a9cefe-464d-447c-b757-577d88c924db
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8525c106-4d0c-4ee7-9329-41649e777d71
+      - req-89a9cefe-464d-447c-b757-577d88c924db
       Date:
-      - Wed, 26 Sep 2018 18:44:11 GMT
+      - Thu, 25 Oct 2018 18:22:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9338,13 +8727,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:11 GMT
+      - Thu, 25 Oct 2018 18:22:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4dee03ba-c6a9-46be-b171-6a21a1752448
+      - req-87115fe0-4973-4c6e-8207-11abd0351cf4
       Content-Length:
       - '4131'
       Connection:
@@ -9353,10 +8742,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:11.727337", "expires":
-        "2018-09-26T19:44:11Z", "id": "8d8dee8324be407ca5ce683a076d78c8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:09.179745", "expires":
+        "2018-10-25T19:22:09Z", "id": "2ed768347bb44056ac46df60ea4f81a3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TC-VJe8ASMKcVgDfTQenFQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["42_UhXEERYGjaRcCti_JIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9400,7 +8789,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -9415,27 +8804,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-041aecc3-035b-4244-8e5d-5dbfc2f44d87
+      - req-7ce37cf1-25f8-4c52-b984-1eeca6bbfb96
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-041aecc3-035b-4244-8e5d-5dbfc2f44d87
+      - req-7ce37cf1-25f8-4c52-b984-1eeca6bbfb96
       Date:
-      - Wed, 26 Sep 2018 18:44:11 GMT
+      - Thu, 25 Oct 2018 18:22:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -9450,27 +8839,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3cf21aae-f049-43ec-83db-be6371436e3d
+      - req-987a3694-8637-4d9b-ada0-2ae7ca4d9e12
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3cf21aae-f049-43ec-83db-be6371436e3d
+      - req-987a3694-8637-4d9b-ada0-2ae7ca4d9e12
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9488,13 +8877,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e4b5c9c4-e9ab-4640-94cc-14271cc9adb4
+      - req-9930afc3-b6c2-4c03-847c-925650064613
       Content-Length:
       - '4118'
       Connection:
@@ -9503,10 +8892,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:12.254929", "expires":
-        "2018-09-26T19:44:12Z", "id": "cfd381ed22914cb188ef6706ceed84cf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:09.765883", "expires":
+        "2018-10-25T19:22:09Z", "id": "0dee90b269d8407ea43e476ffa743ba7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LXsbDAZTREaV2NSvI5OT_A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6fv-MTphSlmYr3qLBCMHnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9550,7 +8939,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -9565,27 +8954,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c08668c-5e09-4d70-9a53-eb74696d65eb
+      - req-eaa29a80-b09f-4c7a-8e91-ed974fa96c97
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6c08668c-5e09-4d70-9a53-eb74696d65eb
+      - req-eaa29a80-b09f-4c7a-8e91-ed974fa96c97
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -9600,22 +8989,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41429b18-b4fa-411d-b44b-62bfebe9518a
+      - req-7b5fbc9f-0203-4810-b048-f9fb533d7351
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-41429b18-b4fa-411d-b44b-62bfebe9518a
+      - req-7b5fbc9f-0203-4810-b048-f9fb533d7351
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9630,7 +9019,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -9645,22 +9034,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1c782be-d74b-495d-95ce-d05e5c1001b5
+      - req-69f0d76f-cad6-426a-9421-f863470c032f
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-e1c782be-d74b-495d-95ce-d05e5c1001b5
+      - req-69f0d76f-cad6-426a-9421-f863470c032f
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9675,7 +9064,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -9690,27 +9079,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6176d1b6-52be-426f-b0b2-1d99cc3cd509
+      - req-51b3a511-d052-43d4-b300-9e5b597182ea
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6176d1b6-52be-426f-b0b2-1d99cc3cd509
+      - req-51b3a511-d052-43d4-b300-9e5b597182ea
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -9725,27 +9114,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2dc1451b-ac09-4e32-9638-13e5c105a976
+      - req-0a4e84de-2041-4498-be1f-06d02e0812be
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2dc1451b-ac09-4e32-9638-13e5c105a976
+      - req-0a4e84de-2041-4498-be1f-06d02e0812be
       Date:
-      - Wed, 26 Sep 2018 18:44:12 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -9760,27 +9149,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6292808f-3f87-4611-b974-4f6ef6f64514
+      - req-21eacd81-9d09-4c19-8454-f1657e3609c9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6292808f-3f87-4611-b974-4f6ef6f64514
+      - req-21eacd81-9d09-4c19-8454-f1657e3609c9
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -9795,27 +9184,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c4b19fa-f817-436a-a2a5-af9fa3612ab7
+      - req-d66e5e9b-9eda-4a87-9f6d-ff33c9f23fad
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6c4b19fa-f817-436a-a2a5-af9fa3612ab7
+      - req-d66e5e9b-9eda-4a87-9f6d-ff33c9f23fad
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -9830,27 +9219,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-caa9b181-30bf-4138-8356-3ae1225a4914
+      - req-1e4b9a35-e5f1-403a-8736-46bfd968c6fb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-caa9b181-30bf-4138-8356-3ae1225a4914
+      - req-1e4b9a35-e5f1-403a-8736-46bfd968c6fb
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -9865,27 +9254,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46a45a02-3758-491a-a6d9-1317f8a69c2e
+      - req-7940cbb3-6273-4122-bdc5-ad16acb73634
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-46a45a02-3758-491a-a6d9-1317f8a69c2e
+      - req-7940cbb3-6273-4122-bdc5-ad16acb73634
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -9900,27 +9289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b9aae21-99e6-48d4-8d1b-86893dacb4c3
+      - req-b318ea63-3d5f-491e-98f6-76cf50f39ae5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9b9aae21-99e6-48d4-8d1b-86893dacb4c3
+      - req-b318ea63-3d5f-491e-98f6-76cf50f39ae5
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -9935,27 +9324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-44bc8994-0391-447d-93a0-94e2c134b639
+      - req-6ddfc89d-b919-4734-a87e-224e30d2c580
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-44bc8994-0391-447d-93a0-94e2c134b639
+      - req-6ddfc89d-b919-4734-a87e-224e30d2c580
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -9970,27 +9359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b1035cb7-9dee-436f-b3f6-dda4eefff4f2
+      - req-9b067222-6da9-44da-89da-0bb3b24a5fe7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b1035cb7-9dee-436f-b3f6-dda4eefff4f2
+      - req-9b067222-6da9-44da-89da-0bb3b24a5fe7
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -10005,27 +9394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a64ceff0-81c3-4fe1-b73c-f53bd19f9793
+      - req-c2267da3-d585-49b7-bb7d-82543b2cdeeb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a64ceff0-81c3-4fe1-b73c-f53bd19f9793
+      - req-c2267da3-d585-49b7-bb7d-82543b2cdeeb
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -10040,27 +9429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d804240-ea64-44b0-94f9-9a21b1920d50
+      - req-442dab22-1823-4aa2-ac47-b2668354b7d5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5d804240-ea64-44b0-94f9-9a21b1920d50
+      - req-442dab22-1823-4aa2-ac47-b2668354b7d5
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -10075,27 +9464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c08c9c42-741d-4fe1-b7a2-119c1f2c94a6
+      - req-39c8921a-9eb8-4bc2-b2db-44688e783238
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c08c9c42-741d-4fe1-b7a2-119c1f2c94a6
+      - req-39c8921a-9eb8-4bc2-b2db-44688e783238
       Date:
-      - Wed, 26 Sep 2018 18:44:13 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -10110,27 +9499,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8af416ad-af3c-414f-92c2-53c0385ca986
+      - req-d73f48bf-a6f2-48d1-99de-d128b776afba
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8af416ad-af3c-414f-92c2-53c0385ca986
+      - req-d73f48bf-a6f2-48d1-99de-d128b776afba
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -10145,27 +9534,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-02a3cca9-2550-4186-9328-9a0cf9a6bf7b
+      - req-fabcd7fd-5494-47f6-938c-351be2fcb82d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-02a3cca9-2550-4186-9328-9a0cf9a6bf7b
+      - req-fabcd7fd-5494-47f6-938c-351be2fcb82d
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -10180,22 +9569,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dad8e794-9113-4804-b401-e646c93b2229
+      - req-8f0ac54c-cd66-47d4-a8b9-f4ddd52b6329
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dad8e794-9113-4804-b401-e646c93b2229
+      - req-8f0ac54c-cd66-47d4-a8b9-f4ddd52b6329
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10207,7 +9596,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10222,22 +9611,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eef075e5b9504e21816ba75ba0e47d74
+      - 23637d656704468c944d32fa43493eff
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-674edf78-98f4-448b-9d51-8b5bb6fad78c
+      - req-4a4ddc8b-83bc-489d-8102-bea0a1f7834e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-674edf78-98f4-448b-9d51-8b5bb6fad78c
+      - req-4a4ddc8b-83bc-489d-8102-bea0a1f7834e
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10249,7 +9638,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -10264,22 +9653,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b3b9326-3016-4ebc-bbf6-180556ca3418
+      - req-14287cd3-3b52-4ec9-bd40-d4e2d106f5b6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6b3b9326-3016-4ebc-bbf6-180556ca3418
+      - req-14287cd3-3b52-4ec9-bd40-d4e2d106f5b6
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10291,7 +9680,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10306,22 +9695,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d8dee8324be407ca5ce683a076d78c8
+      - 2ed768347bb44056ac46df60ea4f81a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-40b47360-fa1f-45ef-8936-bf9ff4924718
+      - req-aab4d288-7393-43c3-a84e-58c2e16d78ca
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-40b47360-fa1f-45ef-8936-bf9ff4924718
+      - req-aab4d288-7393-43c3-a84e-58c2e16d78ca
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10333,7 +9722,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -10348,22 +9737,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1171acf9-1d75-401f-8610-def65474cc80
+      - req-6ce9b4b0-2aaa-4bf1-9598-3c7e762106e7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1171acf9-1d75-401f-8610-def65474cc80
+      - req-6ce9b4b0-2aaa-4bf1-9598-3c7e762106e7
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10375,7 +9764,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10390,22 +9779,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b104c609e1984e219b24c8c3e5b922da
+      - 35f284e8281d419c910a0b906151c422
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b8978af-c832-41b7-80d9-f7db71acb150
+      - req-1bc9b7c2-1e42-4759-b2aa-d974a2acb0bf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9b8978af-c832-41b7-80d9-f7db71acb150
+      - req-1bc9b7c2-1e42-4759-b2aa-d974a2acb0bf
       Date:
-      - Wed, 26 Sep 2018 18:44:14 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10417,7 +9806,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -10432,22 +9821,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d820acbb-89ac-4263-96cd-ae26c43b5e8e
+      - req-97f76c03-ae63-4c4b-a0a5-4f496ffd69a5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d820acbb-89ac-4263-96cd-ae26c43b5e8e
+      - req-97f76c03-ae63-4c4b-a0a5-4f496ffd69a5
       Date:
-      - Wed, 26 Sep 2018 18:44:15 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10459,7 +9848,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10474,22 +9863,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd381ed22914cb188ef6706ceed84cf
+      - 0dee90b269d8407ea43e476ffa743ba7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c22e825-e70f-4071-b50a-2a6e5dfde5e0
+      - req-24294153-a198-4bf0-91ef-4d6968da6a52
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6c22e825-e70f-4071-b50a-2a6e5dfde5e0
+      - req-24294153-a198-4bf0-91ef-4d6968da6a52
       Date:
-      - Wed, 26 Sep 2018 18:44:15 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10501,7 +9890,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10519,13 +9908,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1dc39074-39dc-4edc-b059-bb8b3d8f8de9
+      - req-8ed958f4-7a6c-427f-a8bb-076f4446b9ac
       Content-Length:
       - '4170'
       Connection:
@@ -10534,10 +9923,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:16.201614", "expires":
-        "2018-09-26T19:44:16Z", "id": "80d54ba14c1d415ca063bb08c8083955", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:12.668619", "expires":
+        "2018-10-25T19:22:12Z", "id": "3b337a386624429480fa22fb488ff4e2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WZD5fAn3QaKzbIaAeD5NRA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["b2RD-MhzQViKO-ZKL_DRCA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10582,7 +9971,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10600,13 +9989,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f9ff744-1dd4-4691-bfe4-2ac2ce470906
+      - req-98562f05-d0ed-43a9-9f80-e645d37d85ec
       Content-Length:
       - '4170'
       Connection:
@@ -10615,10 +10004,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:16.394758", "expires":
-        "2018-09-26T19:44:16Z", "id": "02ffa6c124a641c2afd6ddd5ee8ff240", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:12.861564", "expires":
+        "2018-10-25T19:22:12Z", "id": "b72e901891df431e824f6070a31fee32", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zGGhIlU9RhSDHb4oWCWmww"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["88pt2TEsRG-t0BLKNZHAYg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10663,13 +10052,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10681,13 +10070,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
+      - Thu, 25 Oct 2018 18:22:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74e32d31-85d2-44ff-9c56-2879325cc1fe
+      - req-b708573c-db87-44f6-9d98-bbe4578ad615
       Content-Length:
       - '370'
       Connection:
@@ -10696,13 +10085,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:16.548694", "expires":
-        "2018-09-26T19:44:16Z", "id": "ca066a472b9a48c4a0db95e16728a263", "audit_ids":
-        ["OsMh70LdSrK2QC-qsO5A-g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.012857", "expires":
+        "2018-10-25T19:22:13Z", "id": "1322a2c1388c4a949473f84bfce72541", "audit_ids":
+        ["jFaX7JYvRtuaBKKTBpB2kQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10717,20 +10106,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca066a472b9a48c4a0db95e16728a263
+      - 1322a2c1388c4a949473f84bfce72541
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
+      - Thu, 25 Oct 2018 18:22:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10bc2a82-bbd0-47e1-a1b5-5a56e3b92068
+      - req-91e4a8e1-43c6-46f8-9b5c-e5cfa1369488
       Content-Length:
       - '500'
       Connection:
@@ -10747,133 +10136,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:16 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"ca066a472b9a48c4a0db95e16728a263"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a0a5587f-0bc6-47d1-bcbb-01c5f68eda26
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:16.849176", "expires":
-        "2018-09-26T19:44:16Z", "id": "0d0a65afa1be46cd98d1d602e74af42f", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["P0tBoLL2ThS2ct1RD_wudw",
-        "OsMh70LdSrK2QC-qsO5A-g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:16 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ca066a472b9a48c4a0db95e16728a263
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:44:16 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-7516ac3a-c6d6-468d-92fa-b118749a1809
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10891,13 +10154,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13db2dae-d772-4c5c-b570-9d29b4aaa905
+      - req-55c251d8-7bd4-4bce-814c-5cb7c24f8811
       Content-Length:
       - '4117'
       Connection:
@@ -10906,10 +10169,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:17.165813", "expires":
-        "2018-09-26T19:44:17Z", "id": "930b62c7cd784beaaaab7ba2202067fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.338445", "expires":
+        "2018-10-25T19:22:13Z", "id": "2832df69794b40488dbddb92c2681dcf", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1yCk5o8HTImwki3dMAwvaQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fnug4PVdTcai_x8MMyLcbw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -10953,7 +10216,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10971,13 +10234,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5d67cf6-7000-4f32-bb9d-87b0b2824fae
+      - req-dff6575e-8f5d-4c07-9a55-4dd0ee904e7d
       Content-Length:
       - '4131'
       Connection:
@@ -10986,10 +10249,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:17.341458", "expires":
-        "2018-09-26T19:44:17Z", "id": "da5f466efd394e2bb3aff7a55ab733ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.525539", "expires":
+        "2018-10-25T19:22:13Z", "id": "b5a08b5f64be4606af6e1a99b3919259", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0aMK8zzARaKJ0bPHut1inQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["o8LvFS2dQqm0B1ha8pUdlg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11033,7 +10296,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11051,13 +10314,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-654cd440-9512-4a8c-9786-2c95a1ac4cfc
+      - req-97797c13-b81b-45d9-927d-98672421969e
       Content-Length:
       - '4118'
       Connection:
@@ -11066,10 +10329,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:17.520901", "expires":
-        "2018-09-26T19:44:17Z", "id": "db691e442ebc45f995587a83e9012900", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.708552", "expires":
+        "2018-10-25T19:22:13Z", "id": "67cceccfb18044cfa5e271215f5c5e4e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5c5o4eybQcytkq3RfK742g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jaBiB8pVTc-BRuemg8-92Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11113,7 +10376,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11131,13 +10394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-51632661-ff37-44f6-b4a8-db7223f107df
+      - req-e2df8675-8a35-4e81-a236-5126503ea6ff
       Content-Length:
       - '4117'
       Connection:
@@ -11146,10 +10409,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:17.708012", "expires":
-        "2018-09-26T19:44:17Z", "id": "4a91b78f48f74cc990920b42f89e93df", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:13.898245", "expires":
+        "2018-10-25T19:22:13Z", "id": "17b6bb36ac844e8485dc8e5819efe80e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["f-6QlZbvSbqocgqPT1eU1g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3xfX0F-rQXKHRlQBVvdRKA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11193,7 +10456,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -11208,7 +10471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a91b78f48f74cc990920b42f89e93df
+      - 17b6bb36ac844e8485dc8e5819efe80e
   response:
     status:
       code: 200
@@ -11237,15 +10500,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf4bba395cdd14e4b90a6c-005babd381
+      - tx5af4fb8c0c804822b14b3-005bd209d5
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -11260,7 +10523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a91b78f48f74cc990920b42f89e93df
+      - 17b6bb36ac844e8485dc8e5819efe80e
   response:
     status:
       code: 200
@@ -11289,14 +10552,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx556ba303d97443259e003-005babd381
+      - txf24ecc0ffa9f4afd9a98f-005bd209d6
       Date:
-      - Wed, 26 Sep 2018 18:44:17 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11314,13 +10577,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9b9a351-6871-42c5-b7c9-e447b1dba465
+      - req-2a413752-016e-4f23-9f59-07032ed756b6
       Content-Length:
       - '4131'
       Connection:
@@ -11329,10 +10592,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:18.165986", "expires":
-        "2018-09-26T19:44:18Z", "id": "7ba3c40b19ae4e41b8064e2c2fae47ea", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:14.346785", "expires":
+        "2018-10-25T19:22:14Z", "id": "a571880be8df4a9d84beed47162f368d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["L7pNVpxeTx2EegwcStTj5A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["42BfPQwURuCpJJZuJ_mzrw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11376,7 +10639,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -11391,7 +10654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ba3c40b19ae4e41b8064e2c2fae47ea
+      - a571880be8df4a9d84beed47162f368d
   response:
     status:
       code: 200
@@ -11404,22 +10667,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987458.32482'
+      - '1540491734.52365'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987458.32482'
+      - '1540491734.52365'
       X-Trans-Id:
-      - txc47a41c494074583afc21-005babd382
+      - tx6d20586908f84cf09f454-005bd209d6
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -11434,7 +10697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02ffa6c124a641c2afd6ddd5ee8ff240
+      - b72e901891df431e824f6070a31fee32
   response:
     status:
       code: 200
@@ -11447,22 +10710,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987458.46821'
+      - '1540491734.68964'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987458.46821'
+      - '1540491734.68964'
       X-Trans-Id:
-      - txda3840ae4d6446b0adf66-005babd382
+      - tx286af2c5b1314ee797cb9-005bd209d6
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11480,13 +10743,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b69a8ed-c66a-451f-acc3-246828e76517
+      - req-c40a5ce8-27b5-4e9e-b200-d1b6acbcfb52
       Content-Length:
       - '4118'
       Connection:
@@ -11495,10 +10758,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:44:18.652357", "expires":
-        "2018-09-26T19:44:18Z", "id": "65d0a92e20e347e1b535fce095b6295a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:22:14.872059", "expires":
+        "2018-10-25T19:22:14Z", "id": "90af07e201a44a04814897a4b987e554", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["paR83C-1TrWUg8kkFkR0ag"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dmsyVdGqQb6O6x5zehBUrQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11542,7 +10805,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -11557,7 +10820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 65d0a92e20e347e1b535fce095b6295a
+      - 90af07e201a44a04814897a4b987e554
   response:
     status:
       code: 200
@@ -11570,22 +10833,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987458.81566'
+      - '1540491735.03769'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987458.81566'
+      - '1540491735.03769'
       X-Trans-Id:
-      - tx83e48ad2421248c9a5665-005babd382
+      - tx58b90e8527e74bdab03b7-005bd209d6
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -11600,7 +10863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a91b78f48f74cc990920b42f89e93df
+      - 17b6bb36ac844e8485dc8e5819efe80e
   response:
     status:
       code: 200
@@ -11621,9 +10884,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txdff4fedce129411e94673-005babd382
+      - tx1f9b7b307521452fadc69-005bd209d7
       Date:
-      - Wed, 26 Sep 2018 18:44:18 GMT
+      - Thu, 25 Oct 2018 18:22:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -11633,7 +10896,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -11648,7 +10911,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a91b78f48f74cc990920b42f89e93df
+      - 17b6bb36ac844e8485dc8e5819efe80e
   response:
     status:
       code: 200
@@ -11669,14 +10932,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx3168b6243c124afb8ab42-005babd382
+      - tx2d7ee339a4914ec786b5a-005bd209d7
       Date:
-      - Wed, 26 Sep 2018 18:44:19 GMT
+      - Thu, 25 Oct 2018 18:22:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -11691,7 +10954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a91b78f48f74cc990920b42f89e93df
+      - 17b6bb36ac844e8485dc8e5819efe80e
   response:
     status:
       code: 200
@@ -11712,12 +10975,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx679fec4bd5724acca1141-005babd383
+      - txaab52ccef741468db4833-005bd209d7
       Date:
-      - Wed, 26 Sep 2018 18:44:19 GMT
+      - Thu, 25 Oct 2018 18:22:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:44:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:37 GMT
+      - Thu, 25 Oct 2018 18:23:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9bb5f127-c6bd-4cb7-83b5-7c57b0e3552c
+      - req-773edac4-796e-4874-a193-3a2d0dff08c0
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:37:37.514388Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:05.380432Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xUa-OL7LS_OQcME7Xb7Y2Q"],
-        "issued_at": "2018-09-26T18:37:37.514407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wW0WGSFBR7mv7Bbz40-2ig"],
+        "issued_at": "2018-10-25T18:23:05.380454Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:37 GMT
+      - Thu, 25 Oct 2018 18:23:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,21 +182,21 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-5029280d-5e4d-42af-99f3-0e3e4292c1ca
+      - req-5074e502-cd48-4752-9e42-b5edfd69b41c
       Date:
-      - Wed, 26 Sep 2018 18:37:37 GMT
+      - Thu, 25 Oct 2018 18:23:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:38 GMT
+      - Thu, 25 Oct 2018 18:23:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b658cf27-cc10-4d40-8e93-adc839eab024
+      - req-0dcaa908-8ebf-48ad-82ab-171d53bf0024
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:37:38.113966Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:05.822184Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bif1MQy9TOeWhG5Wv15OuQ"],
-        "issued_at": "2018-09-26T18:37:38.113986Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eU2yiZpjQKKxZX8RmV2_mw"],
+        "issued_at": "2018-10-25T18:23:05.822205Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,34 +325,34 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3258f0d-3d08-4547-8485-d4ee92677333
+      - req-fd939103-f7d5-42a5-8136-6f897c1c3045
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-f3258f0d-3d08-4547-8485-d4ee92677333
+      - req-fd939103-f7d5-42a5-8136-6f897c1c3045
       Date:
-      - Wed, 26 Sep 2018 18:37:38 GMT
+      - Thu, 25 Oct 2018 18:23:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:38 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 004d617991404e15af52e3d170d7c201
+      - f6ac138c77be43c5891320ee3ebdd097
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e742069c-bbf2-42b9-b2d3-ff6fe7c230de
+      - req-c72ff87e-3700-41bb-a9c3-916dfef501f5
       Content-Length:
       - '297'
       Connection:
@@ -381,15 +381,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:37:38.689086Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:23:06.104058Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dLcGncuxRCisWDFcd9lAfQ"],
-        "issued_at": "2018-09-26T18:37:38.689105Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Pj6-H6zWRuySLFRRVxBG1A"],
+        "issued_at": "2018-10-25T18:23:06.104079Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -401,29 +401,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 004d617991404e15af52e3d170d7c201
+      - f6ac138c77be43c5891320ee3ebdd097
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:38 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47c5c9af-1938-4d00-b5c1-d6804df9a515
+      - req-a30459cd-9402-4c8f-be4f-df64a24b6f5f
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -447,13 +447,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"004d617991404e15af52e3d170d7c201"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -465,196 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:38 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '04190f386042440b8ca2ce91fe2741b1'
+      - f130f696cdfa428089d3a195c4b33719
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ef89b97-666d-4632-8b8f-15fc8c8d8bfa
-      Content-Length:
-      - '7313'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:38.689086Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5Gg3rw6zTDyKa40PY0pr3w",
-        "dLcGncuxRCisWDFcd9lAfQ"], "issued_at": "2018-09-26T18:37:38.988468Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - '04190f386042440b8ca2ce91fe2741b1'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-2daea2ad-0ec3-4678-8dce-f42bacbe80ca
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 38dbae534dd94a8580861b9211e05851
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-db156656-c5f7-4a11-8213-6b4583746f7a
+      - req-1adac250-6dd9-4ba7-9ea2-f9b42197f316
       Content-Length:
       - '7278'
       Connection:
@@ -666,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:39.285304Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:06.430495Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -745,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1YngNtknS4eHL7E_w8W1Ow"],
-        "issued_at": "2018-09-26T18:37:39.285323Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NfhJYt7SThC25gF9ycKGhg"],
+        "issued_at": "2018-10-25T18:23:06.430515Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -763,7 +582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
   response:
     status:
       code: 200
@@ -774,7 +593,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,13 +602,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -801,15 +620,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-201f967a-e119-4cbc-a75e-a6e19ab02969
+      - req-d51b28d1-d160-4ce1-b411-b683a231af8e
       Content-Length:
       - '7278'
       Connection:
@@ -821,7 +640,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:39.547200Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:06.712880Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -900,10 +719,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6eKUVCvAQ3GPyhY6fyoqBA"],
-        "issued_at": "2018-09-26T18:37:39.547218Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2slE-xEvQy2ybU18oY_w6w"],
+        "issued_at": "2018-10-25T18:23:06.712911Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -918,7 +737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
   response:
     status:
       code: 200
@@ -929,7 +748,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -938,13 +757,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -956,15 +775,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
+      - Thu, 25 Oct 2018 18:23:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e8aa6ce9-30ef-4ac1-8ad2-31d8ec3dd573
+      - req-d03938f5-5f18-446b-be78-8632140fd9f5
       Content-Length:
       - '7264'
       Connection:
@@ -976,7 +795,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:39.835936Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:07.029783Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1055,10 +874,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GPsPHDeoSJ-weIeiR4ctPg"],
-        "issued_at": "2018-09-26T18:37:39.835955Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jt6C2AXgRiS-Czz4QB_qCQ"],
+        "issued_at": "2018-10-25T18:23:07.029810Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1073,7 +892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
   response:
     status:
       code: 200
@@ -1084,7 +903,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:39 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1093,13 +912,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1111,15 +930,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-de3fcb77-2f80-4ca5-939e-197ecc0bf249
+      - req-774e8edb-45e2-4760-b469-bffe72d1b219
       Content-Length:
       - '7278'
       Connection:
@@ -1131,7 +950,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:40.101596Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:07.313887Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1210,10 +1029,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZkZin1tiR6OP2WL8WGCxrQ"],
-        "issued_at": "2018-09-26T18:37:40.101615Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7jJuzbsNQQStAimE864P7Q"],
+        "issued_at": "2018-10-25T18:23:07.313909Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1228,7 +1047,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
   response:
     status:
       code: 200
@@ -1239,7 +1058,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1248,13 +1067,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1266,15 +1085,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-408870a0-047d-4bd8-b8c6-79bfe70a51ab
+      - req-56908282-564f-42e1-aa89-95cde411c0f5
       Content-Length:
       - '7265'
       Connection:
@@ -1286,7 +1105,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:40.366812Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:07.591424Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1365,10 +1184,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Me-P39DHTg2fQyehL29_9Q"],
-        "issued_at": "2018-09-26T18:37:40.366832Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CfLoxzoVRRaihLJtClbeEg"],
+        "issued_at": "2018-10-25T18:23:07.591445Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1383,7 +1202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
   response:
     status:
       code: 200
@@ -1394,7 +1213,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1403,13 +1222,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1421,15 +1240,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a9253f79-918f-47f2-abd3-8e1d46af651f
+      - req-5a35295c-f96e-4ccb-ba7d-e4272329d3af
       Content-Length:
       - '7278'
       Connection:
@@ -1441,7 +1260,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:40.629193Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:07.930638Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1520,10 +1339,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LSGvfIfnQfOGiPCFlCjfdg"],
-        "issued_at": "2018-09-26T18:37:40.629212Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fRzlsX3ESpa3lwjYnRRl3w"],
+        "issued_at": "2018-10-25T18:23:07.930663Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1538,7 +1357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
   response:
     status:
       code: 200
@@ -1549,7 +1368,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1558,7 +1377,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1573,7 +1392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1586,26 +1405,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-58717a08-a0b1-42b0-ab5d-b1f748349611
+      - req-7666b7df-319d-43e3-af25-fbf323d7eb86
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1620,7 +1439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1633,26 +1452,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6c0e9629-93c6-4f3b-bb04-6b93921eebda
+      - req-045605ae-d51c-4148-a3d2-0875ab4b2058
       Date:
-      - Wed, 26 Sep 2018 18:37:40 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1667,7 +1486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1680,26 +1499,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fe77aecd-981b-4355-ae6a-0dcb2ef99c74
+      - req-d2b66a6c-8f5c-41ed-afae-afd2a383f251
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1714,7 +1533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1727,26 +1546,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fd0f73f9-384a-4d73-9874-b95e8fd329a7
+      - req-0c5d19d0-cce1-480d-80c3-21ffcc078d9a
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1761,7 +1580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1774,26 +1593,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-94afa62a-e1fc-40f2-805b-6ba425e00acd
+      - req-9de7dc2e-82d6-497b-aaf7-f56a2eb0067e
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1808,7 +1627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1821,26 +1640,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6636ba74-ce4c-4992-ac5b-ba9006ee4636
+      - req-f1713f91-e8f6-4e6e-b660-fb546ecfc9ba
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1855,7 +1674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1868,26 +1687,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b9794695-b1f5-4945-8a03-1717ee9c1727
+      - req-757fbec9-63cf-4144-a0f2-d841244fa3c4
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1902,7 +1721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1915,26 +1734,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e99a9f66-82b0-4a46-beac-3fd0e312b340
+      - req-91115749-53ed-401e-b093-9e4e69931fd4
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1949,7 +1768,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1962,26 +1781,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-039ca9f0-d4f1-4685-926f-ad028074466f
+      - req-55a141a5-7e06-4ae9-871a-e2c1140490c0
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1996,7 +1815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2009,26 +1828,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-02dc1f2f-4aaf-4813-ac69-8e69ddd05528
+      - req-9fcf109b-88ef-42f0-882b-8f911fb3cb57
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -2043,7 +1862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2056,26 +1875,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c2e345e6-52a6-47d3-afa8-65eb52bef474
+      - req-85d6e926-a116-4d94-95bb-f9d537d18c5c
       Date:
-      - Wed, 26 Sep 2018 18:37:41 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -2090,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2103,26 +1922,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e6db3af8-0e09-40af-be55-f5fb07260059
+      - req-d640cd16-40bf-49da-aeed-22fa4a588abe
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -2137,7 +1956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2150,26 +1969,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-58fe564e-80e5-4149-9a73-75d14acd74bc
+      - req-56bc4560-46db-4539-ab0a-14e56bcf8e77
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2184,7 +2003,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2197,26 +2016,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d3acf60d-bec2-4dd3-9a71-4d444973adba
+      - req-02d77f43-2c55-4c61-bd41-add0402a5071
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:37:39.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:23:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:23:00.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:37:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:23:03.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:37:39.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:23:05.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:37:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:23:06.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2231,7 +2050,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2244,9 +2063,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-0e07198f-ce1d-43ce-9a60-712934256a37
+      - req-6afd3ae0-d46c-44c4-80b3-b3df0f7d72af
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2260,7 +2079,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2275,7 +2094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2107,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-59e6b340-3a0e-4c9a-b8bb-399cf3623811
+      - req-00684e89-8e5c-4d03-b397-a64ddf48284a
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2304,7 +2123,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2319,7 +2138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2332,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-a9caf51d-53bb-41f8-a6ad-667b20aab164
+      - req-d71e39c1-a2b9-4bcc-9e90-78589a216783
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2349,7 +2168,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2364,7 +2183,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2377,9 +2196,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-c9f64db4-8b65-4b37-aa78-2c10c3690dce
+      - req-7bceccdc-e269-46f3-8438-7f1adc49b742
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2389,7 +2208,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2404,7 +2223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2417,21 +2236,21 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-0066a78c-d326-4252-a57c-f9934d04319c
+      - req-d342bb4a-74d0-49eb-8195-dedeeee4ed63
       Date:
-      - Wed, 26 Sep 2018 18:37:42 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2443,15 +2262,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 59909f5221514d6c9e2894182673f445
+      - c7401c59232747e5ab68a1a887f666d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0aa8d39c-a8ce-4b88-8b02-499e483f1da0
+      - req-0163c893-f25a-4a7c-bed9-6bac78c0f920
       Content-Length:
       - '7311'
       Connection:
@@ -2463,7 +2282,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:37:43.152815Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:10.499849Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2542,55 +2361,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hO7r3urKT-GpodI24hW1tQ"],
-        "issued_at": "2018-09-26T18:37:43.152848Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UKyE9KZrSFqoqdlca9Kdeg"],
+        "issued_at": "2018-10-25T18:23:10.499871Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 59909f5221514d6c9e2894182673f445
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.206:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.206:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.206:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2602,15 +2382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f0a61bae2b4e4eb49f23e8f16705447c
+      - a7e49ae42f714628b39a203354139571
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e2aab934-b849-430b-96fb-b534a161283e
+      - req-688776f1-4a26-4d6b-9219-5d2cd132fabf
       Content-Length:
       - '7278'
       Connection:
@@ -2622,7 +2402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:43.416250Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:10.698483Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2701,10 +2481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["94W6jOnQRd6YU4lzcZAMtA"],
-        "issued_at": "2018-09-26T18:37:43.416269Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yheXLfZmTTSBYwwufZ0OKw"],
+        "issued_at": "2018-10-25T18:23:10.698503Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2719,7 +2499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a61bae2b4e4eb49f23e8f16705447c
+      - a7e49ae42f714628b39a203354139571
   response:
     status:
       code: 200
@@ -2730,9 +2510,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8b0c2e6b-4574-47fe-b4fe-8fa46b5ca37a
+      - req-9e2cabda-fd5d-40a6-aba9-e25471146a4c
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2774,7 +2554,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -2789,7 +2569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a61bae2b4e4eb49f23e8f16705447c
+      - a7e49ae42f714628b39a203354139571
   response:
     status:
       code: 200
@@ -2800,20 +2580,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-76302284-7876-43ab-acec-c4f3a85047b9
+      - req-e1892aa6-2357-4635-b194-9cd939b91914
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2825,15 +2605,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b30e2c83f68c4e9c88cf1b4b37cacc29
+      - f5e865d6a4d1477082297ae3658f691b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7687f024-7f8d-4229-a369-831d339d3644
+      - req-c0371235-86f6-4a08-9c3d-31a17f492189
       Content-Length:
       - '7278'
       Connection:
@@ -2845,7 +2625,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:43.854717Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:11.189073Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2924,10 +2704,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QN7GGTdfTZOZ9LM1vaX_XA"],
-        "issued_at": "2018-09-26T18:37:43.854737Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DNYR4ZSeRnqRN5gCu0JbFQ"],
+        "issued_at": "2018-10-25T18:23:11.189095Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2942,7 +2722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b30e2c83f68c4e9c88cf1b4b37cacc29
+      - f5e865d6a4d1477082297ae3658f691b
   response:
     status:
       code: 200
@@ -2953,9 +2733,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3b8cff79-3c4b-4ccd-880a-fb76140904d6
+      - req-813e0067-1f09-453c-84fb-66b0d2383589
       Date:
-      - Wed, 26 Sep 2018 18:37:43 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2997,7 +2777,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3012,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b30e2c83f68c4e9c88cf1b4b37cacc29
+      - f5e865d6a4d1477082297ae3658f691b
   response:
     status:
       code: 200
@@ -3023,20 +2803,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-129e32ec-7502-4534-8e91-df8ec2c79953
+      - req-04ecbb44-1ee4-4c2d-aa18-5a5fe2d134fd
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3048,15 +2828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7f884ac7f9e84da58067dc297829adf5
+      - d05c9d6467554b32b4e2abd904b494dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40126e36-dab2-440e-90bc-ab4cce72f134
+      - req-1834d413-bff3-46bb-971d-d55137dd9c21
       Content-Length:
       - '7264'
       Connection:
@@ -3068,7 +2848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:44.283796Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:11.634836Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3147,10 +2927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GonnJlbmS6SUs5oQdYcNhA"],
-        "issued_at": "2018-09-26T18:37:44.283817Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lmtEkdM7TACI1Y3rRktHFw"],
+        "issued_at": "2018-10-25T18:23:11.634860Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3165,7 +2945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f884ac7f9e84da58067dc297829adf5
+      - d05c9d6467554b32b4e2abd904b494dd
   response:
     status:
       code: 200
@@ -3176,9 +2956,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-35a15ead-488d-41dc-afe4-1f45254b93d0
+      - req-cc36c919-066f-41fb-bfe1-37a337f62600
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3220,7 +3000,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3235,7 +3015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7f884ac7f9e84da58067dc297829adf5
+      - d05c9d6467554b32b4e2abd904b494dd
   response:
     status:
       code: 200
@@ -3246,20 +3026,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5d33f346-8035-4d37-b715-bedb3a0fed90
+      - req-e8271300-a00b-4709-99e1-33c3f0c4d0de
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3271,15 +3051,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e921a4a3d63248288bc05bf4837bf4df
+      - 18c480fde27a49f1b5d61200aad9c2dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f207807a-a496-43cb-859d-0c39a41d3cbb
+      - req-10393815-3ed3-4440-a4cc-f36449612a83
       Content-Length:
       - '7278'
       Connection:
@@ -3291,7 +3071,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:44.731142Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:12.077712Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3370,10 +3150,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_d5jIjCjTw2zZAM1Kk2yAQ"],
-        "issued_at": "2018-09-26T18:37:44.731162Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZSXOZaHZRqS1YCwQGFoKxg"],
+        "issued_at": "2018-10-25T18:23:12.077734Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3388,7 +3168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e921a4a3d63248288bc05bf4837bf4df
+      - 18c480fde27a49f1b5d61200aad9c2dc
   response:
     status:
       code: 200
@@ -3399,9 +3179,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-dbe1e9f6-12a6-47b4-b7be-8071b0ee54f5
+      - req-cca15f2f-266d-4d74-b2aa-a9dce21e50bd
       Date:
-      - Wed, 26 Sep 2018 18:37:44 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3443,7 +3223,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3458,7 +3238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e921a4a3d63248288bc05bf4837bf4df
+      - 18c480fde27a49f1b5d61200aad9c2dc
   response:
     status:
       code: 200
@@ -3469,14 +3249,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-20e35051-c657-402c-80c1-164c94196137
+      - req-41f875e1-14c9-4ed5-9646-959324308787
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3491,7 +3271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59909f5221514d6c9e2894182673f445
+      - c7401c59232747e5ab68a1a887f666d8
   response:
     status:
       code: 200
@@ -3502,9 +3282,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e2261a68-8c1b-4e7d-a7ac-cddb9e480a32
+      - req-a2aef4ba-35d5-424b-af96-44f997b35a43
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3546,7 +3326,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3561,7 +3341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59909f5221514d6c9e2894182673f445
+      - c7401c59232747e5ab68a1a887f666d8
   response:
     status:
       code: 200
@@ -3572,20 +3352,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-993a281b-e737-4149-9c72-7b802a1fbded
+      - req-cbc20b33-b643-4ec4-998c-3b6987214d2f
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3597,15 +3377,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 408f556daf5a40c6ac8334b0f3d0015e
+      - facb966a41e4488b855978671daf7100
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-402386eb-8c92-4364-b704-f4570a6f0c49
+      - req-f6defc26-9653-42b8-af80-90342a1b201b
       Content-Length:
       - '7265'
       Connection:
@@ -3617,7 +3397,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:45.461258Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:12.791978Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3696,10 +3476,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8FR318rqSDSkhVZ7CdJ-dg"],
-        "issued_at": "2018-09-26T18:37:45.461277Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OSoUYgcAT4eh3eKQYuN2tQ"],
+        "issued_at": "2018-10-25T18:23:12.791999Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3714,7 +3494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 408f556daf5a40c6ac8334b0f3d0015e
+      - facb966a41e4488b855978671daf7100
   response:
     status:
       code: 200
@@ -3725,9 +3505,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-60550c7f-1a65-4233-8c8a-bbc49326512d
+      - req-07d2b832-6aaf-4183-86b1-c71911bbf5cd
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3769,7 +3549,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3784,7 +3564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 408f556daf5a40c6ac8334b0f3d0015e
+      - facb966a41e4488b855978671daf7100
   response:
     status:
       code: 200
@@ -3795,20 +3575,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5e883075-69f8-41ec-8602-04286321aed6
+      - req-7cc32c79-650b-46e5-a0e2-a5359c868beb
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3820,15 +3600,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:45 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7e7b20fd7890464682bd1763e01bb755
+      - b94a9863b79947faa0510f1be62d4f73
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0b2afa8e-c6e9-40a1-bd7d-97c2625b308b
+      - req-61750fc9-9560-4168-a517-44a2b2f71797
       Content-Length:
       - '7278'
       Connection:
@@ -3840,7 +3620,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:45.910495Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:13.263829Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3919,10 +3699,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nrKueuIGRpmfMdwRXx_B8g"],
-        "issued_at": "2018-09-26T18:37:45.910515Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AzCWdqbBTNKrhMVUA2-jXg"],
+        "issued_at": "2018-10-25T18:23:13.263851Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3937,7 +3717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e7b20fd7890464682bd1763e01bb755
+      - b94a9863b79947faa0510f1be62d4f73
   response:
     status:
       code: 200
@@ -3948,9 +3728,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-59070cc6-fc48-4c52-b985-3b4936d0468f
+      - req-67093d28-6d9b-41b3-90ba-614aceada845
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3992,7 +3772,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4007,7 +3787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e7b20fd7890464682bd1763e01bb755
+      - b94a9863b79947faa0510f1be62d4f73
   response:
     status:
       code: 200
@@ -4018,14 +3798,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-eae198d6-466a-4d18-855c-58d787699a00
+      - req-cf38b7b7-90a5-4d82-a12b-caf2a08fa70d
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -4040,7 +3820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4053,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-17791615-2094-4345-9b33-f74b97409e66
+      - req-c8432571-d159-4203-a732-9736b0f64f44
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4065,7 +3845,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4080,7 +3860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4093,9 +3873,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-6db49d23-e292-48bc-a251-9efa8cc5f424
+      - req-5c98bcd8-5285-4c25-aa61-56c4f381fc97
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4105,7 +3885,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -4120,7 +3900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4133,9 +3913,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f02e472c-408a-4354-b554-9cd400972407
+      - req-1149c06e-cf07-48eb-aa6b-cf9e3e2e3eb9
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4145,7 +3925,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4160,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4173,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f7140f54-5409-4e66-b670-d1a41a2e9abd
+      - req-2ec4775c-6500-4b7f-acb8-c0d61904fe94
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4185,7 +3965,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -4200,7 +3980,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4213,9 +3993,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-edc95ef8-5744-4d4e-925c-7be7ee596a6e
+      - req-86584c9b-89d2-4643-9ea5-9f367cfb9b56
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4225,7 +4005,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4240,7 +4020,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4253,9 +4033,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-5d6d61fc-c23d-4d8f-8276-8837c10de8ec
+      - req-585b116a-7e85-4adc-8dca-8cdd54b59180
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4265,7 +4045,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4280,7 +4060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4293,9 +4073,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-271190a1-a28b-4c3c-9dff-71aafdfebf3c
+      - req-23ba6d48-912d-4bfb-8d27-1f98f57946db
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4305,7 +4085,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4320,7 +4100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4333,9 +4113,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ead34991-e22a-4506-a227-90d58809a7b0
+      - req-839c3904-b6d4-42b0-bcf0-10e45568e813
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4345,7 +4125,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4360,7 +4140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4373,9 +4153,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-97a4ea5f-afe1-42e9-b771-3172808a4817
+      - req-42010771-ba82-4da9-aead-962678453e55
       Date:
-      - Wed, 26 Sep 2018 18:37:46 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4385,7 +4165,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4400,7 +4180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4413,9 +4193,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-eb758dfb-78dc-4c21-9de8-176e419e1401
+      - req-3fa69ad7-a86c-471e-b4df-5893877fa0cb
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4425,7 +4205,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4440,7 +4220,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4453,9 +4233,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-d2a29fc0-15c2-4efc-8666-17695840fb50
+      - req-6182766e-fcb3-41a9-82f4-13a14c04eec7
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4465,7 +4245,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4480,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4493,9 +4273,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-efe830b5-ffa1-4d57-9b3e-73b1b5a65564
+      - req-92350d1a-a4bc-49d5-a115-de7f5c8649d1
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4505,7 +4285,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4520,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4533,9 +4313,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2a3b1730-bafc-489d-b551-9ff80c2a3b7d
+      - req-4b2085dd-e0d1-4eb3-a3e5-415299f1898c
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4545,7 +4325,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4560,7 +4340,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4573,9 +4353,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-6f5d2b44-98e5-4a03-bca0-ee108c1329d6
+      - req-a7019d90-2f5d-4dbf-9b32-6c39f4689715
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4585,13 +4365,13 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4603,15 +4383,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2baeabbd4de4197846badb1ae6b4cd9
+      - '0789bdef445543c09723fd0e23a315d6'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9610f0f0-80cd-4ab2-8843-c6f05f504c5c
+      - req-a21f21ae-6c51-48ac-89f7-6f592f54436a
       Content-Length:
       - '7311'
       Connection:
@@ -4623,7 +4403,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:37:47.731615Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:15.050201Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4702,16 +4482,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P_3DNw3rRBCd9h9o7pGllg"],
-        "issued_at": "2018-09-26T18:37:47.731639Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mBtOEUnPSJK8K7NXPIjpzw"],
+        "issued_at": "2018-10-25T18:23:15.050225Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4723,15 +4503,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:47 GMT
+      - Thu, 25 Oct 2018 18:23:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b0ae1500c17456289921fcda1e559dd
+      - e642a4ee8a3f4358a962f1b5ab58b263
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-adb2b750-4b44-4ebd-a8c2-4deee41bbb99
+      - req-c64a0b6b-a59a-47ce-b919-3dac2df6ea14
       Content-Length:
       - '7278'
       Connection:
@@ -4743,7 +4523,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:47.936632Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:15.248318Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4822,10 +4602,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mYdxJ-hjRS2f0tUh4fBbsQ"],
-        "issued_at": "2018-09-26T18:37:47.936653Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6YCFMsGuRDOD2l7P59bQ0g"],
+        "issued_at": "2018-10-25T18:23:15.248341Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -4840,7 +4620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b0ae1500c17456289921fcda1e559dd
+      - e642a4ee8a3f4358a962f1b5ab58b263
   response:
     status:
       code: 200
@@ -4851,20 +4631,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-70854a25-f80d-48f4-bfc8-ab433fa9773a
+      - req-40eb0b9a-a1e1-4290-8001-81d1a3a1404b
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4876,15 +4656,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 44209c2292f94cf0b22d6cde5e818353
+      - d41ff711da6543ed88b017dd3195c356
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8b43311a-2a48-4823-83d4-f31703cd3a7e
+      - req-8572b440-4668-42cf-9b08-eab4d62f95ea
       Content-Length:
       - '7278'
       Connection:
@@ -4896,7 +4676,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:48.326722Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:15.578020Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4975,10 +4755,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z6PmKtGoTPKWGY2ceYNDDg"],
-        "issued_at": "2018-09-26T18:37:48.326741Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tPW-SMfESquok_kCKjV8pw"],
+        "issued_at": "2018-10-25T18:23:15.578041Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -4993,7 +4773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44209c2292f94cf0b22d6cde5e818353
+      - d41ff711da6543ed88b017dd3195c356
   response:
     status:
       code: 200
@@ -5004,20 +4784,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-185f2921-b64c-41f1-8d66-20b0d62a85e6
+      - req-0e902fd2-f57e-47d4-b53c-80936f06a297
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5029,15 +4809,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40943142-3ea4-4fb1-913f-90717ed01a18
+      - req-ff432820-040c-49da-a150-5b3fea94a575
       Content-Length:
       - '7264'
       Connection:
@@ -5049,7 +4829,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:48.649877Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:15.901135Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5128,10 +4908,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UjIb8ydJRJ20rvm2vnruwg"],
-        "issued_at": "2018-09-26T18:37:48.649897Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eTiYDuHxSQ2KPlW0GacP5Q"],
+        "issued_at": "2018-10-25T18:23:15.901156Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5146,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5157,9 +4937,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-3eb55984-2aab-4290-a8bc-6db74a6e7ac9
+      - req-87b2cbe1-7c72-4877-8e74-380399c3d1f6
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5193,7 +4973,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5208,7 +4988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5219,20 +4999,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f6219c8d-8454-4568-97ff-cf50fc8c5a77
+      - req-5e648cf9-df01-4f31-ad45-8c8fb67ff60e
       Date:
-      - Wed, 26 Sep 2018 18:37:48 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5244,15 +5024,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 336033b9018e44d8bc0c099b6aac7a20
+      - '01580a6b380d4d4296a594666fe62d4a'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-24d60069-8da7-4638-8556-88bd0482d4e7
+      - req-f9172b86-4349-4870-95c5-6b1349a8b61c
       Content-Length:
       - '7278'
       Connection:
@@ -5264,7 +5044,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:49.100121Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:16.352769Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5343,10 +5123,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1ZXEZAkRSV6ym8DmCHWmig"],
-        "issued_at": "2018-09-26T18:37:49.100140Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pZDTgcPSSvK1u2SK7j_2HA"],
+        "issued_at": "2018-10-25T18:23:16.352789Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5361,7 +5141,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 336033b9018e44d8bc0c099b6aac7a20
+      - '01580a6b380d4d4296a594666fe62d4a'
   response:
     status:
       code: 200
@@ -5372,14 +5152,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f7fc881c-dcc1-45d3-b93e-b86a1b0dae4c
+      - req-a0efff89-f8e3-44cf-996f-332d3ba4001d
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5394,7 +5174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2baeabbd4de4197846badb1ae6b4cd9
+      - '0789bdef445543c09723fd0e23a315d6'
   response:
     status:
       code: 200
@@ -5405,20 +5185,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-945be153-d6c4-4e6e-bda8-0fdc03e2a5ef
+      - req-0f15d2ea-cf71-4dfb-b45b-fd48a56a0de7
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5430,15 +5210,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eacbbb53d4794c89ad0262ca249a379b
+      - 7c1e42367d0841f9b20f5d74e107ff2c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-993bb976-300d-4ff8-bd3f-6407173fdb23
+      - req-a237b272-9244-4131-9b71-416f894a5a9f
       Content-Length:
       - '7265'
       Connection:
@@ -5450,7 +5230,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:49.534228Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:16.813271Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5529,10 +5309,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NbNBDEWVTjuM_nNE7JniIQ"],
-        "issued_at": "2018-09-26T18:37:49.534247Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K8q1uPOCTPK2seULGgLl_g"],
+        "issued_at": "2018-10-25T18:23:16.813291Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5547,7 +5327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eacbbb53d4794c89ad0262ca249a379b
+      - 7c1e42367d0841f9b20f5d74e107ff2c
   response:
     status:
       code: 200
@@ -5558,20 +5338,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-69af60da-67d3-43b9-84b1-ed2b4d8cd661
+      - req-820f8114-1c06-49ad-be63-a70b00f821ea
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5583,15 +5363,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7a053f00df44fbe8959d501b37a528d
+      - 11c10ab07bf140ffa66105c5267a1aa8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7b8aa8a1-b042-4214-87fb-7cf7cd893e28
+      - req-32d5ed23-193c-4d01-8661-64cf47d09574
       Content-Length:
       - '7278'
       Connection:
@@ -5603,7 +5383,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:49.848975Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:17.151617Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5682,10 +5462,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b68TnFH6TzuD6pWduyhTXw"],
-        "issued_at": "2018-09-26T18:37:49.848997Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJCsaPEUSxCyDqSndbdmDg"],
+        "issued_at": "2018-10-25T18:23:17.151639Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5700,7 +5480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7a053f00df44fbe8959d501b37a528d
+      - 11c10ab07bf140ffa66105c5267a1aa8
   response:
     status:
       code: 200
@@ -5711,14 +5491,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-79f1dd3c-d358-4e54-99d2-e5ab0c6ef70c
+      - req-081f5a47-5c0b-4b36-aaf9-8642e06f51c3
       Date:
-      - Wed, 26 Sep 2018 18:37:49 GMT
+      - Thu, 25 Oct 2018 18:23:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5733,7 +5513,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5744,9 +5524,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3eb40a5a-6248-4aed-9af0-b30899051c41
+      - req-658b52ce-07de-445a-8b76-002b62c1f1df
       Date:
-      - Wed, 26 Sep 2018 18:37:50 GMT
+      - Thu, 25 Oct 2018 18:23:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5773,7 +5553,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5788,7 +5568,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5799,9 +5579,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-48cbb357-8c9c-4bca-8ce1-b92dea466a5a
+      - req-ad146f56-16f0-4dcf-8abe-06ab089e7b64
       Date:
-      - Wed, 26 Sep 2018 18:37:50 GMT
+      - Thu, 25 Oct 2018 18:23:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5828,7 +5608,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5843,7 +5623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5854,9 +5634,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-174dea35-7c82-42f8-a885-337e0e8a3dd2
+      - req-071c8844-eff4-433b-8ab1-8f59ba01c40b
       Date:
-      - Wed, 26 Sep 2018 18:37:50 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5883,7 +5663,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5898,7 +5678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5909,9 +5689,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-67177a44-ef88-42e4-abe0-c75fd4697576
+      - req-5a984e65-f995-4dfd-9404-c3a3256719f6
       Date:
-      - Wed, 26 Sep 2018 18:37:50 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5967,7 +5747,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5982,7 +5762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -5993,9 +5773,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5214671d-137c-458f-b8a6-2bed7d979304
+      - req-a0255f2a-70ad-4553-ac0b-d0249a254427
       Date:
-      - Wed, 26 Sep 2018 18:37:51 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6007,7 +5787,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -6022,7 +5802,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6035,14 +5815,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-5fcd0775-6fab-47a6-a447-cff2b546fb3d
+      - req-5c49aa75-1178-43a5-8591-4093d1cf232f
       Date:
-      - Wed, 26 Sep 2018 18:37:51 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -6057,7 +5837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6070,14 +5850,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-ffacbe1f-cc7d-4539-bc64-cf6f00e7d0d7
+      - req-aba06592-ee6b-468c-a68d-d9c077601cdd
       Date:
-      - Wed, 26 Sep 2018 18:37:51 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -6092,7 +5872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6105,13 +5885,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-0c71cf9d-96ee-4d30-8fc9-e3a2eb5303cc
+      - req-150d77a7-11a4-46b8-b4fc-645f927b7ec7
       Date:
-      - Wed, 26 Sep 2018 18:37:51 GMT
+      - Thu, 25 Oct 2018 18:23:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:53:02Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -6153,7 +5933,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6168,7 +5948,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6181,9 +5961,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-935b4e03-70c5-414d-83d8-66c4a68bb07a
+      - req-ed844646-fb0e-46f4-a27f-bf6a789c4453
       Date:
-      - Wed, 26 Sep 2018 18:37:51 GMT
+      - Thu, 25 Oct 2018 18:23:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6207,7 +5987,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:53:07Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -6229,7 +6009,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6244,7 +6024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6257,13 +6037,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-892209a5-24f9-4405-b52a-0e87da8612e0
+      - req-ba299b09-d9f7-493f-8f50-ccab73681480
       Date:
-      - Wed, 26 Sep 2018 18:37:52 GMT
+      - Thu, 25 Oct 2018 18:23:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:52:52Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -6284,7 +6064,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:52:47Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -6307,7 +6087,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6322,7 +6102,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6335,9 +6115,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-0a2c71fc-47ca-4c14-97f8-906a0116df0e
+      - req-c1c55381-cc30-4695-9660-8283e1b0cf46
       Date:
-      - Wed, 26 Sep 2018 18:37:52 GMT
+      - Thu, 25 Oct 2018 18:23:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6379,7 +6159,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6394,7 +6174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6407,9 +6187,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-7d0f7559-ad54-449b-bd9c-67a05d0beb6f
+      - req-278206c3-ef81-42a0-927d-1a518f0b37b7
       Date:
-      - Wed, 26 Sep 2018 18:37:52 GMT
+      - Thu, 25 Oct 2018 18:23:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6432,7 +6212,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6447,7 +6227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6460,14 +6240,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-17bf23c2-c3d7-4b68-88c7-6d18f5353ef9
+      - req-bfc01903-ca4b-4223-b0e1-17b11915e095
       Date:
-      - Wed, 26 Sep 2018 18:37:52 GMT
+      - Thu, 25 Oct 2018 18:23:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6482,7 +6262,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6495,14 +6275,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-53311f6f-1b81-45e7-8ea1-6644d52bd17b
+      - req-4d74956f-e31b-416e-89c1-e55b620f1170
       Date:
-      - Wed, 26 Sep 2018 18:37:52 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6517,7 +6297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6530,14 +6310,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-82f49cda-adcf-44e0-8c2f-f960737dbac6
+      - req-8b742950-ec5c-4484-968d-c7129c2df08f
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6552,7 +6332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6565,14 +6345,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-2b96b837-ad41-496c-a2eb-8c464c8e14d1
+      - req-1330e64e-bace-41a8-9885-22d0e1d59449
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6587,7 +6367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -6598,9 +6378,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-42dce917-2843-4e6f-98c2-2aa271294073
+      - req-33ce865e-5236-43d5-b26d-4afcee794f09
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6656,7 +6436,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6671,7 +6451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -6682,9 +6462,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-89052d22-833e-4a71-8d17-af6665d22e47
+      - req-ff914aea-8af0-4482-8fe8-10d85f2d6e24
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6696,7 +6476,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6711,7 +6491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -6722,9 +6502,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2fce2637-eb8e-48ac-9172-f14d2a8f133a
+      - req-263fda41-5313-4f21-972c-30908edf0a28
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6780,7 +6560,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6795,7 +6575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3115007d1392456c80639ce11bb78e52
+      - faa88d26ea1647bcb811cd5fda7a0f13
   response:
     status:
       code: 200
@@ -6806,9 +6586,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-680ea439-e0c9-48f6-9156-6fe954083956
+      - req-bfd4dbdf-f26d-4824-a4e6-8c8b4c75471f
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6820,7 +6600,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6835,7 +6615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38dbae534dd94a8580861b9211e05851
+      - f130f696cdfa428089d3a195c4b33719
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6848,9 +6628,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-ff36590d-347f-4ad5-91a7-6f8cdd73bab1
+      - req-c6030d6d-be6d-4e68-a4a4-3af30ee6e89f
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6859,7 +6639,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6874,7 +6654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 251bb9573f7943e99f9a8d8627d46aa0
+      - e9afc6b25c6a43feb9c5d51bbd84241a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6887,9 +6667,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-106a2534-6def-4026-bb82-23b7a5314ff4
+      - req-3978441e-afd7-4dad-b0fb-548a488e8f0e
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6898,7 +6678,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6913,7 +6693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6926,9 +6706,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6009c142-9b07-4d14-8692-a1c7925e8218
+      - req-514a7e82-7f5e-4cf3-b693-46a2f51bb310
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6937,7 +6717,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6952,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 042ae9e066f94ceda77a52bc634f1a47
+      - 9f339daaf2b442ea94a1334e891fdbd8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6965,9 +6745,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-becd5b0e-9653-404d-ab24-ca7ce25f1f38
+      - req-056c77a4-ef8e-4dec-9c3c-bb1c9e73b1bd
       Date:
-      - Wed, 26 Sep 2018 18:37:53 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6976,7 +6756,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6991,7 +6771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7004,9 +6784,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6aad5846-9e43-4791-9105-9e2100aa2bcf
+      - req-c08fb11c-e86e-4931-b0ab-72c8e8b2d836
       Date:
-      - Wed, 26 Sep 2018 18:37:54 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7015,7 +6795,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7030,7 +6810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 722b52154e904f2c883efd8933da8e91
+      - 822b32934d0b41cc9dc4b9cb86cdc202
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7043,9 +6823,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-60a543a9-57ad-4ca3-8b9b-928929f2196c
+      - req-bce71348-a64f-4719-9c7c-6e449969bcb3
       Date:
-      - Wed, 26 Sep 2018 18:37:54 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7054,7 +6834,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7069,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7cc4085a442489f981aec41da670bc9
+      - 180af607b5ef47c8940e3c3e35de425c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7082,9 +6862,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-823d03f6-d3e1-4ba0-ad64-f70f8c5cfdad
+      - req-139479c5-b3c3-4967-94f2-7d84d5de9df8
       Date:
-      - Wed, 26 Sep 2018 18:37:54 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7093,13 +6873,13 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7111,15 +6891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:59 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-24182a0e-4f07-4fb4-8701-cdf6f053fa0f
+      - req-2b87c194-4d29-432e-8abd-0139b5570c96
       Content-Length:
       - '7278'
       Connection:
@@ -7131,7 +6911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:37:59.515826Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:21.707503Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7210,10 +6990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9dm-cbFxQKa7EAKYVxHf_A"],
-        "issued_at": "2018-09-26T18:37:59.515846Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_x5hyvPwT_qO3lO6hPddMg"],
+        "issued_at": "2018-10-25T18:23:21.707526Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7228,22 +7008,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5287b1bf-d851-4f36-a0af-208f9255b450
+      - req-bd7329a1-c55b-48c1-866f-756d7979b9e6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5287b1bf-d851-4f36-a0af-208f9255b450
+      - req-bd7329a1-c55b-48c1-866f-756d7979b9e6
       Date:
-      - Wed, 26 Sep 2018 18:37:59 GMT
+      - Thu, 25 Oct 2018 18:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7253,13 +7033,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:37:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7271,15 +7051,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:37:59 GMT
+      - Thu, 25 Oct 2018 18:23:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03e653c8-b7b1-4948-9386-c9addc34bb3b
+      - req-88790f2e-6c05-4468-9a3c-c3ec65100e46
       Content-Length:
       - '7278'
       Connection:
@@ -7291,7 +7071,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:00.023605Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:22.172805Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7370,10 +7150,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Cp4GVrpWQGuqa_PApmLGEw"],
-        "issued_at": "2018-09-26T18:38:00.023626Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C9qHiyGzSc2lx4U3_1XnQQ"],
+        "issued_at": "2018-10-25T18:23:22.172838Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7388,22 +7168,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6844b931-222a-470d-ad2d-19ed2ac2c5e6
+      - req-642a86ca-a343-491f-ad8a-96728ca5d7d9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6844b931-222a-470d-ad2d-19ed2ac2c5e6
+      - req-642a86ca-a343-491f-ad8a-96728ca5d7d9
       Date:
-      - Wed, 26 Sep 2018 18:38:00 GMT
+      - Thu, 25 Oct 2018 18:23:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7413,13 +7193,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7431,15 +7211,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:00 GMT
+      - Thu, 25 Oct 2018 18:23:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ea85b72f-5380-4de5-bd98-d6fb951a61a4
+      - req-9232466a-53e5-49bd-bd7c-73be0aaeda1b
       Content-Length:
       - '7264'
       Connection:
@@ -7451,7 +7231,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:00.983520Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:22.617586Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7530,10 +7310,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u_3WlO7rQU6jVy5QJkI8rQ"],
-        "issued_at": "2018-09-26T18:38:00.983541Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UTrxYQ2iQIWiL6qIbTPt-w"],
+        "issued_at": "2018-10-25T18:23:22.617608Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7548,22 +7328,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee653cbb-e970-442a-962c-788be30afb9d
+      - req-fe84678f-6479-4400-9a0d-917ebf4c0ad2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ee653cbb-e970-442a-962c-788be30afb9d
+      - req-fe84678f-6479-4400-9a0d-917ebf4c0ad2
       Date:
-      - Wed, 26 Sep 2018 18:38:01 GMT
+      - Thu, 25 Oct 2018 18:23:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7573,13 +7353,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7591,15 +7371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:01 GMT
+      - Thu, 25 Oct 2018 18:23:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1509962c-f616-41fc-bad5-71b49ecac527
+      - req-aadb940b-cd8b-4bb7-9bbd-01750cc9fc47
       Content-Length:
       - '7278'
       Connection:
@@ -7611,7 +7391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:01.436864Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:23.076905Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7690,10 +7470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q70omCGoR6eE9Wtc-xJcfQ"],
-        "issued_at": "2018-09-26T18:38:01.436884Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZlYENFj7S029PEFlcFXCKQ"],
+        "issued_at": "2018-10-25T18:23:23.076926Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7708,22 +7488,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d22fe9f-bc67-4d48-88f3-d46364b357dd
+      - req-7a52f46e-8dcd-43fa-a782-562b06608d69
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1d22fe9f-bc67-4d48-88f3-d46364b357dd
+      - req-7a52f46e-8dcd-43fa-a782-562b06608d69
       Date:
-      - Wed, 26 Sep 2018 18:38:01 GMT
+      - Thu, 25 Oct 2018 18:23:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7733,7 +7513,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7748,22 +7528,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2034d167-37a7-4b39-8779-e1f1d925c71b
+      - req-3964489c-0bff-4572-8af9-98b4dd085536
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-2034d167-37a7-4b39-8779-e1f1d925c71b
+      - req-3964489c-0bff-4572-8af9-98b4dd085536
       Date:
-      - Wed, 26 Sep 2018 18:38:01 GMT
+      - Thu, 25 Oct 2018 18:23:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7773,13 +7553,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7791,15 +7571,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:02 GMT
+      - Thu, 25 Oct 2018 18:23:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-791a93a5-414b-46fd-b9b3-648cbf97fd29
+      - req-6974d5e2-8635-465b-9244-a4b91993e3c3
       Content-Length:
       - '7265'
       Connection:
@@ -7811,7 +7591,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:02.177035Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:23.842968Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7890,10 +7670,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4mSY0ZtXTHCEfj3fmB0psQ"],
-        "issued_at": "2018-09-26T18:38:02.177070Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DTa2IPo3R8OlxeUOPlbFAg"],
+        "issued_at": "2018-10-25T18:23:23.842996Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7908,22 +7688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6387084-d3e2-4bdc-96b7-6f5ba0ca8411
+      - req-6c9174d0-25f2-43e8-8dd3-7cfa6a857c72
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c6387084-d3e2-4bdc-96b7-6f5ba0ca8411
+      - req-6c9174d0-25f2-43e8-8dd3-7cfa6a857c72
       Date:
-      - Wed, 26 Sep 2018 18:38:02 GMT
+      - Thu, 25 Oct 2018 18:23:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7933,13 +7713,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7951,15 +7731,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:02 GMT
+      - Thu, 25 Oct 2018 18:23:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-85bc1dcf-7e81-4437-89d2-1cd769042e96
+      - req-3bce1804-b5e8-4448-8e43-58cdefa96cee
       Content-Length:
       - '7278'
       Connection:
@@ -7971,7 +7751,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:02.628855Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:24.314775Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8050,10 +7830,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["49uAh36gSGylnbDRKpnCvg"],
-        "issued_at": "2018-09-26T18:38:02.628875Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9_DTs891TDOZNp_X9xu2XA"],
+        "issued_at": "2018-10-25T18:23:24.314795Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8068,22 +7848,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c69dc97c-f86f-467f-9d7c-aaf3290b5b15
+      - req-947e6061-acf3-48e0-a6e1-50105604cd98
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c69dc97c-f86f-467f-9d7c-aaf3290b5b15
+      - req-947e6061-acf3-48e0-a6e1-50105604cd98
       Date:
-      - Wed, 26 Sep 2018 18:38:02 GMT
+      - Thu, 25 Oct 2018 18:23:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8093,13 +7873,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8111,15 +7891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
+      - Thu, 25 Oct 2018 18:23:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 636b9a39f829481d9a1fe8fe472e43ec
+      - 2c1afe73a4784a67afdc6faf2c93d065
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c345130e-82ec-401d-ba37-d19c2921d790
+      - req-8fa246d5-9a3e-420c-971e-371c6ccc0bda
       Content-Length:
       - '7311'
       Connection:
@@ -8131,7 +7911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:03.254607Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:25.063753Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8210,48 +7990,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xMzEQ_iHQ3SsC-JRJ0C8Lg"],
-        "issued_at": "2018-09-26T18:38:03.254628Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xHUhFpmwSZOtOaNqDt5I_A"],
+        "issued_at": "2018-10-25T18:23:25.063785Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 636b9a39f829481d9a1fe8fe472e43ec
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8263,15 +8011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
+      - Thu, 25 Oct 2018 18:23:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2a1f1f9bb71140e3bdf43774377b8bf3
+      - cfb208185354488a91573eab8e40133a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-09881526-f8b5-4cb2-9232-b1faa922a308
+      - req-d8588edf-5c12-4d8e-9126-d250b4c76a59
       Content-Length:
       - '7278'
       Connection:
@@ -8283,7 +8031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:03.527665Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:25.273952Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8362,10 +8110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UQKYmWR8S3-xAn-tRAA6UA"],
-        "issued_at": "2018-09-26T18:38:03.527684Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmFRYUEjQ9-OPRCqAHy9zw"],
+        "issued_at": "2018-10-25T18:23:25.273972Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8380,7 +8128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a1f1f9bb71140e3bdf43774377b8bf3
+      - cfb208185354488a91573eab8e40133a
   response:
     status:
       code: 200
@@ -8391,22 +8139,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e90877fb-456e-49b3-b36f-46d6108b1c65
+      - req-f9551114-9f2f-4560-ad15-b771fdea7ed0
       Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
+      - Thu, 25 Oct 2018 18:23:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8418,15 +8166,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
+      - Thu, 25 Oct 2018 18:23:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b997aa8cbd9d438da6f77d7cf91b46d5
+      - ed72b8b815bc43fd8a4df9c46bbf17c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-05299026-ee56-449e-9485-ddfbe8bde74f
+      - req-11ebd1a4-ab2d-48d2-98aa-ca5458bb3b2e
       Content-Length:
       - '7278'
       Connection:
@@ -8438,7 +8186,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:03.827565Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:25.580784Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8517,10 +8265,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8HQyV0pVTiup29PZTzZFZA"],
-        "issued_at": "2018-09-26T18:38:03.827585Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DO-q4X2yRJ2eGBnKDJlD_Q"],
+        "issued_at": "2018-10-25T18:23:25.580805Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8535,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b997aa8cbd9d438da6f77d7cf91b46d5
+      - ed72b8b815bc43fd8a4df9c46bbf17c8
   response:
     status:
       code: 200
@@ -8546,22 +8294,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1c5be13c-26f4-47d5-83b5-e04ef764162b
+      - req-c19deb53-48b9-41e3-bea6-f15bed39a537
       Date:
-      - Wed, 26 Sep 2018 18:38:03 GMT
+      - Thu, 25 Oct 2018 18:23:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8573,15 +8321,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3146c0b10c0d4cd397f68aff702966f0
+      - 669a659aab354ab89912bf090e2dbfa1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f1ab96bf-b6b3-4eae-9cdd-df993db513aa
+      - req-db7bb487-a399-47de-9603-7794dd54e7df
       Content-Length:
       - '7264'
       Connection:
@@ -8593,7 +8341,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:04.163160Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:25.912560Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8672,10 +8420,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rSA1jn7jR8CWEUn5WbrLkQ"],
-        "issued_at": "2018-09-26T18:38:04.163184Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EGpdyBHxSl6N9mlAqPdc4w"],
+        "issued_at": "2018-10-25T18:23:25.912585Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8690,7 +8438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3146c0b10c0d4cd397f68aff702966f0
+      - 669a659aab354ab89912bf090e2dbfa1
   response:
     status:
       code: 200
@@ -8701,22 +8449,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-71dc6123-9cce-4c37-ab58-dcadd35ad450
+      - req-378d3687-b20b-4b0c-8717-7b125f9dbf4e
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8728,15 +8476,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0f08b6091c02449e818bd8d1a30a4731
+      - 3d068caf8da240a2a7784206e098fac9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4f12fcca-8582-499c-9874-342f4d11b16f
+      - req-01a08f26-d03b-4b96-a780-9773bf832cb6
       Content-Length:
       - '7278'
       Connection:
@@ -8748,7 +8496,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:04.490530Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:26.223395Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8827,10 +8575,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_r93EnyYRPakdHDMk3MHhg"],
-        "issued_at": "2018-09-26T18:38:04.490550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2c80vBEpSOq3Iznv0bTw_w"],
+        "issued_at": "2018-10-25T18:23:26.223416Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8845,7 +8593,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f08b6091c02449e818bd8d1a30a4731
+      - 3d068caf8da240a2a7784206e098fac9
   response:
     status:
       code: 200
@@ -8856,16 +8604,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d4e96536-a5b9-433f-94bb-a0c382fa2606
+      - req-5f5ceaa6-869c-444c-a01d-9cffb4e55818
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8880,7 +8628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 636b9a39f829481d9a1fe8fe472e43ec
+      - 2c1afe73a4784a67afdc6faf2c93d065
   response:
     status:
       code: 200
@@ -8891,22 +8639,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8a1c4005-2342-4c95-88d7-88a2b8bc90c9
+      - req-3326ed4b-006e-461e-b47b-85d030e2a3c1
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8918,15 +8666,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:04 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ebe79c089641481aaad13bd9a53d098d
+      - a253380776d44024ab5310257058cabe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-092f68d9-1602-429d-8064-3d74b250c427
+      - req-c7837f50-6351-4b7f-b32c-937d33d5e5e7
       Content-Length:
       - '7265'
       Connection:
@@ -8938,7 +8686,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:04.919538Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:26.630467Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9017,10 +8765,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c-YWrI_KQO6LCna7OfqeGg"],
-        "issued_at": "2018-09-26T18:38:04.919571Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KpVR8--YTsi8WnaaP2rSNQ"],
+        "issued_at": "2018-10-25T18:23:26.630488Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -9035,7 +8783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebe79c089641481aaad13bd9a53d098d
+      - a253380776d44024ab5310257058cabe
   response:
     status:
       code: 200
@@ -9046,22 +8794,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e9732c9f-fd25-488b-b5de-44b536250dd0
+      - req-2ae12fed-31fa-4838-868b-9772a7ad29e5
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9073,15 +8821,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4832e0dae04649ae9fda3066a9d2fa7e
+      - fab986bc9b66491c9053ca37a6af92c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cdc47026-4cf6-4472-9d86-5d6d3694d193
+      - req-66bc261e-de69-4584-8a83-6ad6f872b518
       Content-Length:
       - '7278'
       Connection:
@@ -9093,7 +8841,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:05.231095Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:26.938235Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9172,10 +8920,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DlVdVbh7RTyhUgQOmbr8yg"],
-        "issued_at": "2018-09-26T18:38:05.231115Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kSLVBR9NRVC1psITGUub7g"],
+        "issued_at": "2018-10-25T18:23:26.938257Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -9190,7 +8938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4832e0dae04649ae9fda3066a9d2fa7e
+      - fab986bc9b66491c9053ca37a6af92c5
   response:
     status:
       code: 200
@@ -9201,16 +8949,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1d91a5bc-04ea-423a-ae74-6645daaa7908
+      - req-f7a298b8-babb-4544-ba36-33d897b933d9
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9225,7 +8973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9238,9 +8986,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-61b04f64-89a5-4b97-b7f0-ca28a3e22678
+      - req-550c7d2e-03c3-42f4-8ce0-1729c577fd5c
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9263,7 +9011,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9278,7 +9026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9291,9 +9039,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a1749feb-5b66-4877-84d2-9067598975d5
+      - req-ce1b3ebf-1e74-4848-95ba-ecce3c29eadd
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9316,7 +9064,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9331,7 +9079,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9344,9 +9092,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-96cc5969-8348-47b4-b01e-4ff9fae7473e
+      - req-2ecec3b6-fbe6-446a-bb2c-a9ffbbe0212b
       Date:
-      - Wed, 26 Sep 2018 18:38:05 GMT
+      - Thu, 25 Oct 2018 18:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9369,7 +9117,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9384,7 +9132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9397,9 +9145,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-706b55f2-af45-471a-9790-690d44a49b9e
+      - req-0e9424e7-0a2c-4b39-8d2e-24509b59f361
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9422,7 +9170,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9437,7 +9185,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9450,9 +9198,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-73ec94db-1470-48cd-8db8-0a1ad8d1708c
+      - req-ae9377a1-5916-4460-b5b6-62c4d99b88ae
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9475,7 +9223,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -9490,7 +9238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9503,15 +9251,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-cc8fed65-8902-4dce-be5e-0b2074b8b342
+      - req-7ac75672-6e1c-4860-9eed-f9d2908bfe0e
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9526,7 +9274,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9539,9 +9287,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-baad5a94-aba3-4174-bb3b-87f18e780f8e
+      - req-e658e389-5b5f-4f21-8683-72bea529568c
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9564,7 +9312,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9579,7 +9327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9592,15 +9340,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-b4545839-3caf-459f-9624-db342256b645
+      - req-f38908cf-27b4-48ac-aa0c-fae6dc45d03e
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9615,7 +9363,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9628,9 +9376,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-4d58d442-8125-4c65-9d69-e968a63d4c47
+      - req-08780e1b-35c3-466b-95e8-ba6e8705f440
       Date:
-      - Wed, 26 Sep 2018 18:38:06 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9653,7 +9401,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9668,7 +9416,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9681,9 +9429,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-66cbe7cb-2894-4bbb-8546-5cb8d192df26
+      - req-21216fcb-62ba-4ce6-9ed7-63d93dfb08c4
       Date:
-      - Wed, 26 Sep 2018 18:38:07 GMT
+      - Thu, 25 Oct 2018 18:23:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9706,7 +9454,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9721,7 +9469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4acd3e5250264550b2b311d89eed9351
+      - f3704f32307549d9ae9d8754d49694c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9734,9 +9482,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-c16cf626-252e-4679-8e71-7f8638d91bb4
+      - req-fbc79449-fdc8-4ef2-8749-393aba1a6889
       Date:
-      - Wed, 26 Sep 2018 18:38:07 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9759,13 +9507,13 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9777,15 +9525,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:07 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2845a0d66a7746c7911fb1003a77d831
+      - 91f2addda8dd4eeb953a3b605764778e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2f8c2903-96e0-404d-9e9e-b9d4d350c44e
+      - req-43a3f2c8-436a-4852-99dc-52340a2384dc
       Content-Length:
       - '7311'
       Connection:
@@ -9797,7 +9545,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:07.494650Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:29.279631Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9876,16 +9624,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6cs4QwyiS-SK8n70dbdVxg"],
-        "issued_at": "2018-09-26T18:38:07.494669Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["heIUFfV2TgeSY2QTa-EFIg"],
+        "issued_at": "2018-10-25T18:23:29.279652Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"2845a0d66a7746c7911fb1003a77d831"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9897,135 +9645,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:07 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 84ca3cbb0e2944318c0bd3e5e6b6e2cb
+      - 84d6245eeb704851bff7d935de1851b4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c462f337-89f2-4171-b056-3bb62d5beb80
-      Content-Length:
-      - '7346'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:07.494650Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x9UKzsJdRParkpHPBRd_yw",
-        "6cs4QwyiS-SK8n70dbdVxg"], "issued_at": "2018-09-26T18:38:07.681103Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:07 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:07 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 21a6a28f371f4a71b79f8bd670bbddab
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-8e404bfa-134c-4e76-94c7-6aca59ac34e3
+      - req-285a77a1-7610-491b-857b-15ecf0522310
       Content-Length:
       - '7311'
       Connection:
@@ -10037,7 +9665,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:07.873799Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:29.484587Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10116,130 +9744,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zYHJ6ZMIQ7qD4PBOdsIHAQ"],
-        "issued_at": "2018-09-26T18:38:07.873818Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DBNzH03iTXKnt-4mJaba7Q"],
+        "issued_at": "2018-10-25T18:23:29.484607Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:07 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"21a6a28f371f4a71b79f8bd670bbddab"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - b1a09132f9364052ae83889025aab15a
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-8bad3998-d3ae-4bd6-8f81-0012e85c95af
-      Content-Length:
-      - '7346'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:07.873799Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nttXDRiMRNCsoRHwoIhxxw",
-        "zYHJ6ZMIQ7qD4PBOdsIHAQ"], "issued_at": "2018-09-26T18:38:08.050952Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -10254,7 +9762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a2a66bbef014938ad8449c407cbfdc0
+      - d5e08decea854f9d9045e427794321a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10267,14 +9775,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-54362214-cd4f-4811-b184-4e78f9e5afa3
+      - req-3b7affa7-cf83-4950-a1cb-586392863b02
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -10289,27 +9797,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8592ab83-270f-4564-a2bb-515f554e1e6c
+      - req-96855370-94f8-4bd2-a9b2-823166434939
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8592ab83-270f-4564-a2bb-515f554e1e6c
+      - req-96855370-94f8-4bd2-a9b2-823166434939
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -10324,27 +9832,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0dc1f45-fb85-4f56-8705-f498c0c51519
+      - req-bd103677-2c57-40be-9da3-6da5e36420f5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d0dc1f45-fb85-4f56-8705-f498c0c51519
+      - req-bd103677-2c57-40be-9da3-6da5e36420f5
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -10359,22 +9867,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ac3b79e-e72a-422a-82d6-c2592a330f46
+      - req-6e4159bd-ba34-46f9-a293-e09d2e013f99
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-6ac3b79e-e72a-422a-82d6-c2592a330f46
+      - req-6e4159bd-ba34-46f9-a293-e09d2e013f99
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10407,7 +9915,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -10422,22 +9930,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b7ad8f2-8c78-4757-97f3-3cdc2638743e
+      - req-87d4a405-7955-4662-a330-f42b2c9ccf77
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-1b7ad8f2-8c78-4757-97f3-3cdc2638743e
+      - req-87d4a405-7955-4662-a330-f42b2c9ccf77
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -10454,7 +9962,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -10469,27 +9977,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e913c05-7694-4bcf-b87d-8c6ce5d51e84
+      - req-8824a436-80fc-47df-b64d-84889f62a17b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5e913c05-7694-4bcf-b87d-8c6ce5d51e84
+      - req-8824a436-80fc-47df-b64d-84889f62a17b
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -10504,27 +10012,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-55f8ff1b-68e7-4e3b-a09d-44da83018e74
+      - req-dbeadca5-ef16-4bf1-a0c4-8231be42fa5f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-55f8ff1b-68e7-4e3b-a09d-44da83018e74
+      - req-dbeadca5-ef16-4bf1-a0c4-8231be42fa5f
       Date:
-      - Wed, 26 Sep 2018 18:38:08 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -10539,27 +10047,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d57978c-302e-4ebf-a15c-250ab5f2e3c7
+      - req-5aa36745-557a-4155-948c-53d6b6a6c181
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5d57978c-302e-4ebf-a15c-250ab5f2e3c7
+      - req-5aa36745-557a-4155-948c-53d6b6a6c181
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -10574,27 +10082,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2bb3a460-5930-41bf-827c-b9868b8bd945
+      - req-92f9459a-56cd-408f-a7ed-911216a78495
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2bb3a460-5930-41bf-827c-b9868b8bd945
+      - req-92f9459a-56cd-408f-a7ed-911216a78495
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -10609,27 +10117,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-58f2c9bc-2232-4190-a6cc-bd1961fc9dbf
+      - req-a06ef15a-5f1f-45b1-ad0b-de06cd858e5a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-58f2c9bc-2232-4190-a6cc-bd1961fc9dbf
+      - req-a06ef15a-5f1f-45b1-ad0b-de06cd858e5a
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -10644,27 +10152,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa6c3de2-6292-4a39-ab81-03cd1aea1875
+      - req-c2a1abae-ab29-4742-8b76-3659e9ac35b5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fa6c3de2-6292-4a39-ab81-03cd1aea1875
+      - req-c2a1abae-ab29-4742-8b76-3659e9ac35b5
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -10679,27 +10187,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4816b7f1-fdc0-48d4-b272-d189f66e3549
+      - req-2b6fb03c-a5df-44fe-92ce-1765f154c598
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4816b7f1-fdc0-48d4-b272-d189f66e3549
+      - req-2b6fb03c-a5df-44fe-92ce-1765f154c598
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -10714,27 +10222,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b350ded-b180-4469-b93d-1914680c7393
+      - req-770d7907-42af-4c6c-8bdd-2ba2555f8c12
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6b350ded-b180-4469-b93d-1914680c7393
+      - req-770d7907-42af-4c6c-8bdd-2ba2555f8c12
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -10749,22 +10257,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16bd3c0b-9a35-4940-915e-047879154c95
+      - req-7af9f0f5-050d-4f58-bcee-0ae635a983af
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-16bd3c0b-9a35-4940-915e-047879154c95
+      - req-7af9f0f5-050d-4f58-bcee-0ae635a983af
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10779,7 +10287,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -10794,22 +10302,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-47be99ac-5897-42d7-8318-b3b99f0c99d1
+      - req-da667e53-4fd0-4436-9d5f-5a59ef38c164
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-47be99ac-5897-42d7-8318-b3b99f0c99d1
+      - req-da667e53-4fd0-4436-9d5f-5a59ef38c164
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10824,7 +10332,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -10839,27 +10347,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d0ca28e-2f7f-49b0-908b-176c376bd6bf
+      - req-d38b5b8c-0424-40b5-b221-c2cb965d9681
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0d0ca28e-2f7f-49b0-908b-176c376bd6bf
+      - req-d38b5b8c-0424-40b5-b221-c2cb965d9681
       Date:
-      - Wed, 26 Sep 2018 18:38:09 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -10874,27 +10382,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4551ea3c-2799-4531-a0ef-352701a5ee6d
+      - req-bde6f186-a431-4ff5-abf5-b9e03a856eea
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4551ea3c-2799-4531-a0ef-352701a5ee6d
+      - req-bde6f186-a431-4ff5-abf5-b9e03a856eea
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -10909,27 +10417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-227bc911-9344-434c-b09e-d2ca2842e0a1
+      - req-5ae8c6ba-1f7a-4b55-acd0-6b4a6f1fcdeb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-227bc911-9344-434c-b09e-d2ca2842e0a1
+      - req-5ae8c6ba-1f7a-4b55-acd0-6b4a6f1fcdeb
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -10944,27 +10452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4204b982-d11a-4f89-9d6c-5e4b65a92807
+      - req-56b10ec0-9ca7-4598-829e-835c3bb7e28f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4204b982-d11a-4f89-9d6c-5e4b65a92807
+      - req-56b10ec0-9ca7-4598-829e-835c3bb7e28f
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10979,27 +10487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0eb696d2-1fcd-406b-b63b-b636b9ab3192
+      - req-8f9118d6-8032-4f88-af7e-b993f49ac30b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0eb696d2-1fcd-406b-b63b-b636b9ab3192
+      - req-8f9118d6-8032-4f88-af7e-b993f49ac30b
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -11014,27 +10522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ca045c1-4495-426c-b7fb-ff67c7fcb0fa
+      - req-7704632e-4d12-4f5b-89a1-d1255845caef
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0ca045c1-4495-426c-b7fb-ff67c7fcb0fa
+      - req-7704632e-4d12-4f5b-89a1-d1255845caef
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11049,27 +10557,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-92b6853c-b58f-4d26-903d-6597907298ad
+      - req-652accdb-65f0-4970-9dcd-10916aa18cb4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-92b6853c-b58f-4d26-903d-6597907298ad
+      - req-652accdb-65f0-4970-9dcd-10916aa18cb4
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -11084,27 +10592,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-33bbcb85-f56b-4160-bb8d-4cc6966760a5
+      - req-f29ee310-754d-49b0-a9c3-556457ae0e51
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-33bbcb85-f56b-4160-bb8d-4cc6966760a5
+      - req-f29ee310-754d-49b0-a9c3-556457ae0e51
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11119,27 +10627,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fae11666875a40dc9f1373ee5df1c6f2
+      - af0c0dc7d33e455795f54919f18c62e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-927c86eb-7743-4900-b36e-62cc3b0d30bd
+      - req-f01c38ea-ddc9-4cb6-99a1-8661e46b000e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-927c86eb-7743-4900-b36e-62cc3b0d30bd
+      - req-f01c38ea-ddc9-4cb6-99a1-8661e46b000e
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11154,27 +10662,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0addb1130b4a4e5880cfd5b950fdf4a2
+      - 40df23f85caf4012800eb3fcfc9892f8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-da3f66c6-53e0-425e-940a-f840bcf9d2af
+      - req-a4b5d01d-a944-4828-a902-5f5749498c77
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-da3f66c6-53e0-425e-940a-f840bcf9d2af
+      - req-a4b5d01d-a944-4828-a902-5f5749498c77
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11189,22 +10697,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e0d5452-60e9-48e6-9527-08d7a568b128
+      - req-6b02bc8b-bccd-4fd7-b617-9a533129993f
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-4e0d5452-60e9-48e6-9527-08d7a568b128
+      - req-6b02bc8b-bccd-4fd7-b617-9a533129993f
       Date:
-      - Wed, 26 Sep 2018 18:38:10 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11237,7 +10745,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11252,22 +10760,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4af6b74d-8cc9-4f66-a9bc-a362991bfa3c
+      - req-c2897109-e9bc-4e3a-9dc7-6849b9724fbb
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-4af6b74d-8cc9-4f66-a9bc-a362991bfa3c
+      - req-c2897109-e9bc-4e3a-9dc7-6849b9724fbb
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11308,7 +10816,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11323,22 +10831,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6afec224-35c4-4f76-9022-dba5dec2025c
+      - req-c06519c0-18ac-4fe5-8028-20d2942eaf7b
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-6afec224-35c4-4f76-9022-dba5dec2025c
+      - req-c06519c0-18ac-4fe5-8028-20d2942eaf7b
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11372,7 +10880,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11387,27 +10895,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c58413ea2f8640eb8af46b2befd62c6f
+      - af141bbba50d4c7682fc8e0ef20fa8b0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb2b9ad7-d011-476d-8dca-48c14bec2769
+      - req-1fbc69ab-15bc-4183-924b-eda1a0dd1300
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bb2b9ad7-d011-476d-8dca-48c14bec2769
+      - req-1fbc69ab-15bc-4183-924b-eda1a0dd1300
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11422,27 +10930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da318e6cab7748dea626683efb14e8f8
+      - 4c95374afc0046328c9725d0f7aa1ee9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6c5e1b6-30f6-42b2-8c68-8bbe1e53fb9a
+      - req-51354c60-fe64-48e2-8b64-9b3948a7937c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c6c5e1b6-30f6-42b2-8c68-8bbe1e53fb9a
+      - req-51354c60-fe64-48e2-8b64-9b3948a7937c
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11457,27 +10965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7bcba72d7bc140f3ac54ba2d0f568b30
+      - 33a0d96815174b8aa583a7ca218f6c04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d6d301c-79cb-443a-9dce-9c91521da1fb
+      - req-14b89e13-55fe-4d33-9673-2a0474234acf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5d6d301c-79cb-443a-9dce-9c91521da1fb
+      - req-14b89e13-55fe-4d33-9673-2a0474234acf
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11492,27 +11000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0e978945153d4149a7bff1fbd5471efe
+      - b76000d73bb449eeab41eed995219e04
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99e9612f-6738-4ca2-88a2-ace1c38417be
+      - req-b16eb563-c94b-4e9b-b43d-afcbb2332d87
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-99e9612f-6738-4ca2-88a2-ace1c38417be
+      - req-b16eb563-c94b-4e9b-b43d-afcbb2332d87
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11527,33 +11035,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a8d8c4f61e04468b7a1d52eea74ad28
+      - ddc3d137ab67417fad7b53b1298dd5f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-36957c0e-c6d6-49b7-96b3-4d3716fa3f8f
+      - req-8095280a-0a8e-497e-b062-9ccf4a6361e5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-36957c0e-c6d6-49b7-96b3-4d3716fa3f8f
+      - req-8095280a-0a8e-497e-b062-9ccf4a6361e5
       Date:
-      - Wed, 26 Sep 2018 18:38:11 GMT
+      - Thu, 25 Oct 2018 18:23:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11565,15 +11073,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:14 GMT
+      - Thu, 25 Oct 2018 18:23:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b325da95047d496a9f3988c3bdf94422
+      - c189d6d9bc994a9fbf8c3f5802a82f6c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-39428e98-91f0-4edb-a32e-82e2f0f93908
+      - req-be644ebb-081b-49de-8104-98b2bb83b894
       Content-Length:
       - '7311'
       Connection:
@@ -11585,7 +11093,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:14.575079Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:34.848016Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11664,16 +11172,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8U85P8M5SDmARyUyZpWsaQ"],
-        "issued_at": "2018-09-26T18:38:14.575099Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NLa_yjJ3SZaxwpJtSxU1rg"],
+        "issued_at": "2018-10-25T18:23:34.848037Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11685,15 +11193,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:14 GMT
+      - Thu, 25 Oct 2018 18:23:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-228caedb-9791-4eb0-a6a4-4044ad060cb1
+      - req-14b761b6-73ea-4062-8faf-cbef002ab10b
       Content-Length:
       - '7311'
       Connection:
@@ -11705,7 +11213,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:14.772447Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:35.050604Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11784,10 +11292,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iBehYFSkSrCXpaJl2PsJdQ"],
-        "issued_at": "2018-09-26T18:38:14.772466Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qiPhQpT2TL-2VT_8_uk0xw"],
+        "issued_at": "2018-10-25T18:23:35.050626Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -11802,7 +11310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -11813,22 +11321,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-d95bcfa4-fbb5-4f0e-8347-c93f8c2842a6
+      - req-15a51ff9-590b-4560-ae87-268a9997bc4e
       Date:
-      - Wed, 26 Sep 2018 18:38:14 GMT
+      - Thu, 25 Oct 2018 18:23:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
         "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -11838,6 +11336,11 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
@@ -11848,50 +11351,55 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        31}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        59}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        13}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11903,15 +11411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
+      - Thu, 25 Oct 2018 18:23:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bc867d394e148cd9d80168c6c940ac3
+      - 8e16167250ec47f2b108cd70bc9cc787
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c2311bb0-fbfe-4976-a633-902d167572fe
+      - req-44f41342-1f5a-47e6-894f-b20515bc5b3b
       Content-Length:
       - '7311'
       Connection:
@@ -11923,7 +11431,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:15.107308Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:23:35.391533Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12002,16 +11510,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6Xj1z1NgQwCdYph5VM1xNA"],
-        "issued_at": "2018-09-26T18:38:15.107329Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XVcT-gBNS8O8tMt0lA882Q"],
+        "issued_at": "2018-10-25T18:23:35.391554Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12023,15 +11531,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
+      - Thu, 25 Oct 2018 18:23:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bdf355f859654a6593097886821cc54b
+      - 7194695b7af6423aaea002585dd94416
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1993d32e-acd4-4a4d-93aa-c6308ca2f4a6
+      - req-1fefbdd4-5ba1-4c2b-bf5b-e90018f4e028
       Content-Length:
       - '297'
       Connection:
@@ -12040,15 +11548,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:38:15.270724Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:23:35.558630Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iAppvMNfS2eFk-FeR0cnyQ"],
-        "issued_at": "2018-09-26T18:38:15.270742Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NluokNZ3SsWsUjraHNumVQ"],
+        "issued_at": "2018-10-25T18:23:35.558649Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -12060,29 +11568,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdf355f859654a6593097886821cc54b
+      - 7194695b7af6423aaea002585dd94416
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
+      - Thu, 25 Oct 2018 18:23:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-05023a43-4ec4-4b09-83b2-215ad0e0985c
+      - req-920e200e-c906-46b7-97c4-fa45eea6c506
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -12106,13 +11614,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"bdf355f859654a6593097886821cc54b"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12124,27 +11632,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
+      - Thu, 25 Oct 2018 18:23:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 812c08ef429243bfbb40bd5def952339
+      - 878b79a3862e48baa94b6172632086f1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fe07956f-f29b-47fb-b2f5-f3b35543f575
+      - req-a2b0a0a8-a26c-4f2d-bd23-de6b63cd94e9
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:15.270724Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:35.898621Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12223,77 +11731,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nLfgFYleTMieyQw-AYjh0A",
-        "iAppvMNfS2eFk-FeR0cnyQ"], "issued_at": "2018-09-26T18:38:15.583131Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N1TZciWISdOVP47fEPNJUA"],
+        "issued_at": "2018-10-25T18:23:35.898643Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 812c08ef429243bfbb40bd5def952339
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-fac875ad-020e-48bd-a711-adfb23766165
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12305,15 +11752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:15 GMT
+      - Thu, 25 Oct 2018 18:23:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c3b3268ac1264a688f64c7762b5d2f30
+      - 7e6af8e7383b4dfab4c46156d8621990
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d42e5223-1d1c-421e-a3b1-5f86047bb98a
+      - req-c94fbdc7-934e-4cf2-981a-ec1448a37091
       Content-Length:
       - '7278'
       Connection:
@@ -12325,127 +11772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:15.871392Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zyDMd8LoSyG-VYnzDVfR2g"],
-        "issued_at": "2018-09-26T18:38:15.871411Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:15 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 5c317347fabd4b2ca2a926530460e4cb
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-2db6d093-f6d4-4694-ab21-96d35c4c6fb2
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:16.058268Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:36.094239Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12524,16 +11851,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_4hbEntfTUGT6Zkj1aNLUw"],
-        "issued_at": "2018-09-26T18:38:16.058286Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vY3VMbu3Tz2Q0pSBhK0xFw"],
+        "issued_at": "2018-10-25T18:23:36.094260Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12545,15 +11872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
+      - Thu, 25 Oct 2018 18:23:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bb79a6b79c184194be41dfb59c635eeb
+      - 6cca12e1cfc54261a53c64dfb342b99b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c0714cd8-6493-4bc1-bc92-e5ad36299f64
+      - req-c076a32e-a834-495b-89d0-f4ab506d3002
       Content-Length:
       - '7264'
       Connection:
@@ -12565,7 +11892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:16.255775Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:36.293567Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12644,16 +11971,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z0S0Gzl6QrCV6vOjAb1vog"],
-        "issued_at": "2018-09-26T18:38:16.255796Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jOiYGwrJRtGYzzpk4HWtqg"],
+        "issued_at": "2018-10-25T18:23:36.293585Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12665,15 +11992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
+      - Thu, 25 Oct 2018 18:23:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3196a3791584d349a95aa9c338280f4
+      - 95645d8247de4f099bb7b908e5348b70
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fbff0d86-d93a-40ff-8cb5-246009965832
+      - req-d7f2075d-2515-4639-b7c6-7c65aeaabba3
       Content-Length:
       - '7278'
       Connection:
@@ -12685,7 +12012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:16.441369Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:36.492584Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12764,16 +12091,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XTKNN7KdQSG4Nufu7kxESA"],
-        "issued_at": "2018-09-26T18:38:16.441388Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9NkcUo1NRfSaBaotjW84LA"],
+        "issued_at": "2018-10-25T18:23:36.492603Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12785,15 +12112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
+      - Thu, 25 Oct 2018 18:23:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 66d8fa33724f46e4ae33fff5cdffa506
+      - cd9da9be9c944719a803c695a8e5c02c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ecf3c215-9e8e-4db6-b748-b36c65c30ed6
+      - req-f0ac65b1-925f-44e9-83ed-0af401e68bfc
       Content-Length:
       - '7265'
       Connection:
@@ -12805,7 +12132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:16.640094Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:36.694022Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12884,16 +12211,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m4XMRC8mSsmBPUfm9Si8xw"],
-        "issued_at": "2018-09-26T18:38:16.640127Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UG73LZVqTqe0RRvr9IDQbw"],
+        "issued_at": "2018-10-25T18:23:36.694043Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12905,15 +12232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
+      - Thu, 25 Oct 2018 18:23:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ab504129e67c4995af6e4b2acb046491
+      - ef5c8e7541da431cbb4c0d470b5a516e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-85fe5f34-3ce2-4fa9-8171-367bdbe60cbf
+      - req-17f1d26f-1c99-4acd-aec4-a1589e783454
       Content-Length:
       - '7278'
       Connection:
@@ -12925,7 +12252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:16.843272Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:36.893740Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13004,16 +12331,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zzUq6sPtTzaJLPddADOoCw"],
-        "issued_at": "2018-09-26T18:38:16.843295Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FfzdmXoPQYmrYvYu6gMcnQ"],
+        "issued_at": "2018-10-25T18:23:36.893773Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13025,15 +12352,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:16 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fa109789216740c5b225d81306837fc4
+      - f58da1f4da954aa2af5b0cd84d7f21ab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-360ff7fe-4b4f-4e49-81b2-bb4557028e96
+      - req-4c67453b-0a87-4083-81d4-6ca8acd7e3eb
       Content-Length:
       - '7278'
       Connection:
@@ -13045,7 +12372,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:17.056181Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:37.100170Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13124,10 +12451,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KndKmZgGRimwS3bmSw4Hlw"],
-        "issued_at": "2018-09-26T18:38:17.056204Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZGEnfti0Q2uZuTPRlZlZOQ"],
+        "issued_at": "2018-10-25T18:23:37.100192Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -13142,7 +12469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa109789216740c5b225d81306837fc4
+      - f58da1f4da954aa2af5b0cd84d7f21ab
   response:
     status:
       code: 200
@@ -13153,20 +12480,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7ff10570-e44e-47ce-8c06-2e8f810da7e4
+      - req-d58fd1af-6b1c-40d1-9755-55017ff2ef6a
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13178,15 +12505,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4e11506311d24a8e9055cd02583ef882
+      - 57e81df591f7407389aa03b21ed51da1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ddab5fba-a8dd-4eb8-8716-39d58438d83f
+      - req-db00f0f5-1a1d-4912-8bba-1e2f9cb15091
       Content-Length:
       - '7278'
       Connection:
@@ -13198,7 +12525,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:17.386978Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:37.424152Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13277,10 +12604,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8QBkkBiESEm6l-nalsOasg"],
-        "issued_at": "2018-09-26T18:38:17.387014Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w3jyCsOfTsqTgmExo0cHrQ"],
+        "issued_at": "2018-10-25T18:23:37.424173Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -13295,7 +12622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e11506311d24a8e9055cd02583ef882
+      - 57e81df591f7407389aa03b21ed51da1
   response:
     status:
       code: 200
@@ -13306,20 +12633,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c60b7e9d-589e-413c-ac9e-ff961880a6ca
+      - req-5a510e37-30dd-47cf-9e4f-46758d84d786
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13331,15 +12658,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-58982602-09dc-4ebc-bf3e-a0a9a0c9eb4d
+      - req-7624af31-4beb-44e0-8510-b94e4782fe61
       Content-Length:
       - '7264'
       Connection:
@@ -13351,7 +12678,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:17.712969Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:37.748666Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13430,10 +12757,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4vCg6zL_QE2lM1DDC2ClHQ"],
-        "issued_at": "2018-09-26T18:38:17.713018Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FsH2IhsXQmmybBRGzpCxww"],
+        "issued_at": "2018-10-25T18:23:37.748687Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -13448,7 +12775,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -13459,9 +12786,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d5ce0c2c-4907-4728-9409-dfd524f35188
+      - req-940df5df-6996-4503-95ea-defb12448bd3
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -13495,7 +12822,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -13510,7 +12837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -13521,20 +12848,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2d0b3bda-1151-40f9-8c23-cad29049595b
+      - req-0972e4ac-7d18-4566-8add-b2be13442e4e
       Date:
-      - Wed, 26 Sep 2018 18:38:17 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13546,15 +12873,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 21de6ce604114d23bfff4d5ff80d9591
+      - 65f9ac6e647d4ba3aa14c0ffadf748a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3bb9680b-a866-42bf-a99d-e7bc5bb0f7cd
+      - req-95ed8bf0-9bd8-4f94-b880-582556beae6d
       Content-Length:
       - '7278'
       Connection:
@@ -13566,7 +12893,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:18.149801Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:38.202619Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13645,10 +12972,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2TOBzTSGSbqeMYFBhyUzpQ"],
-        "issued_at": "2018-09-26T18:38:18.149822Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["35RQG6F3T2mTSKGiNgL6uw"],
+        "issued_at": "2018-10-25T18:23:38.202640Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -13663,7 +12990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21de6ce604114d23bfff4d5ff80d9591
+      - 65f9ac6e647d4ba3aa14c0ffadf748a6
   response:
     status:
       code: 200
@@ -13674,14 +13001,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d0ed029f-ef2b-4656-9caa-24eea7e2d606
+      - req-7b86a8d7-2ff3-412b-835b-5509f3d5407d
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -13696,7 +13023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bc867d394e148cd9d80168c6c940ac3
+      - 8e16167250ec47f2b108cd70bc9cc787
   response:
     status:
       code: 200
@@ -13707,20 +13034,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-48a4a9b7-39ee-4866-b1b3-5740cacf54f5
+      - req-521618aa-bffb-4993-8508-66ff4dd9cd47
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13732,15 +13059,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 88d392dc84034a038110a31b96b51449
+      - 190692da52be495a94895799d7fa5a49
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78006160-fe73-4cd8-ab9b-8b699368bec6
+      - req-9b74cdf9-0c60-4a5f-a085-762ec969a4a9
       Content-Length:
       - '7265'
       Connection:
@@ -13752,7 +13079,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:18.581486Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:38.646223Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13831,10 +13158,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RF1d92y_QoWTUfsJcKk-UQ"],
-        "issued_at": "2018-09-26T18:38:18.581506Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_MQMWeM5QHe0J3AUudVUPg"],
+        "issued_at": "2018-10-25T18:23:38.646244Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -13849,7 +13176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 88d392dc84034a038110a31b96b51449
+      - 190692da52be495a94895799d7fa5a49
   response:
     status:
       code: 200
@@ -13860,20 +13187,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-acae9592-a5bc-4d04-a23d-edfc54547e45
+      - req-87de3328-9d9e-4bb2-9ce4-7023ed10d806
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13885,15 +13212,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:18 GMT
+      - Thu, 25 Oct 2018 18:23:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 17aeb7b71d044b37916bc3abeafe0124
+      - 77f9f0a7fd4e4a17b137b85509c433f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-be5b7a01-e004-420c-b9df-e8be7bd9d9ef
+      - req-5bf7f788-d2bb-4ce8-b2a3-4b8619371d24
       Content-Length:
       - '7278'
       Connection:
@@ -13905,7 +13232,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:18.893184Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:38.981439Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13984,10 +13311,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["99auYAD4THa3jnxisMwelQ"],
-        "issued_at": "2018-09-26T18:38:18.893204Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_e9KvGYCRZyn3DuRYmjwQQ"],
+        "issued_at": "2018-10-25T18:23:38.981462Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -14002,7 +13329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17aeb7b71d044b37916bc3abeafe0124
+      - 77f9f0a7fd4e4a17b137b85509c433f0
   response:
     status:
       code: 200
@@ -14013,14 +13340,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-79cf9672-a9e6-47ce-964e-76c9316bf479
+      - req-7edf233d-050a-4dbc-9627-ccbb6d929c75
       Date:
-      - Wed, 26 Sep 2018 18:38:19 GMT
+      - Thu, 25 Oct 2018 18:23:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -14035,7 +13362,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14046,9 +13373,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-17f0439e-3c06-4b2c-a4f3-c470f17f1e5f
+      - req-846b2135-de54-491d-a0ab-d637b6d83cbd
       Date:
-      - Wed, 26 Sep 2018 18:38:19 GMT
+      - Thu, 25 Oct 2018 18:23:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14075,7 +13402,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -14090,7 +13417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14101,9 +13428,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ec3c466d-6f35-4f93-ae34-8cc2a2a29549
+      - req-ff18fa29-1564-4fa5-830a-8c537659d3f2
       Date:
-      - Wed, 26 Sep 2018 18:38:19 GMT
+      - Thu, 25 Oct 2018 18:23:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14130,7 +13457,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -14145,7 +13472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14156,9 +13483,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c030743b-0a3c-4c8b-90bc-06757ee37365
+      - req-2bfc3b8a-48ea-487f-8f9b-e58f3249a627
       Date:
-      - Wed, 26 Sep 2018 18:38:19 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14185,7 +13512,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -14200,7 +13527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14211,9 +13538,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6dbf5ad4-653a-40fb-b119-c5c7f19e1da8
+      - req-80130b8d-2968-4ddc-bc30-949b71982e0a
       Date:
-      - Wed, 26 Sep 2018 18:38:19 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14225,7 +13552,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -14240,7 +13567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14251,9 +13578,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0b8f5884-750d-4c83-b690-ccb1cfd3884b
+      - req-4f27770a-d28b-442f-958b-900efaf34e96
       Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14265,7 +13592,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -14280,7 +13607,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06bb4d10b54c4f18b49428b8b8f33865
+      - d31c9ee5542d4b02801b15d4137e1b8b
   response:
     status:
       code: 200
@@ -14291,9 +13618,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-8af33678-dc0e-4b84-b78d-cb617935a717
+      - req-19d5924d-5b83-42a8-b0b0-1cae50dd559a
       Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14305,13 +13632,13 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14323,15 +13650,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47469c91-df2d-4ba4-b8d1-f709777ff75a
+      - req-3cf93e11-4b5d-42fd-b834-16ae33f30288
       Content-Length:
       - '7278'
       Connection:
@@ -14343,7 +13670,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:20.349638Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:40.588062Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14422,10 +13749,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ULEOeu2PRJuYSyn9lTGZMw"],
-        "issued_at": "2018-09-26T18:38:20.349658Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2gdwBpTZRv6NHWWgKjeziw"],
+        "issued_at": "2018-10-25T18:23:40.588085Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14440,7 +13767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -14451,49 +13778,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-44091370-2443-44ed-8fdd-3a86a9fdfa2d
+      - req-b5a444f4-19a0-4617-b7e6-1428f0bfc2c6
       Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -14539,102 +13830,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d297fbf3-3a64-4c9a-a23f-aec9d5b7479c
-      Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
@@ -14653,92 +13854,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-246249d5-5e91-4fce-ab81-5b8832d79a0b
-      Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
@@ -14756,72 +13871,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14836,7 +13899,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -14847,23 +13910,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-37f4507a-303a-414f-88af-6a11bfad3fc5
+      - req-163d1e18-0d10-4515-9d14-34bd0afff97a
       Date:
-      - Wed, 26 Sep 2018 18:38:20 GMT
+      - Thu, 25 Oct 2018 18:23:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -14875,11 +13967,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -14887,12 +13985,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -14910,168 +14002,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-762564ef-69ae-4d1b-8f01-06a26c7e9e22
-      Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -15085,145 +14015,13 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4eecee9c-ccf8-4a7b-bbd5-c8aaf171055c
-      Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15235,15 +14033,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8726a81e-a41f-4d7e-99eb-e85523f80040
+      - req-8bb9eda9-7eee-48eb-a49b-83d6597ef73c
       Content-Length:
       - '7278'
       Connection:
@@ -15255,7 +14053,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:21.466795Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:41.126334Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15334,10 +14132,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q590KLI0SvKmBIpiGefRlA"],
-        "issued_at": "2018-09-26T18:38:21.466814Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jA7ok5EnSb-wxmdE-Hs56Q"],
+        "issued_at": "2018-10-25T18:23:41.126355Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15352,7 +14150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -15363,9 +14161,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ed56dd85-1bba-44ee-86e2-a06258403686
+      - req-92e686d7-8dd2-4a01-b136-7d5205ee6e6b
       Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -15469,7 +14267,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15484,7 +14282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -15495,49 +14293,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dbbf1880-3c2b-4aba-b605-1eae2ad72c31
+      - req-63f559aa-5754-4a87-9415-14396f7137e6
       Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -15583,31 +14345,67 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15619,15 +14417,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:21 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b49ad07a-55e4-4498-afe6-efc4a6525eef
+      - req-c5402aba-d973-459e-a5ca-51ee094946a5
       Content-Length:
       - '7264'
       Connection:
@@ -15639,7 +14437,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:21.986269Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:41.659751Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15718,10 +14516,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JScMyVo_RZONymxKdplvfw"],
-        "issued_at": "2018-09-26T18:38:21.986291Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4cEQ0h-WRZeqvLZnG6wsPA"],
+        "issued_at": "2018-10-25T18:23:41.659783Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15736,7 +14534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -15747,49 +14545,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bcf9f2b4-9200-413a-b99b-56d8161df4d6
+      - req-d3df6035-7246-48e1-b82e-54e53a38704a
       Date:
-      - Wed, 26 Sep 2018 18:38:22 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -15835,25 +14597,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15868,7 +14666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -15879,64 +14677,63 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f8c9c4dc-9344-473d-9f44-668ca4a8efa8
+      - req-fce97bf5-9938-4b91-a277-b8030b1092ab
       Date:
-      - Wed, 26 Sep 2018 18:38:22 GMT
+      - Thu, 25 Oct 2018 18:23:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
         "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -15944,16 +14741,10 @@ http_interactions:
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -15972,6 +14763,12 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -15985,13 +14782,13 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16003,15 +14800,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:22 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6730c713-79da-4558-9ab5-448043231855
+      - req-9ab00f5b-162a-49e0-83d0-ebebdad6698b
       Content-Length:
       - '7278'
       Connection:
@@ -16023,7 +14820,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:22.564608Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:42.204583Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16102,10 +14899,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TSEXZtqkT3SdogYGZUoJLw"],
-        "issued_at": "2018-09-26T18:38:22.564633Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OEq8qSlWSPqA4qq66008vQ"],
+        "issued_at": "2018-10-25T18:23:42.204605Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16120,7 +14917,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -16131,23 +14928,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c51b6c74-79bd-4deb-822e-9140a7fb0275
+      - req-807d1a39-5594-4258-8031-84a2f45b0f33
       Date:
-      - Wed, 26 Sep 2018 18:38:22 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -16159,11 +14985,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -16171,12 +15003,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -16194,53 +15020,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -16252,7 +15048,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -16263,33 +15059,75 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f7b098ae-29ff-4137-9baf-874a4818c665
+      - req-a4ba6847-862d-4193-9bb8-90aba2c0b68a
       Date:
-      - Wed, 26 Sep 2018 18:38:22 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
@@ -16303,12 +15141,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -16320,56 +15152,20 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16384,7 +15180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -16395,23 +15191,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e1a16d49-89a2-4b47-8e4e-237e6a15d7ec
+      - req-87aeef68-336c-4141-8529-f3c29a4af0b3
       Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -16423,11 +15248,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -16435,12 +15266,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -16458,53 +15283,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -16516,7 +15311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -16527,33 +15322,75 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c26e2997-8afd-42f7-adf3-4056915104a7
+      - req-d14b611f-acab-47ec-ac8c-f98fccd71794
       Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
@@ -16567,12 +15404,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -16584,62 +15415,26 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16651,15 +15446,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
+      - Thu, 25 Oct 2018 18:23:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-36348ac8-3efe-4563-8599-c3f771ef278d
+      - req-f5587fc3-c56a-4c0e-84f9-ff4f098783b3
       Content-Length:
       - '7265'
       Connection:
@@ -16671,7 +15466,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:23.379137Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:43.060249Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16750,10 +15545,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WiXWwcAfSUOrAeq3s8bHuQ"],
-        "issued_at": "2018-09-26T18:38:23.379157Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qpVl8eUEQUugc9xkijensA"],
+        "issued_at": "2018-10-25T18:23:43.060278Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16768,7 +15563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -16779,23 +15574,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d72d159c-4528-4d9d-a165-7d71b982a935
+      - req-06570cc8-9698-4b92-ab15-71c29e5c7a1d
       Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
+      - Thu, 25 Oct 2018 18:23:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -16807,11 +15631,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -16819,12 +15649,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -16842,168 +15666,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1abbf0d6-2d65-4df9-8dff-cb33fcbc0286
-      Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -17017,7 +15679,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -17032,7 +15694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -17043,23 +15705,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4064e0d7-9da1-4dc3-8410-ce8a1ee1c15f
+      - req-8c8d9f99-7a30-451b-994e-92ed3b463650
       Date:
-      - Wed, 26 Sep 2018 18:38:23 GMT
+      - Thu, 25 Oct 2018 18:23:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -17071,11 +15762,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -17083,12 +15780,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -17106,168 +15797,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:23 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3bb6fc03-26c8-44a2-abbe-0ee915aea804
-      Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -17281,277 +15810,13 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0a85cae6-c81d-4a47-8347-05190fe8c22a
-      Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-16af36ed-50c7-4fd3-a678-c4b4f260e5db
-      Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17563,15 +15828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
+      - Thu, 25 Oct 2018 18:23:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a1cd3bbe-ec92-4d30-b817-21d4d34ac684
+      - req-c41f7314-9b6b-495b-8be7-dfbc564e9fe1
       Content-Length:
       - '7278'
       Connection:
@@ -17583,7 +15848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:24.551070Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:43.605176Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17662,10 +15927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aRuXkMU-TvOqn2O_HaZdSg"],
-        "issued_at": "2018-09-26T18:38:24.551092Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_CgkLie2ThCjS9kvN01Q5Q"],
+        "issued_at": "2018-10-25T18:23:43.605198Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -17680,7 +15945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -17691,9 +15956,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d0062b6b-7882-4d56-bde9-eec80d0ed18c
+      - req-f0097441-0280-49b3-a928-90ac3f40ef6e
       Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
+      - Thu, 25 Oct 2018 18:23:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -17797,7 +16062,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -17812,7 +16077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -17823,49 +16088,13 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a03294b7-cea4-4b0f-a998-ee1a39e1dc7c
+      - req-ee9f5eab-716f-4839-b089-401bafe0af17
       Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
+      - Thu, 25 Oct 2018 18:23:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -17911,25 +16140,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17944,7 +16209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -17955,9 +16220,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b12189aa-fb36-4d59-8132-c3ce2d6aa867
+      - req-925e2f9d-e371-40b5-8c45-327bc881ee3a
       Date:
-      - Wed, 26 Sep 2018 18:38:24 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17999,7 +16264,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18014,7 +16279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -18025,9 +16290,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c6e8e7de-5339-4889-bb6c-ef83aa693634
+      - req-2a073e37-e1f7-45fd-b8ed-a843dbc2ae0e
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18069,7 +16334,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18084,7 +16349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -18095,9 +16360,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c63d4df8-1cd1-4956-94a9-d31b45f89871
+      - req-27563458-dfb6-4944-a892-55cfaba07d83
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18139,7 +16404,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18154,7 +16419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -18165,9 +16430,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-08fa6a04-265a-4f50-bdba-98a23cd4ca95
+      - req-8efd8a8c-72e0-4670-a47c-ee94166d4c0d
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18209,7 +16474,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18224,7 +16489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -18235,9 +16500,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-26ef4959-109b-46c7-88a3-e6cd5ea6852e
+      - req-a9e069d8-f5b9-4eaa-9e44-b13a0dc88ca7
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18279,7 +16544,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18294,7 +16559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -18305,9 +16570,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c8d7caee-5e70-4fea-8cfa-025cd90c7b4f
+      - req-4bae1713-1f95-47e4-9d9a-da2891bd1de9
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18349,7 +16614,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18364,7 +16629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -18375,9 +16640,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-04588701-708a-48e9-999f-19742d634072
+      - req-063dd348-72ff-4d80-8e45-7838921b8188
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18419,7 +16684,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18434,7 +16699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -18445,9 +16710,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e07832aa-e60b-42bc-acde-418ba8cd22b0
+      - req-76338af0-ac12-446e-8385-60bd7aeb10b3
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18489,7 +16754,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18504,7 +16769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -18515,9 +16780,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a5be7c7d-387c-4bcd-adad-e5d6b70a9d89
+      - req-1f8e6d1e-95a1-49fa-87e8-d3a47bc4e665
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18559,7 +16824,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18574,7 +16839,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -18585,9 +16850,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-58dc07f2-1516-49fb-a706-292033364d9c
+      - req-29973715-cf36-4788-9530-30fa652d3ef4
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18629,7 +16894,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18644,7 +16909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -18655,9 +16920,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ddcd57be-35e3-451a-8816-2b026cfa29a7
+      - req-177df783-a0c1-417d-97f6-0ca7dcef7c3a
       Date:
-      - Wed, 26 Sep 2018 18:38:25 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18699,7 +16964,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18714,7 +16979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -18725,9 +16990,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1be5f9cf-2764-4e23-8b9f-4eb8c4a4670a
+      - req-07ebc7fd-ef25-4c7b-a1fc-5d937117a2eb
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18769,7 +17034,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -18784,7 +17049,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -18795,9 +17060,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c73d5a14-44c9-4adb-8e68-47dfffe62e91
+      - req-9a56dc0c-a868-42ec-9ee7-14e821d9d802
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18839,7 +17104,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -18854,7 +17119,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -18865,9 +17130,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3cf39ad4-74a6-4db8-bbe8-f35e25672a78
+      - req-b6cb3fdb-143a-416b-adb2-8e80cc1731d1
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -18909,7 +17174,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18924,7 +17189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -18935,9 +17200,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4c0061c7-2e74-4c95-9628-5ae5eb439620
+      - req-ded8b19f-170b-4f81-b927-85deaa630af5
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19340,7 +17605,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19355,7 +17620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -19366,9 +17631,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c9e5d71f-cc6d-4db7-962c-0625770bd807
+      - req-2ee69273-3d0f-40cd-afeb-bd54b3dc9d32
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19771,7 +18036,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19786,7 +18051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -19797,9 +18062,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-80420a15-f7ab-4fa2-bf04-cf61c9fd10df
+      - req-c6758c61-fab5-44ee-aee0-651d1095252a
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20202,7 +18467,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20217,7 +18482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -20228,9 +18493,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-aaf64456-fcd5-4b86-8056-38b064eb9845
+      - req-d8d43297-f21b-469c-99db-fe63dd00a743
       Date:
-      - Wed, 26 Sep 2018 18:38:26 GMT
+      - Thu, 25 Oct 2018 18:23:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20633,7 +18898,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20648,7 +18913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -20659,9 +18924,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0eb6c9c4-416e-4100-83f3-76a2ccf2b972
+      - req-147cfb73-4aad-429f-9c2f-aacaef0a1c80
       Date:
-      - Wed, 26 Sep 2018 18:38:27 GMT
+      - Thu, 25 Oct 2018 18:23:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21064,7 +19329,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21079,7 +19344,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -21090,9 +19355,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-195999bb-fb82-4145-9aa1-895fcbf3b089
+      - req-5936e646-c02b-4294-a44f-365148c3e1e2
       Date:
-      - Wed, 26 Sep 2018 18:38:27 GMT
+      - Thu, 25 Oct 2018 18:23:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21495,7 +19760,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21510,7 +19775,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -21521,9 +19786,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-a3a4ee19-4108-4f7a-a6ca-7370fe48a7de
+      - req-77e52c37-f2ae-45d8-af1a-7ff8804051af
       Date:
-      - Wed, 26 Sep 2018 18:38:27 GMT
+      - Thu, 25 Oct 2018 18:23:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21926,7 +20191,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21941,7 +20206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -21952,9 +20217,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-19ac765b-3923-4157-a326-307d7a9719ea
+      - req-577171be-f34c-413e-a5c3-856785cac0bd
       Date:
-      - Wed, 26 Sep 2018 18:38:27 GMT
+      - Thu, 25 Oct 2018 18:23:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22357,7 +20622,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22372,7 +20637,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -22383,9 +20648,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7e437e8a-d1c7-4d0e-b210-87b9cc5d2aaa
+      - req-80d22c18-6e1e-4944-ad04-94b838f64019
       Date:
-      - Wed, 26 Sep 2018 18:38:27 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22788,7 +21053,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22803,7 +21068,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -22814,9 +21079,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-cef13f78-6f1f-4f6a-8989-c40e4012bd77
+      - req-5e0345a5-3b6b-4ef5-ad42-32128cd64ead
       Date:
-      - Wed, 26 Sep 2018 18:38:28 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23219,7 +21484,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -23234,7 +21499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -23245,9 +21510,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0975c47f-9874-4fb6-80fc-4a2ec64fa755
+      - req-08a8093e-71ab-4c5e-9a20-3db63b854da1
       Date:
-      - Wed, 26 Sep 2018 18:38:28 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23650,7 +21915,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -23665,7 +21930,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -23676,9 +21941,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-50b0a989-9375-48f7-8b8b-7fe4b6d7e6fe
+      - req-6d3ef0b7-9c4b-4bcc-83a0-ede251063bae
       Date:
-      - Wed, 26 Sep 2018 18:38:28 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24081,7 +22346,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -24096,7 +22361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -24107,9 +22372,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b2eb885b-b68d-4f1e-b017-225029c7334f
+      - req-dfbb0c47-0e72-4582-89c3-d8fc40f930b8
       Date:
-      - Wed, 26 Sep 2018 18:38:28 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24512,7 +22777,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -24527,7 +22792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -24538,9 +22803,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b19f48c0-690b-4ce6-ae4b-99a1831501fc
+      - req-f62d7017-f86c-4289-916b-b6279ed78f8b
       Date:
-      - Wed, 26 Sep 2018 18:38:28 GMT
+      - Thu, 25 Oct 2018 18:23:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -24943,7 +23208,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24958,7 +23223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -24969,9 +23234,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5e74e1b5-db4d-4784-8fdb-03cea6aec8f7
+      - req-bc4793ec-9247-464d-a046-3a3ef809e716
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25003,7 +23268,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25018,7 +23283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -25029,9 +23294,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-530aa6ea-6c9d-4caa-8f35-ee18c01ecd76
+      - req-e6dda8c7-a149-4dc0-bb2e-756b1db51311
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25063,7 +23328,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25078,7 +23343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -25089,9 +23354,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-56c51ade-5a30-4498-8c18-6b3453938a6f
+      - req-9b10cb17-100b-4cef-95f4-a6624be6581f
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25123,7 +23388,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25138,7 +23403,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -25149,9 +23414,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-781fb77d-4d23-40e5-b85f-7cb598234e52
+      - req-77a743a1-774e-4532-8522-a7f2357d94b2
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25183,7 +23448,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25198,7 +23463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -25209,9 +23474,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5d89a5f2-7455-4b1d-97af-c441241a0aa9
+      - req-5efd7e32-10e6-41c8-928b-78c10aafea58
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25243,7 +23508,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25258,7 +23523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -25269,9 +23534,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ac4135da-7118-4705-89b5-4255c015c7ab
+      - req-7e9386a8-cb0a-4a51-b8f0-79d795128d12
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25303,7 +23568,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25318,7 +23583,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -25329,9 +23594,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-68fe2297-0849-410c-bcc9-74b4c3527f4d
+      - req-4ff91ed5-8770-4577-8336-5b2d6e9acdd0
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25363,7 +23628,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25378,7 +23643,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -25389,9 +23654,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-817304b1-1b9a-43ae-a37c-ab0fb43815de
+      - req-9f81efc1-c613-42a3-b809-81b3cd77d9f6
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25423,7 +23688,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25438,7 +23703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -25449,9 +23714,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a60ff41d-bc6f-473d-a08a-46593520f5b2
+      - req-e8a69cf0-528b-4277-8fe3-bdd33fa0605d
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25483,7 +23748,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25498,7 +23763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -25509,9 +23774,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e5c87cdf-b0a3-4efc-aab3-0d8432ea18f7
+      - req-3775ddb1-9ee6-42b3-8a65-5c30d27ac76a
       Date:
-      - Wed, 26 Sep 2018 18:38:29 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25543,7 +23808,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25558,7 +23823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -25569,9 +23834,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-78586eb3-f646-4289-9eb2-10062e6c3e70
+      - req-efead6d4-d575-4d23-9d6f-68f2dad8fdb3
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25603,7 +23868,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25618,7 +23883,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -25629,9 +23894,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6d730384-9332-4a14-9de8-7dce5dc6a62b
+      - req-aea1c78f-0e93-45aa-b18b-a64d141ac7fc
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25663,7 +23928,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -25678,7 +23943,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -25689,9 +23954,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6773a6f5-8702-43a0-8186-27b1a8f99272
+      - req-bab9cbbe-d4b2-4663-88dc-60b7c2f2cf76
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25723,7 +23988,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -25738,7 +24003,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -25749,9 +24014,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ff5ee6d5-7947-4f67-b9fc-b9a30855bf88
+      - req-b70ea594-2017-4303-a741-1a2bc0c77e1c
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -25783,7 +24048,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25798,7 +24063,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -25809,9 +24074,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-44022e38-6b0a-4ab5-9cda-2391b6bf0299
+      - req-b33ca35e-1cde-49d8-9398-d4196236b089
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25846,7 +24111,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25861,7 +24126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -25872,9 +24137,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d60ddc05-f92f-4e56-a8f8-844a3f68bc12
+      - req-b9f7ffee-10ae-48c7-9668-34e20e2b7179
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25917,7 +24182,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25932,7 +24197,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -25943,9 +24208,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d19ba124-7669-4062-a040-d2726c8b6537
+      - req-1a0177b5-b51f-437b-8513-3be092cf9d4e
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25988,7 +24253,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26003,7 +24268,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -26014,9 +24279,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-d7eb79a1-9b11-4ec0-be31-01a29428cf7f
+      - req-b409c06e-4327-44a7-ab02-fc8c1fdbcfe0
       Date:
-      - Wed, 26 Sep 2018 18:38:30 GMT
+      - Thu, 25 Oct 2018 18:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26123,7 +24388,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26138,7 +24403,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -26149,9 +24414,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1669deb0-b536-4eaf-9fea-18e13c3daa72
+      - req-2c4f58b0-7844-4f82-85f3-b6177f0f61ae
       Date:
-      - Wed, 26 Sep 2018 18:38:31 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26193,7 +24458,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26208,7 +24473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81733713165b4b528711b8481630e95d
+      - 6e695167a49543658712ae5942bf5d3b
   response:
     status:
       code: 200
@@ -26219,15 +24484,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-5a43d6ac-36bf-421a-a861-8de6806d0a6d
+      - req-509795e1-de59-4b29-bc18-409630cf754d
       Date:
-      - Wed, 26 Sep 2018 18:38:31 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26242,7 +24507,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26253,9 +24518,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b0ae6838-3989-4a06-b41f-5e7036244a30
+      - req-3e537365-3a59-48c0-b394-d14c46c15302
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26290,7 +24555,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26305,7 +24570,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26316,9 +24581,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9628c2d8-3c41-4dd3-bfe0-b78d7a5ee5c4
+      - req-f591606b-83c5-4adc-a22b-7bed5b4fd2ad
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26361,7 +24626,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26376,7 +24641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26387,9 +24652,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-27b62b0f-b3c1-40b1-9dc6-061d08381889
+      - req-ed4b3606-ff63-4989-82cd-1d780ca47b30
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26432,7 +24697,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26447,7 +24712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26458,9 +24723,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-54390e8e-5c0e-477b-9a56-af7f0167c06e
+      - req-5a7b5a90-de94-49a9-898b-77f847cccd02
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26567,7 +24832,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26582,7 +24847,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26593,9 +24858,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b4c09b11-7082-48af-bbf8-3ae02b0c544b
+      - req-e52fbcef-912b-4c4a-80fe-2d01b418d50d
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26637,7 +24902,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26652,7 +24917,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e50ca9dd4b774def86b9f402cb679878
+      - 2bb685c4c23f4431b4a48d9148bc83d8
   response:
     status:
       code: 200
@@ -26663,15 +24928,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-f9eb1c12-18cf-46a8-ac10-4d722aac2dbb
+      - req-45e0264e-f7d4-4f6c-96e1-71b9ce830f03
       Date:
-      - Wed, 26 Sep 2018 18:38:33 GMT
+      - Thu, 25 Oct 2018 18:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26686,7 +24951,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -26697,9 +24962,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-fb9e778b-d703-439a-9089-61c03aa72435
+      - req-0f4bca40-a615-47fe-a205-18e476c84a77
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26734,7 +24999,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26749,7 +25014,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -26760,9 +25025,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-47f8c3ac-eb3c-4b37-a2e2-9e9c7e11b43b
+      - req-c7e83a88-8995-4625-b87e-b149b7d8ebea
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26805,7 +25070,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26820,7 +25085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -26831,9 +25096,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f1a485df-3e24-4bf5-9570-f6f05319c08b
+      - req-62dec04a-fbe2-4167-9757-16365896f324
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26876,7 +25141,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26891,7 +25156,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -26902,9 +25167,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a16914da-39ca-424e-ae2c-46e23ba876ad
+      - req-7d7dd0e6-d08e-4eb7-9c38-a8c3a9a7b87d
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27011,7 +25276,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27026,7 +25291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -27037,9 +25302,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-41f351f0-5658-4b1f-bb62-7c8c4b9a601b
+      - req-204a39b6-1fe1-492c-b137-8fd11ab51b7d
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27081,7 +25346,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27096,7 +25361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '01058d344b7f4d07a395bfeb4ab6a7b3'
+      - 33810e4d05be4b359550aa74f52aea0f
   response:
     status:
       code: 200
@@ -27107,15 +25372,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-e25e2eee-0df1-488b-8e45-b014603eda06
+      - req-9db744c7-2b4b-421e-aeb2-c1c6f1b92537
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27130,7 +25395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27141,9 +25406,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-4f37201a-0343-4e8d-85f7-a451ed9ef393
+      - req-3ac45dd6-107d-4730-ac7b-5bd8ad3993bb
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27178,7 +25443,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27193,7 +25458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27204,9 +25469,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-3dd013ed-107b-4c34-8bb1-2fba931942a7
+      - req-c2fceb1a-9215-4aee-964b-dfa4160f5c83
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27249,7 +25514,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27264,7 +25529,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27275,9 +25540,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6af7b29a-f74d-47c6-838c-3a5fe50a2cf8
+      - req-c5c5137b-e9c1-401f-a985-82c05bae0708
       Date:
-      - Wed, 26 Sep 2018 18:38:34 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27320,7 +25585,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27335,7 +25600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27346,9 +25611,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a1a656b7-c034-47fc-8da2-2a1fe21bafaa
+      - req-5b58ca38-9bf8-4a6b-9772-5610c16f00cd
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27455,7 +25720,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27470,7 +25735,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27481,9 +25746,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-616c4510-b15e-46f6-8a09-4905f15eb194
+      - req-a6e4d55d-cc22-4bec-b29d-ef8260768d44
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27525,7 +25790,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27540,7 +25805,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5bdf04c89cb41b68a5b35ef8bcfbf66
+      - 488ad1530437494fb329fd84ad52067e
   response:
     status:
       code: 200
@@ -27551,15 +25816,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-7747ae62-7e7f-4be1-b664-dffe5f518946
+      - req-691d0f51-9900-41b6-a1c1-aebafa753536
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27574,7 +25839,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27585,9 +25850,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-1e639cc8-8976-4cc2-b6ed-c468824053cf
+      - req-64149c51-5137-4a3f-a867-18e0dbfd8e12
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27622,7 +25887,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27637,7 +25902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27648,9 +25913,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8198db2f-5567-4a8d-b05c-710b038c5c06
+      - req-96ba721e-4483-41e8-a93f-dfe0ef31d264
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27693,7 +25958,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27708,7 +25973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27719,9 +25984,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cf2dbc35-da28-4155-baf7-fd9b07b74fed
+      - req-90ef9ee3-40e8-4f6a-8816-6f484465792a
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27764,7 +26029,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27779,7 +26044,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27790,9 +26055,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-3061c5d2-61bd-4ae8-90e9-65ea83fdeec5
+      - req-8948824b-2618-4f21-93a3-ab47b3f84024
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27899,7 +26164,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27914,7 +26179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27925,9 +26190,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d3bad95b-76bd-4be1-bdb8-416e97cafb2a
+      - req-a3552132-a70c-41ee-9e78-991c871780df
       Date:
-      - Wed, 26 Sep 2018 18:38:35 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27969,7 +26234,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27984,7 +26249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d56dd7edbce41f8b067b440331c1498
+      - e5c2c8c12d3741cf8758152a15318f97
   response:
     status:
       code: 200
@@ -27995,15 +26260,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-31cc1490-9579-4ec8-bcbc-bede9efb1edc
+      - req-f6b00b5f-4c5c-4f6d-8806-ac995f5ee225
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28018,7 +26283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28029,9 +26294,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-873738d6-680b-418f-b036-0c2ad6e48e31
+      - req-ca8dc3dc-f06e-4a56-a386-e3599632b3f7
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28066,7 +26331,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28081,7 +26346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28092,9 +26357,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ae1e3f2b-c4d2-46bd-bb9d-8436752b3669
+      - req-bb24ae04-2677-4b00-957a-4836be4d5feb
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28137,7 +26402,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28152,7 +26417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28163,9 +26428,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0be3aa1d-0c08-4289-8bda-85be8c0bf199
+      - req-30ff5bfb-6bb1-4f72-bfc3-6c61d1167980
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28208,7 +26473,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28223,7 +26488,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28234,9 +26499,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-867ca6d0-3f1c-460e-999e-3ff76d3889c6
+      - req-41019c7c-46b1-48ff-957c-46789ad94185
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28343,7 +26608,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28358,7 +26623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28369,9 +26634,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-26783e62-8340-4285-9654-e54b7171e5b8
+      - req-fd5f6a09-01f2-47a5-a874-6d1a1305ccdb
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28413,7 +26678,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28428,7 +26693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c0143d163e9d4aefb50ebb66c2dcbdf3
+      - 3e3a7e9b834e47a3b8db9c4414bf8cac
   response:
     status:
       code: 200
@@ -28439,15 +26704,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-9c541b6c-fbdf-4ae6-a39e-fafc2d59c1d8
+      - req-2d40d42a-3e96-4924-9eb2-89d22344a412
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -28462,7 +26727,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28473,9 +26738,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-436dad75-9675-4db7-a5fc-4f77da08eb24
+      - req-ccd9658f-ecc1-416e-b3c0-1ae0803035b5
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -28510,7 +26775,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -28525,7 +26790,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28536,9 +26801,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-870196ea-843e-4c46-8fa9-77c8c8e4fbe4
+      - req-bfa89d09-d17c-4314-8716-6323d7f8e0a9
       Date:
-      - Wed, 26 Sep 2018 18:38:36 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -28581,7 +26846,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -28596,7 +26861,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28607,9 +26872,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cacaf590-35ef-4359-8cf2-0ac6ad519cd5
+      - req-5e452dbc-f4de-4047-9ba9-c87e5472e854
       Date:
-      - Wed, 26 Sep 2018 18:38:37 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -28652,7 +26917,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -28667,7 +26932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28678,9 +26943,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-126c03f3-5ea7-474e-a950-3b64321fd177
+      - req-dac97a77-04e3-4722-94ef-0395f2cebf28
       Date:
-      - Wed, 26 Sep 2018 18:38:37 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -28787,7 +27052,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -28802,7 +27067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28813,9 +27078,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-1c7f6afc-56b4-4109-a4e1-975ff3a46ad5
+      - req-b3201c7e-11c3-4dfe-995e-5063faa6c25b
       Date:
-      - Wed, 26 Sep 2018 18:38:38 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -28857,7 +27122,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -28872,7 +27137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ec7e2e4cd1a46128dc9e83ee42eed8a
+      - 40668f3b334b4e65857fc7fdb74d2771
   response:
     status:
       code: 200
@@ -28883,21 +27148,21 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-995c6fd2-cba9-4f71-8592-9359a0fd4e73
+      - req-4a47f275-2383-418c-bdea-cdb7a98bd66d
       Date:
-      - Wed, 26 Sep 2018 18:38:38 GMT
+      - Thu, 25 Oct 2018 18:23:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -28909,15 +27174,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:40 GMT
+      - Thu, 25 Oct 2018 18:24:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 716788216fc8490080e43565168d3c23
+      - 3157745a867848e281e869e05d266dba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2ddb1f40-9166-4f8e-9419-02f058a0e58d
+      - req-5e95c455-e933-4a42-9098-de42d8749ca7
       Content-Length:
       - '7311'
       Connection:
@@ -28929,7 +27194,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:40.319141Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:00.322800Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29008,16 +27273,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DCEDetKjQiOQbgHODk9X_g"],
-        "issued_at": "2018-09-26T18:38:40.319161Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sdkeG2wNRoGepAK3H8c-dw"],
+        "issued_at": "2018-10-25T18:24:00.322821Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29029,15 +27294,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:40 GMT
+      - Thu, 25 Oct 2018 18:24:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c486a731-92d5-458a-bf88-b122d8a7cc45
+      - req-28c8e661-f9d7-4be3-b747-caed11f0ce58
       Content-Length:
       - '7311'
       Connection:
@@ -29049,7 +27314,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:40.525852Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:00.523188Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29128,16 +27393,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oO0tyLnhRPaHKLK8N97oAw"],
-        "issued_at": "2018-09-26T18:38:40.525870Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Q5xW9D59SWGXKY86TmQmoA"],
+        "issued_at": "2018-10-25T18:24:00.523211Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29149,15 +27414,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:40 GMT
+      - Thu, 25 Oct 2018 18:24:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - befc9ea9cbe44db8b85a95df90bc0f82
+      - 757941b4cc0a453c9c7cb9a7a4d69b86
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43d5e582-e5ac-451a-91b2-51b1ffdf844b
+      - req-e4650153-58cd-4bc8-9128-61c6aa380830
       Content-Length:
       - '297'
       Connection:
@@ -29166,15 +27431,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:38:40.687243Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:00.689813Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gU-fyIDMS0SyTJ9y81qokA"],
-        "issued_at": "2018-09-26T18:38:40.687261Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PRqZLNkqSASdLUupay9qSQ"],
+        "issued_at": "2018-10-25T18:24:00.689834Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -29186,29 +27451,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - befc9ea9cbe44db8b85a95df90bc0f82
+      - 757941b4cc0a453c9c7cb9a7a4d69b86
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:40 GMT
+      - Thu, 25 Oct 2018 18:24:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9fb5749-2316-4c85-8414-15ad0ca658da
+      - req-94f69a1f-f1b8-4174-b4df-9e5ca8b3673e
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -29232,13 +27497,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"befc9ea9cbe44db8b85a95df90bc0f82"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29250,27 +27515,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:40 GMT
+      - Thu, 25 Oct 2018 18:24:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 651bcbde462e495785324e3e01e503e1
+      - ad77da44a58942b79652d8652460ac3c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5d67f45f-cfd1-4ccd-94bf-2c6f9b81b20c
+      - req-bde57675-d58d-4e4f-90d8-cb578b82d02f
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:40.687243Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:01.053790Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29349,77 +27614,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GRBtJT9ETje3p96JMXQ96Q",
-        "gU-fyIDMS0SyTJ9y81qokA"], "issued_at": "2018-09-26T18:38:40.978127Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EveH55csQoawM1Db65MWwA"],
+        "issued_at": "2018-10-25T18:24:01.053813Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 651bcbde462e495785324e3e01e503e1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ec8f0cf3-21dc-498a-a19a-2873cd11510d
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29431,15 +27635,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
+      - Thu, 25 Oct 2018 18:24:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f091ab6ea96a4b489492f323827bde6d
+      - b5d92530c4584c73bbcecbd4592f5b8b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-86d6241a-848d-47ef-a369-ea2cdefab707
+      - req-b782f9af-df14-446a-a1c1-7d2e8b89359f
       Content-Length:
       - '7278'
       Connection:
@@ -29451,127 +27655,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:41.266278Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fHdBMsEjTTqwjwriAk6sSA"],
-        "issued_at": "2018-09-26T18:38:41.266297Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 00525c2dd8104ff0955a724073c3f55d
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-adcdd29e-5cdd-4fc0-af2c-75823d9cdca0
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:41.455415Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:01.252697Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29650,16 +27734,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PpPabl3aTh-n-ZIOFS_vbg"],
-        "issued_at": "2018-09-26T18:38:41.455433Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_K9lKYdZQfKBctBxs0f5Tg"],
+        "issued_at": "2018-10-25T18:24:01.252719Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29671,15 +27755,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
+      - Thu, 25 Oct 2018 18:24:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1ea74cc5e6d344b5a6c1d574fca1ff68
+      - 428c2207dffe423bb85245cd450a3ec5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a28d8f10-e32d-4829-815e-3c4cbbc17dc0
+      - req-0d1f76a6-2b33-4a07-b172-c6b6ba4c322d
       Content-Length:
       - '7264'
       Connection:
@@ -29691,7 +27775,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:41.650490Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:01.453454Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29770,16 +27854,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JDKvvz_XSZqla5KzAf8lSA"],
-        "issued_at": "2018-09-26T18:38:41.650508Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5M4OW9IHSj63c4sGFi9_og"],
+        "issued_at": "2018-10-25T18:24:01.453475Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29791,15 +27875,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
+      - Thu, 25 Oct 2018 18:24:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b276aefbb4fa4b68b16e3300083e35cd
+      - 9c2f70da6fa54b1c83ec26930bfbe0ab
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e59e9eeb-f37f-456b-baf4-fcdf193f7d5d
+      - req-fc884d82-6112-44c5-a45a-a78753dac5d6
       Content-Length:
       - '7278'
       Connection:
@@ -29811,7 +27895,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:41.842607Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:01.648973Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29890,16 +27974,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["63_OiqHrQym-BP2Z4ucSig"],
-        "issued_at": "2018-09-26T18:38:41.842625Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iOrxVA3DS-CJzWJ_Tg7CmQ"],
+        "issued_at": "2018-10-25T18:24:01.648995Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -29911,15 +27995,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:41 GMT
+      - Thu, 25 Oct 2018 18:24:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c1edb4e4cc5b4869b0d0097c6fa7c1c7
+      - b394499ccb9b4ab68dcb15825bb37336
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e5758335-3a49-4757-bdd3-25fa0935416e
+      - req-d7f7b9b9-1e34-4cbe-b6c1-0ce35624233f
       Content-Length:
       - '7265'
       Connection:
@@ -29931,7 +28015,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:42.034238Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:01.841948Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30010,16 +28094,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F6SEfInoRCyxUPcW-eoeOw"],
-        "issued_at": "2018-09-26T18:38:42.034257Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["caYpKcsaQl6sBd5HdWBd2Q"],
+        "issued_at": "2018-10-25T18:24:01.841970Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -30031,15 +28115,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:42 GMT
+      - Thu, 25 Oct 2018 18:24:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5035108ddfef46bd84eef78ec7db6006
+      - c7c877ed31a44274b3c99210cf7438fe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d48035e6-fadd-4b63-9bad-43e8693015ad
+      - req-feaddb11-4115-470b-8903-3db7f14d83dd
       Content-Length:
       - '7278'
       Connection:
@@ -30051,7 +28135,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:42.231903Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:02.053029Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30130,16 +28214,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8XqcAe8qTneUa_SslMWu_g"],
-        "issued_at": "2018-09-26T18:38:42.231923Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-HLK30ApQ2OBulSRO_gpHA"],
+        "issued_at": "2018-10-25T18:24:02.053056Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -30151,15 +28235,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:42 GMT
+      - Thu, 25 Oct 2018 18:24:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c65c7625-f26f-4ea2-8bea-9aafe38c2151
+      - req-4b2d3f34-9372-4c13-a504-6fb034d17698
       Content-Length:
       - '7278'
       Connection:
@@ -30171,7 +28255,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:42.490827Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:02.252210Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30250,10 +28334,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8hXbdHs2Qoa14GfdXPA5WA"],
-        "issued_at": "2018-09-26T18:38:42.490847Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZKzSq2O7S-m0zX9HSJ_U3g"],
+        "issued_at": "2018-10-25T18:24:02.252232Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -30268,33 +28352,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bd0bd390-7b80-4518-9599-2ac90b742dfc
+      - req-68a4c5a5-a70a-4a16-8e46-5a2c7067dfc9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bd0bd390-7b80-4518-9599-2ac90b742dfc
+      - req-68a4c5a5-a70a-4a16-8e46-5a2c7067dfc9
       Date:
-      - Wed, 26 Sep 2018 18:38:42 GMT
+      - Thu, 25 Oct 2018 18:24:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -30306,15 +28390,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:42 GMT
+      - Thu, 25 Oct 2018 18:24:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ee1d667a-f4de-4f36-abb6-ac6b32191a34
+      - req-c7b460e5-6696-4123-9884-c1b02fec5ee7
       Content-Length:
       - '7278'
       Connection:
@@ -30326,7 +28410,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:42.884627Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:02.597486Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30405,10 +28489,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o3jzNZ45STebmcibxA7Lpw"],
-        "issued_at": "2018-09-26T18:38:42.884647Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w7gEJnbfRkmGnWC8jc7L1Q"],
+        "issued_at": "2018-10-25T18:24:02.597507Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -30423,33 +28507,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cef93fd6-9135-4eab-b483-86501bd06b2c
+      - req-08d7bffc-7d84-4837-99cc-64bcfaaa3f1a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cef93fd6-9135-4eab-b483-86501bd06b2c
+      - req-08d7bffc-7d84-4837-99cc-64bcfaaa3f1a
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -30461,15 +28545,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f269334b-a10c-4bed-ad68-f0044e9c3955
+      - req-29ab32bd-c92b-48a1-8792-df93850269b8
       Content-Length:
       - '7264'
       Connection:
@@ -30481,7 +28565,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:43.205032Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:02.942587Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30560,10 +28644,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rJagO_s6TTuGHT-YjlOTwA"],
-        "issued_at": "2018-09-26T18:38:43.205060Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9nkEEdbDSZq4eLON0FFk_Q"],
+        "issued_at": "2018-10-25T18:24:02.942610Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -30578,22 +28662,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9434f8a-df4c-4bb5-9dc1-b05a46998ec9
+      - req-60f8cc8c-7b05-4427-b0b8-31d519b26f46
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-a9434f8a-df4c-4bb5-9dc1-b05a46998ec9
+      - req-60f8cc8c-7b05-4427-b0b8-31d519b26f46
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -30626,7 +28710,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -30641,22 +28725,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a16b0086-0332-42f3-b207-46f48d42f515
+      - req-aee182ee-7974-4d7c-b2eb-adfe1f7463cc
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-a16b0086-0332-42f3-b207-46f48d42f515
+      - req-aee182ee-7974-4d7c-b2eb-adfe1f7463cc
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -30697,7 +28781,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -30712,22 +28796,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad6901c6-cdd6-47fc-880f-409cb8ac86fa
+      - req-fdebeec6-b9f6-4a45-9a8b-38c5f03fe2e9
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-ad6901c6-cdd6-47fc-880f-409cb8ac86fa
+      - req-fdebeec6-b9f6-4a45-9a8b-38c5f03fe2e9
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -30761,7 +28845,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -30776,33 +28860,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-64edaebf-efe7-43a0-adff-4e5bc1cde52b
+      - req-e04c82c9-4ce1-449c-bc38-29cafa713429
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-64edaebf-efe7-43a0-adff-4e5bc1cde52b
+      - req-e04c82c9-4ce1-449c-bc38-29cafa713429
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -30814,15 +28898,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:43 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7866e02b-2de6-426c-a23f-e315e817c992
+      - req-6d866991-ccb5-420b-8738-84a760a4820c
       Content-Length:
       - '7278'
       Connection:
@@ -30834,7 +28918,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:44.038392Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:03.774859Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30913,10 +28997,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JRz2-WGjSmyqzOWfU_txIw"],
-        "issued_at": "2018-09-26T18:38:44.038412Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0N9k0RO2Rbms3oVVM5bzZQ"],
+        "issued_at": "2018-10-25T18:24:03.774879Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -30931,27 +29015,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bfaba29d-3a70-4591-9ead-2126c5208271
+      - req-3077d975-f141-4dbd-8f49-79598f6ad358
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bfaba29d-3a70-4591-9ead-2126c5208271
+      - req-3077d975-f141-4dbd-8f49-79598f6ad358
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -30966,33 +29050,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4b8c100-feb8-4e07-b438-041b6067ea4c
+      - req-894050a4-8438-4a8d-b49f-50d2a3a33898
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c4b8c100-feb8-4e07-b438-041b6067ea4c
+      - req-894050a4-8438-4a8d-b49f-50d2a3a33898
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -31004,15 +29088,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-576e27cd-b3b2-4621-982a-11e774826b74
+      - req-d49f21c9-84bf-41db-8e59-5561216c8f69
       Content-Length:
       - '7265'
       Connection:
@@ -31024,7 +29108,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:44.521177Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:04.269202Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31103,10 +29187,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jYyd0WeTQ02mVCule-MOFA"],
-        "issued_at": "2018-09-26T18:38:44.521196Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gRkej8i9SFq7s9ktWIIAkQ"],
+        "issued_at": "2018-10-25T18:24:04.269223Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -31121,33 +29205,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fa0d170-9527-4a56-bd42-7a9ad692f6a0
+      - req-7d9f8db5-de23-4346-a787-a1d45135a18c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0fa0d170-9527-4a56-bd42-7a9ad692f6a0
+      - req-7d9f8db5-de23-4346-a787-a1d45135a18c
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -31159,15 +29243,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7e4b9844-831f-4fc1-aadb-72bd56355f02
+      - req-d7953d11-af73-459f-9ad0-5b900670e694
       Content-Length:
       - '7278'
       Connection:
@@ -31179,7 +29263,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:44.844560Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:04.613923Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -31258,10 +29342,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kp9S4RixQgidWGSdPq2UDg"],
-        "issued_at": "2018-09-26T18:38:44.844580Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iQjFn0hyRESAapCXTRw5ig"],
+        "issued_at": "2018-10-25T18:24:04.613955Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -31276,27 +29360,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-461b0a7b-1225-4a72-b55d-2d7bd83284fc
+      - req-9556bcf4-1386-4b59-8529-171dbb69d709
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-461b0a7b-1225-4a72-b55d-2d7bd83284fc
+      - req-9556bcf4-1386-4b59-8529-171dbb69d709
       Date:
-      - Wed, 26 Sep 2018 18:38:44 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -31311,27 +29395,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9f589fe9-5701-458b-8a17-565cb34248fb
+      - req-ceb4db6f-4137-4e6e-b9e2-1460b03fbbb1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9f589fe9-5701-458b-8a17-565cb34248fb
+      - req-ceb4db6f-4137-4e6e-b9e2-1460b03fbbb1
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -31346,27 +29430,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-13d69e27-cd7f-45be-ad7a-45516fa9b1de
+      - req-3cf6c5da-9fe5-46b2-ba82-b8b4eff9892f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-13d69e27-cd7f-45be-ad7a-45516fa9b1de
+      - req-3cf6c5da-9fe5-46b2-ba82-b8b4eff9892f
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -31381,27 +29465,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ccbb416-3cb9-4c9d-8a08-0cf66c43ca73
+      - req-82325759-8851-4718-b5e3-eee42d5c9bdb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6ccbb416-3cb9-4c9d-8a08-0cf66c43ca73
+      - req-82325759-8851-4718-b5e3-eee42d5c9bdb
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -31416,27 +29500,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6751d50-71b5-411d-a00b-611a643aefc1
+      - req-9793862b-ebcb-4449-83b1-f62b8335dabf
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d6751d50-71b5-411d-a00b-611a643aefc1
+      - req-9793862b-ebcb-4449-83b1-f62b8335dabf
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -31451,22 +29535,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8154b3a-c168-4edb-8cef-a5272fce8dcc
+      - req-b65b89d9-132d-46f1-9aa2-28e68581116c
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b8154b3a-c168-4edb-8cef-a5272fce8dcc
+      - req-b65b89d9-132d-46f1-9aa2-28e68581116c
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -31481,7 +29565,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -31496,22 +29580,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4167412a-b206-4764-9443-d46b2cbd7a32
+      - req-ee523951-e715-4c3c-8ff3-5e8655f38b03
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-4167412a-b206-4764-9443-d46b2cbd7a32
+      - req-ee523951-e715-4c3c-8ff3-5e8655f38b03
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -31526,7 +29610,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -31541,27 +29625,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3784001-04a9-4093-ab04-327703cf294e
+      - req-be897d55-a652-468d-94bc-72641c034a88
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d3784001-04a9-4093-ab04-327703cf294e
+      - req-be897d55-a652-468d-94bc-72641c034a88
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -31576,27 +29660,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-10b345c1-8450-4af0-951e-b62d16f804f1
+      - req-4290f174-eada-4be6-8ad4-108529b958a6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-10b345c1-8450-4af0-951e-b62d16f804f1
+      - req-4290f174-eada-4be6-8ad4-108529b958a6
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -31611,27 +29695,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa6bf8f6-c49a-4d6e-b69a-0075e641a0f0
+      - req-a123e533-f535-4000-a510-d7ace01608f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-aa6bf8f6-c49a-4d6e-b69a-0075e641a0f0
+      - req-a123e533-f535-4000-a510-d7ace01608f0
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -31646,27 +29730,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e124c639-6534-4413-81e0-3e2f044f3577
+      - req-1515fced-9039-42d7-b17e-670043ed50ee
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e124c639-6534-4413-81e0-3e2f044f3577
+      - req-1515fced-9039-42d7-b17e-670043ed50ee
       Date:
-      - Wed, 26 Sep 2018 18:38:45 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -31681,27 +29765,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3eb3b642-7b8b-4bcb-8b65-7b928f7de52c
+      - req-bd2e8351-5a55-4026-a540-5d12586f275d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3eb3b642-7b8b-4bcb-8b65-7b928f7de52c
+      - req-bd2e8351-5a55-4026-a540-5d12586f275d
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -31716,27 +29800,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b13024e-b770-4f8e-a4fb-1237ba251c25
+      - req-e1ce46a0-60ac-45e3-ac87-d99f1b0c728e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6b13024e-b770-4f8e-a4fb-1237ba251c25
+      - req-e1ce46a0-60ac-45e3-ac87-d99f1b0c728e
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -31751,27 +29835,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c12d605b-9eb5-4a17-9e3e-cea839c07898
+      - req-c4143081-9063-49bf-8afb-315a63d504c0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c12d605b-9eb5-4a17-9e3e-cea839c07898
+      - req-c4143081-9063-49bf-8afb-315a63d504c0
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -31786,27 +29870,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc078dfd-be2c-42bf-b005-30dc11d64edb
+      - req-8868a914-0879-4645-b571-186591da40de
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-cc078dfd-be2c-42bf-b005-30dc11d64edb
+      - req-8868a914-0879-4645-b571-186591da40de
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -31821,27 +29905,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-624dd4c1-1821-463c-9fa3-051a0b655131
+      - req-b16e6fa4-15cc-4f3e-b86d-8e68ffa7adb2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-624dd4c1-1821-463c-9fa3-051a0b655131
+      - req-b16e6fa4-15cc-4f3e-b86d-8e68ffa7adb2
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -31856,27 +29940,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-330acd62-64f2-4856-8ad3-c15e7852ffc5
+      - req-739610b8-23e6-4f6a-9aff-b3244c6a017a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-330acd62-64f2-4856-8ad3-c15e7852ffc5
+      - req-739610b8-23e6-4f6a-9aff-b3244c6a017a
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -31891,27 +29975,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a3966697-c954-4f9e-9860-0e696df302af
+      - req-8e1a1d35-67c1-452a-a47e-82785edb3315
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a3966697-c954-4f9e-9860-0e696df302af
+      - req-8e1a1d35-67c1-452a-a47e-82785edb3315
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -31926,27 +30010,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e333c739-bd3a-4633-82a1-5bf42c3d76e9
+      - req-6cf264f7-ab63-4efa-ae2a-18f0a2ba064a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e333c739-bd3a-4633-82a1-5bf42c3d76e9
+      - req-6cf264f7-ab63-4efa-ae2a-18f0a2ba064a
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -31961,27 +30045,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ae7756c-8823-49f7-bd9c-1a1b6ea61ddf
+      - req-99c5901b-60cd-469b-ab5b-d13f19c6df0f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6ae7756c-8823-49f7-bd9c-1a1b6ea61ddf
+      - req-99c5901b-60cd-469b-ab5b-d13f19c6df0f
       Date:
-      - Wed, 26 Sep 2018 18:38:46 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -31996,27 +30080,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e6038c5f-cd6a-491e-864f-29f0545118c0
+      - req-2d141e49-2136-44fa-b151-98a35a731578
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e6038c5f-cd6a-491e-864f-29f0545118c0
+      - req-2d141e49-2136-44fa-b151-98a35a731578
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -32031,27 +30115,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ef2edc0-319f-4732-b4ba-d3b39c1caae1
+      - req-05caa3aa-2c9b-4f16-b2fc-167c4eefd184
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0ef2edc0-319f-4732-b4ba-d3b39c1caae1
+      - req-05caa3aa-2c9b-4f16-b2fc-167c4eefd184
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -32066,27 +30150,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f52b58b7-c9ca-4b81-bf21-d74bea8baa64
+      - req-22854cc5-53c7-4694-b75d-c0accf77c722
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f52b58b7-c9ca-4b81-bf21-d74bea8baa64
+      - req-22854cc5-53c7-4694-b75d-c0accf77c722
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -32101,27 +30185,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31b92ecc-99b3-4a27-8ea2-e9fe18140a97
+      - req-451fb883-2f06-44f0-aee5-5d69ea88f4d5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-31b92ecc-99b3-4a27-8ea2-e9fe18140a97
+      - req-451fb883-2f06-44f0-aee5-5d69ea88f4d5
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -32136,27 +30220,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37c9cc14-ecdd-4a2f-b9bc-f4269f1d32b6
+      - req-d1630f0c-85c2-4094-a406-2f65c9740186
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-37c9cc14-ecdd-4a2f-b9bc-f4269f1d32b6
+      - req-d1630f0c-85c2-4094-a406-2f65c9740186
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -32171,27 +30255,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-14dac578-5494-46a0-8f10-2a618a1af4f5
+      - req-68842ca5-9faf-45fb-b649-3980d39dbd69
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-14dac578-5494-46a0-8f10-2a618a1af4f5
+      - req-68842ca5-9faf-45fb-b649-3980d39dbd69
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -32206,27 +30290,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-712026e0-5855-4ff4-b72f-d55bb5f979e3
+      - req-5cab6efa-26ad-4d6c-a3e4-6109c68944e4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-712026e0-5855-4ff4-b72f-d55bb5f979e3
+      - req-5cab6efa-26ad-4d6c-a3e4-6109c68944e4
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -32241,27 +30325,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-44f2f300-1074-4ab5-8ac9-2d25ae6be35d
+      - req-7978a3ce-7752-4b04-ae42-c6a35eca2293
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-44f2f300-1074-4ab5-8ac9-2d25ae6be35d
+      - req-7978a3ce-7752-4b04-ae42-c6a35eca2293
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -32276,27 +30360,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-248e8051-4aa1-4cc1-9907-8b37e20b500b
+      - req-888d76ba-c9f4-44bd-9268-b854e3393277
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-248e8051-4aa1-4cc1-9907-8b37e20b500b
+      - req-888d76ba-c9f4-44bd-9268-b854e3393277
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -32311,22 +30395,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6d7c1477-4123-4d17-9046-ae80365c15d1
+      - req-a405fc63-cd94-481a-8bc4-36b9392364bd
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6d7c1477-4123-4d17-9046-ae80365c15d1
+      - req-a405fc63-cd94-481a-8bc4-36b9392364bd
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32338,7 +30422,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32353,22 +30437,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810ce3581eac4244959d1937727b33d2
+      - d74fed218e93457291e2dcf7ac87e56a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c951b104-25a9-42d5-8054-f14c6141172d
+      - req-875d3003-63c6-498c-a9fc-d530db02ae5c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c951b104-25a9-42d5-8054-f14c6141172d
+      - req-875d3003-63c6-498c-a9fc-d530db02ae5c
       Date:
-      - Wed, 26 Sep 2018 18:38:47 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32380,7 +30464,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -32395,22 +30479,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b6c97be-f316-4d39-ae2a-98b45191a256
+      - req-a1857c42-c1d4-4fc2-aa39-4df2a91a2f0e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9b6c97be-f316-4d39-ae2a-98b45191a256
+      - req-a1857c42-c1d4-4fc2-aa39-4df2a91a2f0e
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32422,7 +30506,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32437,22 +30521,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df29e9dbed44459a42b6950781b5715
+      - bd59c3a31a604a50b25e8b400b7dc1cd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-455487b4-3bc3-4228-9cdb-30c61df1b722
+      - req-b3c7999d-509f-42c4-8fb2-c8c25c9fda2b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-455487b4-3bc3-4228-9cdb-30c61df1b722
+      - req-b3c7999d-509f-42c4-8fb2-c8c25c9fda2b
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32464,7 +30548,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -32479,22 +30563,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fba7b2ba-0fcd-4cba-998e-bc51e3c90344
+      - req-4a628a3a-5f59-4716-ba0f-f613f3c0099b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fba7b2ba-0fcd-4cba-998e-bc51e3c90344
+      - req-4a628a3a-5f59-4716-ba0f-f613f3c0099b
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32506,7 +30590,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32521,22 +30605,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d29266704e0543909b277583bd88e94a
+      - d737307f6aaa4aa4926bc081aaddbe70
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c26a27ab-a588-4827-8d34-94e67dae7b0e
+      - req-6794fe3a-5790-4bac-b3af-c431f55a0f66
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c26a27ab-a588-4827-8d34-94e67dae7b0e
+      - req-6794fe3a-5790-4bac-b3af-c431f55a0f66
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32548,7 +30632,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -32563,22 +30647,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-334e4bd2-8bb3-4cad-99fc-6ef3a120380f
+      - req-5b5821f1-883e-42e6-83fa-868fd54e2aca
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-334e4bd2-8bb3-4cad-99fc-6ef3a120380f
+      - req-5b5821f1-883e-42e6-83fa-868fd54e2aca
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32590,7 +30674,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32605,22 +30689,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bac8a289bb424afc97a19aa23765fd39
+      - 3ab1c9677a544f4589fa009361756c73
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9144a4a0-68ff-4603-9e6e-beda40be819e
+      - req-43f84a60-80a7-46a9-a826-9999e1fadb6c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9144a4a0-68ff-4603-9e6e-beda40be819e
+      - req-43f84a60-80a7-46a9-a826-9999e1fadb6c
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32632,7 +30716,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -32647,22 +30731,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b9d131c1-38a2-4051-98cc-31a25007e279
+      - req-414d8334-7c9d-48e4-9e3a-7f8243220f80
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b9d131c1-38a2-4051-98cc-31a25007e279
+      - req-414d8334-7c9d-48e4-9e3a-7f8243220f80
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32674,7 +30758,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32689,22 +30773,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f000155554a049cba68b83155fd8439c
+      - 4923ea4471e64411818e216ba29d6561
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8869e6a6-f537-484c-8ec2-02f39a8a2fde
+      - req-4a70950e-2ee5-4831-8176-36f16ecf6f1b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8869e6a6-f537-484c-8ec2-02f39a8a2fde
+      - req-4a70950e-2ee5-4831-8176-36f16ecf6f1b
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32716,7 +30800,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -32731,22 +30815,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19623e53-e8a9-4cdd-8901-062d25a0f29a
+      - req-3ca563ce-d501-452c-9d22-bc6bdc27b480
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-19623e53-e8a9-4cdd-8901-062d25a0f29a
+      - req-3ca563ce-d501-452c-9d22-bc6bdc27b480
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32758,7 +30842,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32773,22 +30857,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 349b9f7726904687b8e3583bc727100e
+      - dfc4919a0467404182d5ac200ac72b49
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c25b9e9-acd9-482e-8235-b3a1f4cea4f2
+      - req-5272087d-9361-47b1-99e7-3f8c328a2def
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3c25b9e9-acd9-482e-8235-b3a1f4cea4f2
+      - req-5272087d-9361-47b1-99e7-3f8c328a2def
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32800,7 +30884,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -32815,22 +30899,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b639dce-3043-4df4-bfcc-17cb6c53ad0c
+      - req-cb2a5c9b-d748-444a-8c28-15e6cb80784e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0b639dce-3043-4df4-bfcc-17cb6c53ad0c
+      - req-cb2a5c9b-d748-444a-8c28-15e6cb80784e
       Date:
-      - Wed, 26 Sep 2018 18:38:48 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32842,7 +30926,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -32857,22 +30941,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eea9c465aad46c6bcbfee503e8421d0
+      - edf3ad6c8254485cb136ac2f7b143438
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-992d6451-b125-4295-9a1a-a1a8bd730f45
+      - req-8a74c90b-e71a-44f1-8297-d44b202e42cb
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-992d6451-b125-4295-9a1a-a1a8bd730f45
+      - req-8a74c90b-e71a-44f1-8297-d44b202e42cb
       Date:
-      - Wed, 26 Sep 2018 18:38:49 GMT
+      - Thu, 25 Oct 2018 18:24:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -32884,13 +30968,13 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -32902,15 +30986,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:49 GMT
+      - Thu, 25 Oct 2018 18:24:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3cb8846f0d7b4eae921090feadfa354d
+      - 6c4010d958ac4f718165a177d6e589d3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-27773480-d143-4111-8dbb-746498150814
+      - req-52629336-a82a-44a1-863a-b74b5cef52aa
       Content-Length:
       - '7311'
       Connection:
@@ -32922,7 +31006,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:49.374384Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:09.185590Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33001,16 +31085,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bxwNP-P-RTOnGpU38eZGzQ"],
-        "issued_at": "2018-09-26T18:38:49.374403Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3zimhwGkSCSnY9dl1_dnww"],
+        "issued_at": "2018-10-25T18:24:09.185616Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33022,15 +31106,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:49 GMT
+      - Thu, 25 Oct 2018 18:24:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 959838eb0cee416fb555c774d0542386
+      - 48f8e77486d14079af9d597bbde854bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca746973-5a9b-454d-b440-a5fc02354211
+      - req-5c1344be-c13f-42a6-b276-6e57e43b4655
       Content-Length:
       - '7311'
       Connection:
@@ -33042,7 +31126,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:38:49.619439Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:09.397640Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33121,16 +31205,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["82Q4KbUUQAeoHmZ7yGx2Fg"],
-        "issued_at": "2018-09-26T18:38:49.619468Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LUeoAEbjTGubaZ9PF0EvBw"],
+        "issued_at": "2018-10-25T18:24:09.397661Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33142,15 +31226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:49 GMT
+      - Thu, 25 Oct 2018 18:24:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 77850081acd24153958fbe40b1815ee9
+      - b1d7b08d804040d1929028fa8e96ec4a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-55320333-38e5-4f6a-9f89-b4483918d7bf
+      - req-8d6e1823-a971-463b-8917-d045d0f839c0
       Content-Length:
       - '297'
       Connection:
@@ -33159,15 +31243,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:38:49.802715Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:09.563722Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XtODg4dRSkankmd3kDxFaA"],
-        "issued_at": "2018-09-26T18:38:49.802738Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["REtnHYMESRKFB_W3Ll-D7A"],
+        "issued_at": "2018-10-25T18:24:09.563745Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -33179,29 +31263,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77850081acd24153958fbe40b1815ee9
+      - b1d7b08d804040d1929028fa8e96ec4a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:49 GMT
+      - Thu, 25 Oct 2018 18:24:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c3b98518-1b98-4d3c-a84d-7e6e814b472b
+      - req-cb3353ed-3502-40fd-b552-33e7328bc5ba
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -33225,13 +31309,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"77850081acd24153958fbe40b1815ee9"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33243,27 +31327,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:50 GMT
+      - Thu, 25 Oct 2018 18:24:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1bf8ed2d4c1f4a93ba2522ed44470a0e
+      - cc5a663163de4453a50b4b4fb2f3ea0c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-190bef72-5fd5-4e48-9258-88205e7d03c6
+      - req-49bed36d-b593-43b7-9ea1-7f867628cbf1
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:49.802715Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:09.893038Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33342,77 +31426,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AOZ8lWAEQnGFtVS9IWyDbg",
-        "XtODg4dRSkankmd3kDxFaA"], "issued_at": "2018-09-26T18:38:50.161580Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AUZ5Ls01TBGKFPdbKmNXlg"],
+        "issued_at": "2018-10-25T18:24:09.893062Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1bf8ed2d4c1f4a93ba2522ed44470a0e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:50 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-19c0642d-b307-476c-be63-0af07edfbd97
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33424,15 +31447,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:50 GMT
+      - Thu, 25 Oct 2018 18:24:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3c0fef4937014ae1907f96b35806ccca
+      - 670a33aff13d43cfb1aa16d921671585
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9f88639-ed2e-4f00-839c-66b9f7928982
+      - req-9956caa6-2e10-44c7-9bc6-46efb8e1343e
       Content-Length:
       - '7278'
       Connection:
@@ -33444,127 +31467,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:50.491158Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5YFwt2FqS4mPFl_AC92sGQ"],
-        "issued_at": "2018-09-26T18:38:50.491191Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:50 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:38:50 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - dbcd4414d5d045e78a097e90faf09bc2
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-4c4b2b53-9d3b-4688-9a09-5251be3cfe0b
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:50.696220Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:10.106557Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33643,16 +31546,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IGlAW-CnTaGhw6ejJSXUPQ"],
-        "issued_at": "2018-09-26T18:38:50.696243Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uOK1KqAaSwa6-cFh1SAXjg"],
+        "issued_at": "2018-10-25T18:24:10.106587Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33664,15 +31567,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:51 GMT
+      - Thu, 25 Oct 2018 18:24:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cded38d76eb34d70a45393fc9dfacc3d
+      - 616fe4a46c4d4f13ba980c4566773d74
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11baed76-32c2-44c2-9039-9248c5495ff2
+      - req-ee38e22d-a4bb-43fb-90b7-ccc86121d0dc
       Content-Length:
       - '7264'
       Connection:
@@ -33684,7 +31587,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:51.244416Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:10.305318Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33763,16 +31666,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vHLHkcvUTdabF5VfpBug5Q"],
-        "issued_at": "2018-09-26T18:38:51.244454Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3uA7LQsuTIywgdFmwovZ-w"],
+        "issued_at": "2018-10-25T18:24:10.305338Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33784,15 +31687,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:51 GMT
+      - Thu, 25 Oct 2018 18:24:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e8bfb10f99314221b8bbac52d246034b
+      - 9653aad73be84907b94d9e9f8a41347f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5eef3e8a-07cf-4c6d-b61f-6149b278a273
+      - req-8555fd1e-ffd9-4b90-a0ea-afe11942ce00
       Content-Length:
       - '7278'
       Connection:
@@ -33804,7 +31707,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:51.445984Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:10.506389Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33883,16 +31786,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UJr9xBifRA2lDfC14mqNSw"],
-        "issued_at": "2018-09-26T18:38:51.446047Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SPmNg8qbTDyAMS8OlHdPRQ"],
+        "issued_at": "2018-10-25T18:24:10.506410Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -33904,15 +31807,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:51 GMT
+      - Thu, 25 Oct 2018 18:24:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 96cd89872378426fbba525d361199a27
+      - e3f0e950b947432ab18072a9f4eb642b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-38d8e318-b2f4-405e-a5f7-9bce6b37d956
+      - req-30eaa599-2277-4f3a-a161-c5a6c0150f3b
       Content-Length:
       - '7265'
       Connection:
@@ -33924,7 +31827,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:51.650743Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:10.702459Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34003,16 +31906,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qxqLBRAoTyC3pJHCbda2mg"],
-        "issued_at": "2018-09-26T18:38:51.650765Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tlSXByITSd-etMXfJlY25A"],
+        "issued_at": "2018-10-25T18:24:10.702479Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34024,15 +31927,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:51 GMT
+      - Thu, 25 Oct 2018 18:24:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e03b5976b88549d4b149ad029c52ff9a
+      - 332412fda58742479c88bfdbacad82df
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca1a5db6-7b51-4595-8a81-0585ee53bdb5
+      - req-2e3b5c58-1354-490e-889c-8e2ab114cb3d
       Content-Length:
       - '7278'
       Connection:
@@ -34044,7 +31947,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:51.859915Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:10.909646Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34123,16 +32026,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yy5D1bcFQsStXJABkPVjjg"],
-        "issued_at": "2018-09-26T18:38:51.859948Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nx8DdoueQje_3NBYlgc5UQ"],
+        "issued_at": "2018-10-25T18:24:10.909668Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34144,15 +32047,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ff09673d4ea4f20a6c328a9f256dcbe
+      - 6eb0c50eaa194f768f8123d8d2dea1a5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-87d7ba44-dfd6-4f2c-b457-0c761c0d7268
+      - req-d322da7b-3b91-47c7-8561-1b737a6540cb
       Content-Length:
       - '7278'
       Connection:
@@ -34164,7 +32067,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:52.078588Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:11.119905Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34243,10 +32146,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DkxA2cJkRTORHntWLHfuiA"],
-        "issued_at": "2018-09-26T18:38:52.078609Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UsA7TIIFQqaukIeuaJuSFQ"],
+        "issued_at": "2018-10-25T18:24:11.119926Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -34261,7 +32164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ff09673d4ea4f20a6c328a9f256dcbe
+      - 6eb0c50eaa194f768f8123d8d2dea1a5
   response:
     status:
       code: 200
@@ -34274,28 +32177,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987132.28404'
+      - '1540491851.25065'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987132.28404'
+      - '1540491851.25065'
       X-Trans-Id:
-      - tx4974bdfb641148959c232-005babd23c
+      - tx987578296c47405bb87a9-005bd20a4b
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34307,15 +32210,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fa46e67239ed469797f3258008f85fdc
+      - 998fc8dc0eb842eca0afd05cd5e28847
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43ced8fc-dd64-478b-9c86-a80d7795446e
+      - req-a5faad60-da11-431c-8e92-b9dec320fb4e
       Content-Length:
       - '7278'
       Connection:
@@ -34327,7 +32230,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:52.476862Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:11.443170Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34406,10 +32309,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XATZTM2sSY-8fgBw9XpEIw"],
-        "issued_at": "2018-09-26T18:38:52.476906Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CzTYrtTNTpqqPN8PmMP55Q"],
+        "issued_at": "2018-10-25T18:24:11.443191Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -34424,7 +32327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa46e67239ed469797f3258008f85fdc
+      - 998fc8dc0eb842eca0afd05cd5e28847
   response:
     status:
       code: 200
@@ -34437,28 +32340,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987132.60724'
+      - '1540491851.57664'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987132.60724'
+      - '1540491851.57664'
       X-Trans-Id:
-      - txff8e5dc809a44ae4b615f-005babd23c
+      - txdbf178ea841a4b539bbe1-005bd20a4b
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34470,15 +32373,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-323d65c3-da66-4121-99b9-c11d919488e2
+      - req-fe892ff6-75de-41dd-9e26-e0f1ea8b75b4
       Content-Length:
       - '7264'
       Connection:
@@ -34490,7 +32393,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:52.801317Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:11.778850Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34569,10 +32472,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IQq2NIlOQQWDi_SJBGF_2Q"],
-        "issued_at": "2018-09-26T18:38:52.801337Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1evk1eJGSDCfTFY84bbklA"],
+        "issued_at": "2018-10-25T18:24:11.778871Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -34587,7 +32490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
   response:
     status:
       code: 200
@@ -34616,15 +32519,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txa156fcabf4e34a148df0a-005babd23c
+      - tx7d9e38cb13d642569b32e-005bd20a4b
       Date:
-      - Wed, 26 Sep 2018 18:38:52 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -34639,7 +32542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
   response:
     status:
       code: 200
@@ -34668,20 +32571,20 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx8f541a293d4641b7859ee-005babd23d
+      - tx867e75ed99524010b90a0-005bd20a4b
       Date:
-      - Wed, 26 Sep 2018 18:38:53 GMT
+      - Thu, 25 Oct 2018 18:24:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34693,15 +32596,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:53 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e322ebc8f2714f088305d816e764c1ea
+      - 731a02f8c1834d1f99110618f8268e7e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f656b5ef-44ca-467e-a509-89a5e60e904d
+      - req-8c2f7241-421c-44ea-acff-b27100836cbd
       Content-Length:
       - '7278'
       Connection:
@@ -34713,7 +32616,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:53.201351Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:12.194972Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34792,10 +32695,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sFx7xK6DS2ebmCqgjODoEw"],
-        "issued_at": "2018-09-26T18:38:53.201371Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XYz124NhSnqJW-q3_IivdQ"],
+        "issued_at": "2018-10-25T18:24:12.194993Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -34810,7 +32713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e322ebc8f2714f088305d816e764c1ea
+      - 731a02f8c1834d1f99110618f8268e7e
   response:
     status:
       code: 200
@@ -34823,22 +32726,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987133.32187'
+      - '1540491852.32435'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987133.32187'
+      - '1540491852.32435'
       X-Trans-Id:
-      - tx1ff069fa81bd4e04a6602-005babd23d
+      - tx7ec7c95074ba498395d3b-005bd20a4c
       Date:
-      - Wed, 26 Sep 2018 18:38:53 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -34853,7 +32756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 959838eb0cee416fb555c774d0542386
+      - 48f8e77486d14079af9d597bbde854bd
   response:
     status:
       code: 200
@@ -34866,28 +32769,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987134.43105'
+      - '1540491852.44465'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987134.43105'
+      - '1540491852.44465'
       X-Trans-Id:
-      - txc2fc577fc7704e00b6924-005babd23e
+      - tx7ece0df71def4a0d8db01-005bd20a4c
       Date:
-      - Wed, 26 Sep 2018 18:38:54 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -34899,15 +32802,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:54 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 11d0a7c47a7349baa6df25e7763c575c
+      - 4113fafe11c44016801d1ec78fd05b30
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e59086cf-5aa7-4ffa-9378-fe344950f8e9
+      - req-ef97b384-67a2-4d88-864e-8149025e98b8
       Content-Length:
       - '7265'
       Connection:
@@ -34919,7 +32822,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:54.610305Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:12.638781Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -34998,10 +32901,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XHDw0niETcy9pk-O9CnQcQ"],
-        "issued_at": "2018-09-26T18:38:54.610325Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmSrq_NPTIGWrWAzu6iszw"],
+        "issued_at": "2018-10-25T18:24:12.638803Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -35016,7 +32919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11d0a7c47a7349baa6df25e7763c575c
+      - 4113fafe11c44016801d1ec78fd05b30
   response:
     status:
       code: 200
@@ -35029,28 +32932,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987134.73233'
+      - '1540491852.76760'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987134.73233'
+      - '1540491852.76760'
       X-Trans-Id:
-      - txa9cae04a4e154b639f0fa-005babd23e
+      - txd585523dbfe949b98100f-005bd20a4c
       Date:
-      - Wed, 26 Sep 2018 18:38:54 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -35062,15 +32965,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:38:54 GMT
+      - Thu, 25 Oct 2018 18:24:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7878b436e85463baeeae9c6bd90d3c8
+      - 06c77d14b0ad43fda0443ea14e2ffa00
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9567423a-5642-49a3-b374-04887bf49f11
+      - req-1200c333-c7f2-4274-8787-9b4039fb6939
       Content-Length:
       - '7278'
       Connection:
@@ -35082,7 +32985,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:38:54.926304Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:12.987502Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -35161,10 +33064,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UD_jhO7hR2msHFqTljGWpQ"],
-        "issued_at": "2018-09-26T18:38:54.926330Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_A2_HjPxSm-JIWMfGIR98Q"],
+        "issued_at": "2018-10-25T18:24:12.987528Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -35179,7 +33082,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7878b436e85463baeeae9c6bd90d3c8
+      - 06c77d14b0ad43fda0443ea14e2ffa00
   response:
     status:
       code: 200
@@ -35192,22 +33095,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987135.05532'
+      - '1540491853.13466'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987135.05532'
+      - '1540491853.13466'
       X-Trans-Id:
-      - tx3b4b49fc3ff24971b682f-005babd23f
+      - tx094210218be641b3ab80f-005bd20a4d
       Date:
-      - Wed, 26 Sep 2018 18:38:55 GMT
+      - Thu, 25 Oct 2018 18:24:13 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -35222,7 +33125,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
   response:
     status:
       code: 200
@@ -35243,9 +33146,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txd68de898d2394433968b0-005babd23f
+      - txc9b907d88fcc48ccb3d5d-005bd20a4d
       Date:
-      - Wed, 26 Sep 2018 18:38:55 GMT
+      - Thu, 25 Oct 2018 18:24:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -35255,7 +33158,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -35270,7 +33173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
   response:
     status:
       code: 200
@@ -35291,14 +33194,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx9d9fdd8ee15e4c57a81c2-005babd23f
+      - tx4655e714563547a8b481a-005bd20a4d
       Date:
-      - Wed, 26 Sep 2018 18:38:55 GMT
+      - Thu, 25 Oct 2018 18:24:13 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -35313,7 +33216,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489c76e625084a3d8f27a103928541e4
+      - 9ccd4d47522041608afa017e1a0895f0
   response:
     status:
       code: 200
@@ -35334,12 +33237,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0b080b7c903146c2bedbb-005babd23f
+      - tx84c5f0901506429fb38c1-005bd20a4d
       Date:
-      - Wed, 26 Sep 2018 18:38:55 GMT
+      - Thu, 25 Oct 2018 18:24:13 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:38:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:49 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a9a3170-7e4e-4a49-8689-99c7421652d9
+      - req-aabef904-f8d3-4e3f-b182-bbb5149b22a4
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:49.638252Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:19.290231Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ET684I-RSGir2ApfcCKjwA"],
-        "issued_at": "2018-09-26T18:39:49.638275Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OasnnWq-S7mMWbp4UKaybw"],
+        "issued_at": "2018-10-25T18:24:19.290251Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:49 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,21 +182,21 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-395680ee-cab8-4fe5-bc34-26cff2cdc745
+      - req-dbfe3f2d-6f2f-4080-add4-00cf9c1496c9
       Date:
-      - Wed, 26 Sep 2018 18:39:49 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e0d68319-adc4-404d-8c32-6468ae5222b4
+      - req-a02bbb19-9d44-434e-9456-b40fe5c59fd2
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:50.072023Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:19.706814Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gr4HyypPQyiT02k-g9QkZg"],
-        "issued_at": "2018-09-26T18:39:50.072044Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vNPMSIi_RiWxdkUtU-g7XQ"],
+        "issued_at": "2018-10-25T18:24:19.706838Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee1d3c40-cc68-41e9-895b-49b2057dcf14
+      - req-20219a07-b943-4612-a4ee-14a8f3ea0db7
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-ee1d3c40-cc68-41e9-895b-49b2057dcf14
+      - req-20219a07-b943-4612-a4ee-14a8f3ea0db7
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6fd7674d-21f7-4722-90ab-d3787f806427
+      - req-90dc134d-859c-484e-8646-d519e217207f
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:39:49.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:24:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:39:49.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:24:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:39:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:24:13.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:39:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:24:15.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:39:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:24:16.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ae0658aa-84a3-4482-9d24-a4392083b4fd
+      - req-d10a1996-85e1-4ac0-94fb-1696bb3dd788
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:39:49.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:24:14.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:39:49.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:24:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:39:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:24:13.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:39:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:24:15.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:39:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:24:16.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-65a729ed-8a90-4f7f-932d-682d5a84cd9c
+      - req-56f2867e-bd66-4d6b-8136-3d2b5ef63e54
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-6699cd39-969c-4d43-8260-30cbdb3ea239
+      - req-90d7d60f-6cd3-4d61-b676-4228ff019756
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-68c260f2-a56a-407d-a3e7-bc8b6862cc20
+      - req-bee01574-e4c5-4c07-a7b8-3fc55b277250
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-96e21ca1-eb09-4377-963a-694c7b3290c5
+      - req-b3297c08-db98-4664-bfc4-be1d1942f1bf
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,13 +613,13 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:50 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 389cf49ec52243aeb384b6b5874b5da2
+      - d81018949b0942039349a0db44daa1fe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dc8fc91f-486b-413c-a758-5d7338761d45
+      - req-b4f8ee43-2ae9-4659-9fb5-6345e88ed861
       Content-Length:
       - '7311'
       Connection:
@@ -651,7 +651,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:51.024691Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:20.657498Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -730,10 +730,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0sCuTXR8Q8-SYOkDq_cYEA"],
-        "issued_at": "2018-09-26T18:39:51.024710Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QXbVx-slR6a0G7Swyj3P_g"],
+        "issued_at": "2018-10-25T18:24:20.657519Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -748,20 +748,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 389cf49ec52243aeb384b6b5874b5da2
+      - d81018949b0942039349a0db44daa1fe
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d00de6a-5c80-4469-9baf-6ac5a7b8f371
+      - req-3fd60159-529c-47c0-91cc-98b88b538805
       Content-Length:
       - '2179'
       Connection:
@@ -794,7 +794,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -809,7 +809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -822,21 +822,21 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-537a78c9-aec2-4d2e-bd60-c8e5177ef743
+      - req-61c58568-0e6f-4621-9311-98e931195125
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -848,15 +848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4ae0454b4cf54a0daa2081ec06f9aa98
+      - 5e1aff5ec0484f4e9e5736516ec7cd28
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c92759b3-fc52-4bd6-857f-daf73b1c08dd
+      - req-90f5dde4-5401-4b3a-b293-4c2af56f5c06
       Content-Length:
       - '7311'
       Connection:
@@ -868,7 +868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:51.418363Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:21.084902Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -947,49 +947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["auxeQyG2QnmdOLhCrxrVtA"],
-        "issued_at": "2018-09-26T18:39:51.418383Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R5dAsMepT8eMSltOHKAYVA"],
+        "issued_at": "2018-10-25T18:24:21.084923Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4ae0454b4cf54a0daa2081ec06f9aa98
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.206:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.206:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.206:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -1004,7 +965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ae0454b4cf54a0daa2081ec06f9aa98
+      - 5e1aff5ec0484f4e9e5736516ec7cd28
   response:
     status:
       code: 200
@@ -1015,9 +976,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0519f6a8-6b57-462c-b955-2895372559ed
+      - req-31ca643b-51f5-42b5-97c6-16560b3ea0aa
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1059,7 +1020,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -1074,7 +1035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ae0454b4cf54a0daa2081ec06f9aa98
+      - 5e1aff5ec0484f4e9e5736516ec7cd28
   response:
     status:
       code: 200
@@ -1085,14 +1046,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-35122dc1-f1a3-41a0-9191-6afad67f2808
+      - req-ed956f86-ce66-4e30-aa1e-5fb9a3e8ab32
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -1107,7 +1068,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1120,9 +1081,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-c5e2aa28-e92f-4f9a-a627-de30812ef39f
+      - req-2be1ce34-fc67-45c1-bcac-444a5a1d16eb
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1132,7 +1093,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1147,7 +1108,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1160,9 +1121,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2156c169-128f-4a24-9199-85f61dc56654
+      - req-6a2b2e53-622f-4c5b-88c1-22bcc1aa1205
       Date:
-      - Wed, 26 Sep 2018 18:39:51 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1172,13 +1133,13 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1190,15 +1151,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 83fb0b06dbee4e62aa7ecd9ce0af1937
+      - 8f631613b3b74216a0536221a2db51aa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2c59b6e6-e56b-44ff-948f-a01a3dd57afc
+      - req-75eef0b5-1937-42bf-a316-a7b8a2acb10b
       Content-Length:
       - '7311'
       Connection:
@@ -1210,7 +1171,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:52.112212Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:21.718674Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1289,16 +1250,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["riZrvZOdSF6QljVmjll-lQ"],
-        "issued_at": "2018-09-26T18:39:52.112232Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8ad2KO4FQTKDaoH-yHRrmw"],
+        "issued_at": "2018-10-25T18:24:21.718699Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1310,15 +1271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
+      - Thu, 25 Oct 2018 18:24:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be9fbce2c3ab471cb03de0507ac2159d
+      - 15001c0d532545d1826bad7c6a240519
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47238962-3447-4038-ad1b-14dcc65a9277
+      - req-0883d6c4-6985-458c-aba1-141425372226
       Content-Length:
       - '297'
       Connection:
@@ -1327,15 +1288,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:39:52.271723Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:21.887839Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["13a0gXzxSsySZrObVirTDA"],
-        "issued_at": "2018-09-26T18:39:52.271743Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KnX_OJJaSDOlxyybicvquA"],
+        "issued_at": "2018-10-25T18:24:21.887859Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:21 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -1347,29 +1308,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be9fbce2c3ab471cb03de0507ac2159d
+      - 15001c0d532545d1826bad7c6a240519
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d893ee5-28b7-4c9e-85eb-56ea7828bf11
+      - req-839b344a-b383-418a-b7fd-24270e34e523
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -1393,13 +1354,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"be9fbce2c3ab471cb03de0507ac2159d"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1411,196 +1372,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 671c2937b96c4bd6960e5b30d698e699
+      - 215d7b47250645168667d3794b615a62
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f2a959e0-83bc-4730-a392-0c8fb1ee973b
-      Content-Length:
-      - '7313'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:52.271723Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m8lCLJLLQUqVqhaTd60V-Q",
-        "13a0gXzxSsySZrObVirTDA"], "issued_at": "2018-09-26T18:39:52.572477Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 671c2937b96c4bd6960e5b30d698e699
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ddbe2fe6-90b7-44da-81c6-3b44ae6a6359
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 6c796e0876144e3289f3a55565edc44f
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-5dac36bd-47d7-4711-b9a7-904d907f914b
+      - req-b89b6166-a27a-49b3-a035-2b7eeee2ff1b
       Content-Length:
       - '7278'
       Connection:
@@ -1612,7 +1392,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:52.878844Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:22.215578Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1691,10 +1471,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J0r814StSi2V9Twwdp-Mbw"],
-        "issued_at": "2018-09-26T18:39:52.878867Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_gLaWxMiTlS85teOJ6ToSw"],
+        "issued_at": "2018-10-25T18:24:22.215598Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1709,7 +1489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c796e0876144e3289f3a55565edc44f
+      - 215d7b47250645168667d3794b615a62
   response:
     status:
       code: 200
@@ -1720,7 +1500,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:52 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1729,13 +1509,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1747,15 +1527,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:53 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 636d6f5119344a558bcaa6a0221c4688
+      - ecf802efb0e841fa8ee3e7b01874f6d6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-532543cf-c53b-4253-8813-7793cf149e73
+      - req-c73dc7b8-08ba-4c3c-80c5-f79f4e3802cd
       Content-Length:
       - '7278'
       Connection:
@@ -1767,7 +1547,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:53.151683Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:22.497516Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1846,10 +1626,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YQq2-Gm5T_Wt_a9G0MxASg"],
-        "issued_at": "2018-09-26T18:39:53.151702Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bsKr6oaqSyer7sW7QSthIw"],
+        "issued_at": "2018-10-25T18:24:22.497536Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1864,7 +1644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 636d6f5119344a558bcaa6a0221c4688
+      - ecf802efb0e841fa8ee3e7b01874f6d6
   response:
     status:
       code: 200
@@ -1875,7 +1655,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:53 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1884,13 +1664,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1902,15 +1682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:53 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c704a072c4bd4fc991dd5f5d95826e2f
+      - f22ffeeaf87641cab8f4c158f10a5090
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9592fead-52ae-4f48-bf28-fece4fc511d8
+      - req-6f017271-bcc4-490d-ab99-c5098f62bcf5
       Content-Length:
       - '7264'
       Connection:
@@ -1922,7 +1702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:53.414237Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:22.775539Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2001,10 +1781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7m3T7gCMRnq66AurEnoMXA"],
-        "issued_at": "2018-09-26T18:39:53.414255Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yl_ocQEEQ2yg6Z0Y2CPRiw"],
+        "issued_at": "2018-10-25T18:24:22.775559Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2019,7 +1799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c704a072c4bd4fc991dd5f5d95826e2f
+      - f22ffeeaf87641cab8f4c158f10a5090
   response:
     status:
       code: 200
@@ -2030,7 +1810,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:53 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2039,13 +1819,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2057,15 +1837,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:53 GMT
+      - Thu, 25 Oct 2018 18:24:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b2cf2d34c40b47f39122ac646d47e509
+      - 6b5c05cfcb6e40a18e2308332ed6c4cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-42b60d86-4a7e-4e05-a6bb-32ffb698c557
+      - req-654c0263-ff2d-4ef4-9f48-9fbcf0049b45
       Content-Length:
       - '7278'
       Connection:
@@ -2077,7 +1857,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:53.922205Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:23.073510Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2156,10 +1936,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Tc8Zx6TXT7ew3IvNpnV0Nw"],
-        "issued_at": "2018-09-26T18:39:53.922224Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gx3j1SsgTDW3EjgwcJk18Q"],
+        "issued_at": "2018-10-25T18:24:23.073532Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2174,7 +1954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2cf2d34c40b47f39122ac646d47e509
+      - 6b5c05cfcb6e40a18e2308332ed6c4cd
   response:
     status:
       code: 200
@@ -2185,7 +1965,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2194,13 +1974,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2212,15 +1992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee895e520aa046599f7243d6b81026fa
+      - 62ac34c500f04a6595fa2a8d17ef49cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-558bc77c-fe33-4294-943f-51bbea01d0c7
+      - req-e1a6cd55-69b6-4475-9e7d-4b2d5e81e261
       Content-Length:
       - '7265'
       Connection:
@@ -2232,7 +2012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:54.228905Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:23.346170Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2311,10 +2091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BMZoMRbYTCSL5Rl2cD0HYA"],
-        "issued_at": "2018-09-26T18:39:54.228928Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["omB_FfprQ72BR1UBoCTVjA"],
+        "issued_at": "2018-10-25T18:24:23.346189Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2329,7 +2109,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee895e520aa046599f7243d6b81026fa
+      - 62ac34c500f04a6595fa2a8d17ef49cb
   response:
     status:
       code: 200
@@ -2340,7 +2120,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2349,13 +2129,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2367,15 +2147,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 13ff6821476d4434a88a1230e11f9ef4
+      - 248f1080f6674a8da99923edaf11df50
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79b651df-6643-491d-9bd7-11e2ee376b51
+      - req-5e569c60-0e6b-4068-8026-d31cd0e0f83e
       Content-Length:
       - '7278'
       Connection:
@@ -2387,7 +2167,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:54.507155Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:23.621924Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2466,10 +2246,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eBLwh1FNSSqJ4xMjIBTpBg"],
-        "issued_at": "2018-09-26T18:39:54.507174Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WFr3uonCSIKDMVxI80ansA"],
+        "issued_at": "2018-10-25T18:24:23.621957Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2484,7 +2264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13ff6821476d4434a88a1230e11f9ef4
+      - 248f1080f6674a8da99923edaf11df50
   response:
     status:
       code: 200
@@ -2495,7 +2275,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2504,13 +2284,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2522,15 +2302,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 70d9f8c600eb4cb8a0757f49237aaa18
+      - 83b9bef3119c4db3bdca10a14e496c82
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-00adae42-2b4f-45ff-b382-66889a9e6ec7
+      - req-39101b13-6067-4502-ad15-e63f195c0db1
       Content-Length:
       - '7278'
       Connection:
@@ -2542,7 +2322,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:54.785119Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:23.907370Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2621,10 +2401,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bc91NRF8SXepff_ywLNxtw"],
-        "issued_at": "2018-09-26T18:39:54.785138Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9Hjsdc7AQKCwff_o7kcWZg"],
+        "issued_at": "2018-10-25T18:24:23.907393Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -2639,7 +2419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70d9f8c600eb4cb8a0757f49237aaa18
+      - 83b9bef3119c4db3bdca10a14e496c82
   response:
     status:
       code: 200
@@ -2650,20 +2430,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-454de69e-0965-4175-b713-d5c79e17c373
+      - req-8b2c703b-15a4-44cb-a9ba-4a3127c78585
       Date:
-      - Wed, 26 Sep 2018 18:39:54 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2675,15 +2455,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a03d8bb729ae46b683d401f15bf41384
+      - 7065d17bd72f4115848ead57489d5630
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-99ca1b4e-588e-4659-9f23-aad161d7e893
+      - req-4d525161-8723-4281-8382-2c85fe4d0b1a
       Content-Length:
       - '7278'
       Connection:
@@ -2695,7 +2475,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:55.090870Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:24.236698Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2774,10 +2554,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b7xYlmA8TueWTafa5OeHoQ"],
-        "issued_at": "2018-09-26T18:39:55.090890Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UCS_4cLPQT25L56JXpjBLA"],
+        "issued_at": "2018-10-25T18:24:24.236719Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -2792,7 +2572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a03d8bb729ae46b683d401f15bf41384
+      - 7065d17bd72f4115848ead57489d5630
   response:
     status:
       code: 200
@@ -2803,20 +2583,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2de74762-d98a-49d9-9a5c-492731684a69
+      - req-13d23c53-d21e-429c-886d-55a5f69bfd92
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2828,15 +2608,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ac484980-b6c9-4a0c-82cd-8c0a59c6d9b6
+      - req-4442e97c-1dd3-4fd0-9afd-7f7a0506cf88
       Content-Length:
       - '7264'
       Connection:
@@ -2848,7 +2628,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:55.401084Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:24.566021Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2927,10 +2707,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tcYHk2taRIK6r2I3nXptxA"],
-        "issued_at": "2018-09-26T18:39:55.401105Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xi8WM6CMQfe0mYVwyUNfvQ"],
+        "issued_at": "2018-10-25T18:24:24.566043Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -2945,7 +2725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -2956,9 +2736,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-880f78fc-321d-42f8-870e-a4d937e06a4e
+      - req-ce4825e0-1ade-481f-9cb8-8464ab076e84
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2992,7 +2772,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -3007,7 +2787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3018,20 +2798,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e23b4a03-f60e-4e35-9d0d-c5c527e2be2f
+      - req-47302f5c-0d7d-493e-830b-f0cf80c19b03
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3043,15 +2823,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ffad185ea8754e60ad9bdd0b755282c6
+      - 43d5ac9da18c4a1db5bc62720cb6521f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a797848-b5d8-4c3e-b89d-6f2ecbd81ffc
+      - req-6ced49b3-398e-4576-94d3-41509f70af1f
       Content-Length:
       - '7278'
       Connection:
@@ -3063,7 +2843,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:55.835388Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:25.053618Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3142,10 +2922,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ltTKRQtIQOaNOuntll1Afg"],
-        "issued_at": "2018-09-26T18:39:55.835407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N84zJlAxQq6nLiV2p4su5Q"],
+        "issued_at": "2018-10-25T18:24:25.053643Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -3160,7 +2940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ffad185ea8754e60ad9bdd0b755282c6
+      - 43d5ac9da18c4a1db5bc62720cb6521f
   response:
     status:
       code: 200
@@ -3171,14 +2951,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f66e9520-bf17-4d70-9d66-ca0902bca48b
+      - req-103da0b8-b7da-4668-b8c0-fdcbcfc95a2d
       Date:
-      - Wed, 26 Sep 2018 18:39:55 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -3193,7 +2973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 83fb0b06dbee4e62aa7ecd9ce0af1937
+      - 8f631613b3b74216a0536221a2db51aa
   response:
     status:
       code: 200
@@ -3204,20 +2984,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0ff2df5f-7d87-4a6c-8563-40ecf1fe86aa
+      - req-ef054352-c6f2-4e5f-ac18-a4a0500fb3fc
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3229,15 +3009,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e40462a7575d460a8b79f061b9b88fc3
+      - ce9b5d758d3c4de2942aac6d7353cd81
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e6096ebc-cb61-43ce-8472-46c416aa605a
+      - req-83a40a02-1d2e-4e59-8750-06010a9f9970
       Content-Length:
       - '7265'
       Connection:
@@ -3249,7 +3029,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:56.260952Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:25.497420Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3328,10 +3108,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vzUJbu2vS56IPNG15dzosQ"],
-        "issued_at": "2018-09-26T18:39:56.260972Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CtzJ6pXOQ6CMankVYZIQJg"],
+        "issued_at": "2018-10-25T18:24:25.497438Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -3346,7 +3126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e40462a7575d460a8b79f061b9b88fc3
+      - ce9b5d758d3c4de2942aac6d7353cd81
   response:
     status:
       code: 200
@@ -3357,20 +3137,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-acfc4226-75fe-4b0f-a902-72cbcf87826d
+      - req-a2411855-0a41-4613-bf24-b6faa3346bbb
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3382,15 +3162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e4d91c4ec95d4d5fa51b999a655c7cba
+      - e37e764546104afe88a3a014ee1600e6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0fd7a96-c30d-43a1-8bcb-e0bfe0bab355
+      - req-5f7771a7-da60-4006-b3ef-e3b8c9488c03
       Content-Length:
       - '7278'
       Connection:
@@ -3402,7 +3182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:56.565711Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:25.815915Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3481,10 +3261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["B7KHTfmDQFSee9x4Cwl1lg"],
-        "issued_at": "2018-09-26T18:39:56.565730Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WheN_1poTjqNcpJwH-I1kQ"],
+        "issued_at": "2018-10-25T18:24:25.815946Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -3499,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e4d91c4ec95d4d5fa51b999a655c7cba
+      - e37e764546104afe88a3a014ee1600e6
   response:
     status:
       code: 200
@@ -3510,14 +3290,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a6160080-90bf-43f6-8f3b-c8c35e60c67a
+      - req-a335b942-47e3-4c67-8cc9-44b27eba09c5
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -3532,7 +3312,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3543,9 +3323,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-da3e11ef-c1ff-469c-b416-8f86b62d3702
+      - req-8a8776e4-6f29-41ef-bdc6-7b99bfcc5cc2
       Date:
-      - Wed, 26 Sep 2018 18:39:56 GMT
+      - Thu, 25 Oct 2018 18:24:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3572,7 +3352,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -3587,7 +3367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3598,9 +3378,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f3df3ef4-cee3-4fef-bf66-e2ededae0f36
+      - req-fa18f46e-46b7-4701-a298-1f290472b7e7
       Date:
-      - Wed, 26 Sep 2018 18:39:57 GMT
+      - Thu, 25 Oct 2018 18:24:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3627,7 +3407,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -3642,7 +3422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3653,9 +3433,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ca757d54-722c-41f6-a0cd-ec08b5aa0240
+      - req-84f955ae-5867-4c64-a693-cccd5dbcddd8
       Date:
-      - Wed, 26 Sep 2018 18:39:57 GMT
+      - Thu, 25 Oct 2018 18:24:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3682,7 +3462,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -3697,7 +3477,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3708,9 +3488,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-888ec9a7-6c64-4830-acbd-32df3c37118e
+      - req-f8018cfd-ec2b-4907-98d7-12f3c92f0e14
       Date:
-      - Wed, 26 Sep 2018 18:39:57 GMT
+      - Thu, 25 Oct 2018 18:24:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3766,7 +3546,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -3781,7 +3561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -3792,9 +3572,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-0276b7e7-32b3-4fdb-bbb0-648a7cf2a686
+      - req-aa8d3b42-4c30-4430-afeb-0fbb1f5a6458
       Date:
-      - Wed, 26 Sep 2018 18:39:57 GMT
+      - Thu, 25 Oct 2018 18:24:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3806,7 +3586,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -3821,7 +3601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3834,13 +3614,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-4fd41dac-1a66-4ef1-add5-b5a0b3f7fa93
+      - req-40eee6a8-f9ec-4a3f-b220-33f1252485ec
       Date:
-      - Wed, 26 Sep 2018 18:39:57 GMT
+      - Thu, 25 Oct 2018 18:24:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:53:02Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -3882,7 +3662,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -3897,7 +3677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3910,9 +3690,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-0b7298d7-5658-48e1-9b34-576e6e9809fc
+      - req-27cf51a9-6f4a-47a8-89a8-efefe9b887db
       Date:
-      - Wed, 26 Sep 2018 18:39:58 GMT
+      - Thu, 25 Oct 2018 18:24:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -3936,7 +3716,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:53:07Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -3958,7 +3738,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -3973,7 +3753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3986,13 +3766,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-b49df1a4-48ae-434f-83fb-0f15e5a044e7
+      - req-80b382cb-5e80-44ba-ac44-861050245076
       Date:
-      - Wed, 26 Sep 2018 18:39:58 GMT
+      - Thu, 25 Oct 2018 18:24:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:52:52Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -4013,7 +3793,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:52:47Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -4036,7 +3816,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -4051,7 +3831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4064,9 +3844,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-e8ec1fb0-d0a2-4d80-b7c2-76a1922d4671
+      - req-d157a117-1e72-43b7-b602-8b209b3c38c6
       Date:
-      - Wed, 26 Sep 2018 18:39:58 GMT
+      - Thu, 25 Oct 2018 18:24:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -4108,7 +3888,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -4123,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4136,9 +3916,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-be181db5-c6cf-4851-882d-0711d848697e
+      - req-c3859729-82c6-48d7-9931-43616b1e60a6
       Date:
-      - Wed, 26 Sep 2018 18:39:58 GMT
+      - Thu, 25 Oct 2018 18:24:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -4161,7 +3941,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -4176,7 +3956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -4187,9 +3967,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8fbbaed6-3b7b-4dff-8455-3968fe120e40
+      - req-71153074-ec16-4761-a5b1-35d5ea67389a
       Date:
-      - Wed, 26 Sep 2018 18:39:58 GMT
+      - Thu, 25 Oct 2018 18:24:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4245,7 +4025,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -4260,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -4271,9 +4051,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-40485398-d465-46df-808f-fe129b78094c
+      - req-fb5ccbb8-018d-4f49-8c52-1b8aed3b9dee
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4285,7 +4065,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -4300,7 +4080,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -4311,9 +4091,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-403ca625-9c5b-49d0-8266-3d93859e7fa2
+      - req-4624b644-891c-4427-8e71-6f1f1d3b7b47
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4369,7 +4149,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -4384,7 +4164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d18b536d89c46a88040346d763096c6
+      - 28a664af733546c6b39cc148a90dced9
   response:
     status:
       code: 200
@@ -4395,9 +4175,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a3b22ccc-c9a3-4e5b-b4b3-49eecfd5f65a
+      - req-17cfbbdc-0e0d-4e81-a46d-d1b67b61becb
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4409,7 +4189,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4424,7 +4204,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c796e0876144e3289f3a55565edc44f
+      - 215d7b47250645168667d3794b615a62
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4437,9 +4217,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bffdeaba-bec2-453b-9437-99fad6097586
+      - req-66f1975f-d703-45f4-95b9-3ea86108f700
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4448,7 +4228,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4463,7 +4243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 636d6f5119344a558bcaa6a0221c4688
+      - ecf802efb0e841fa8ee3e7b01874f6d6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4476,9 +4256,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-37002498-28b8-4212-801d-cce83f0d8a6e
+      - req-a0a8bb50-e828-4402-b085-9905282ff7b0
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4487,7 +4267,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4502,7 +4282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c704a072c4bd4fc991dd5f5d95826e2f
+      - f22ffeeaf87641cab8f4c158f10a5090
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4515,9 +4295,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3658ab78-b52a-4c46-a624-dc36ec466d75
+      - req-454d2af7-d93f-4faf-a556-e1f836b31cba
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4526,7 +4306,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4541,7 +4321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b2cf2d34c40b47f39122ac646d47e509
+      - 6b5c05cfcb6e40a18e2308332ed6c4cd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4554,9 +4334,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6ce6ef70-4e0c-4bf8-b176-11fbc1fc36dd
+      - req-885a357e-fd80-4b7f-817b-7a197641f6d6
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4565,7 +4345,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4580,7 +4360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4593,9 +4373,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-eb0fd799-a9ea-4f50-afa0-de68e22d9c26
+      - req-39c07e4b-9148-4434-8f93-3aa34cfeaf3f
       Date:
-      - Wed, 26 Sep 2018 18:39:59 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4604,7 +4384,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4619,7 +4399,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee895e520aa046599f7243d6b81026fa
+      - 62ac34c500f04a6595fa2a8d17ef49cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4632,9 +4412,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-92194d11-2053-4189-80fe-89ec9a2840b4
+      - req-28d8c919-c776-4156-80ce-fb4ae684e648
       Date:
-      - Wed, 26 Sep 2018 18:40:00 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4643,7 +4423,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4658,7 +4438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13ff6821476d4434a88a1230e11f9ef4
+      - 248f1080f6674a8da99923edaf11df50
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4671,9 +4451,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2eb2da2f-700e-4ae5-b29a-443e3a1327a7
+      - req-86f72f29-d0c2-4684-97e7-bdbafc626d73
       Date:
-      - Wed, 26 Sep 2018 18:40:00 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4682,13 +4462,13 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4700,15 +4480,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:00 GMT
+      - Thu, 25 Oct 2018 18:24:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ec95b087b0fa4d9a97f168517bc71ed6
+      - d73c4ae451724292b5890961eabac120
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9f80d7d2-e565-4ad2-93c3-c7a746a69e78
+      - req-415c58e5-0467-4933-b04c-9365c75bc630
       Content-Length:
       - '7278'
       Connection:
@@ -4720,7 +4500,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:00.324296Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:29.970452Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4799,10 +4579,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-_b_yJd0S9S8jPQVn6KaLg"],
-        "issued_at": "2018-09-26T18:40:00.324329Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tl7G18b0Sx2jB-sA0pUJrg"],
+        "issued_at": "2018-10-25T18:24:29.970473Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4817,22 +4597,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec95b087b0fa4d9a97f168517bc71ed6
+      - d73c4ae451724292b5890961eabac120
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6726dc87-3edd-43b5-8412-2a4fbc318e7b
+      - req-6149fe48-4665-47e3-9c6f-002fc6ea328c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6726dc87-3edd-43b5-8412-2a4fbc318e7b
+      - req-6149fe48-4665-47e3-9c6f-002fc6ea328c
       Date:
-      - Wed, 26 Sep 2018 18:40:00 GMT
+      - Thu, 25 Oct 2018 18:24:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4842,13 +4622,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4860,15 +4640,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:00 GMT
+      - Thu, 25 Oct 2018 18:24:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a79b9f53e32b446b8e848c98d90fe76a
+      - 2ec37d796c084b5294b455b807d3e376
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8c5e862d-683f-4c9e-bd76-f8c4fd8e3ffa
+      - req-9dd14219-c3be-4387-8fac-9e9ba4f80f98
       Content-Length:
       - '7278'
       Connection:
@@ -4880,7 +4660,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:00.784376Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:30.423923Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4959,10 +4739,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["auKh-Q5JRSa-MC5w-sCcgA"],
-        "issued_at": "2018-09-26T18:40:00.784397Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wrKPrSFIR5iwP6rofAd5OQ"],
+        "issued_at": "2018-10-25T18:24:30.423962Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4977,22 +4757,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a79b9f53e32b446b8e848c98d90fe76a
+      - 2ec37d796c084b5294b455b807d3e376
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b0a29d0-d888-4d2f-9380-559a1e746741
+      - req-9054b371-cc85-48f2-a498-fe05ccece5cf
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3b0a29d0-d888-4d2f-9380-559a1e746741
+      - req-9054b371-cc85-48f2-a498-fe05ccece5cf
       Date:
-      - Wed, 26 Sep 2018 18:40:01 GMT
+      - Thu, 25 Oct 2018 18:24:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5002,13 +4782,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5020,15 +4800,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:01 GMT
+      - Thu, 25 Oct 2018 18:24:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d1baecff49b14d32a7674020cbe5389a
+      - 0f2173462a0f4bc5a235f87650140f77
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e208c4a5-e2ac-4e0f-a703-167ae91b1bab
+      - req-a1c23e2f-6d1c-4709-a24c-39b676632a3e
       Content-Length:
       - '7264'
       Connection:
@@ -5040,7 +4820,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:01.217539Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:30.868842Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5119,10 +4899,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zx5gtVUyQ2-NMHQnaePUww"],
-        "issued_at": "2018-09-26T18:40:01.217559Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I-mp97FBSZmyzG6iV9z_2Q"],
+        "issued_at": "2018-10-25T18:24:30.868862Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5137,22 +4917,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1baecff49b14d32a7674020cbe5389a
+      - 0f2173462a0f4bc5a235f87650140f77
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dec77607-052c-4fe3-b039-42fdec68c91a
+      - req-300fff51-b4f1-4817-9b2b-4c2e092cc71b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-dec77607-052c-4fe3-b039-42fdec68c91a
+      - req-300fff51-b4f1-4817-9b2b-4c2e092cc71b
       Date:
-      - Wed, 26 Sep 2018 18:40:01 GMT
+      - Thu, 25 Oct 2018 18:24:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5162,13 +4942,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5180,15 +4960,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:01 GMT
+      - Thu, 25 Oct 2018 18:24:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a2fdc06f439f40029b1a550f2cc94e14
+      - 95ea9f26fdbb4388b0fd2cd01d6b33ca
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-907a7c11-2eb6-487a-bf57-9971459f57cd
+      - req-4b265be4-b1bb-451e-8f8f-27944f4df7b4
       Content-Length:
       - '7278'
       Connection:
@@ -5200,7 +4980,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:01.661554Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:31.342286Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5279,10 +5059,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fy0GWcibS7mgNwzeMWwtXQ"],
-        "issued_at": "2018-09-26T18:40:01.661573Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WkBfe5ClRDOFfhSzhHvn6g"],
+        "issued_at": "2018-10-25T18:24:31.342305Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5297,22 +5077,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2fdc06f439f40029b1a550f2cc94e14
+      - 95ea9f26fdbb4388b0fd2cd01d6b33ca
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5305352f-8695-44e3-a24c-34c541bc86d8
+      - req-f57e5816-17fc-4c14-b331-53258f93ef9d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5305352f-8695-44e3-a24c-34c541bc86d8
+      - req-f57e5816-17fc-4c14-b331-53258f93ef9d
       Date:
-      - Wed, 26 Sep 2018 18:40:01 GMT
+      - Thu, 25 Oct 2018 18:24:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5322,7 +5102,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5337,22 +5117,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c32c64cc-b868-4d85-8ad7-544ae7caf5b8
+      - req-6a5163d0-e466-46f0-883d-66da56d178a8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c32c64cc-b868-4d85-8ad7-544ae7caf5b8
+      - req-6a5163d0-e466-46f0-883d-66da56d178a8
       Date:
-      - Wed, 26 Sep 2018 18:40:02 GMT
+      - Thu, 25 Oct 2018 18:24:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5362,13 +5142,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5380,15 +5160,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:02 GMT
+      - Thu, 25 Oct 2018 18:24:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 992b139ef0f0407c9d890b4e17236cdf
+      - 2d92f64e7990486c8b4166a8d4a543b2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e76b8a42-e3af-4f53-a8ab-59ed666f76a4
+      - req-b0d4a9dc-9ef4-42b3-a24d-c2e23b6f33ae
       Content-Length:
       - '7265'
       Connection:
@@ -5400,7 +5180,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:02.367981Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:32.094294Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5479,10 +5259,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HDd8zFwrT7mi4wqLhzI7Cw"],
-        "issued_at": "2018-09-26T18:40:02.368002Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xTDxmSEuQF6Jt45LjL5gfA"],
+        "issued_at": "2018-10-25T18:24:32.094320Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5497,22 +5277,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 992b139ef0f0407c9d890b4e17236cdf
+      - 2d92f64e7990486c8b4166a8d4a543b2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8747b586-dedf-464a-9752-31f0490af5ae
+      - req-efe6fe2f-5e87-493c-a967-a9aa9bdfff3c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-8747b586-dedf-464a-9752-31f0490af5ae
+      - req-efe6fe2f-5e87-493c-a967-a9aa9bdfff3c
       Date:
-      - Wed, 26 Sep 2018 18:40:02 GMT
+      - Thu, 25 Oct 2018 18:24:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5522,13 +5302,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5540,15 +5320,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:02 GMT
+      - Thu, 25 Oct 2018 18:24:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 48f945e98fef4aa18bcdf08c2a5e9a7b
+      - aac7d2ab68a54e88a47d0066fd3af272
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-922f53da-06c2-47a8-a3d7-953b12ae4b44
+      - req-110b6806-a401-40c6-9454-a52dd148ae14
       Content-Length:
       - '7278'
       Connection:
@@ -5560,7 +5340,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:02.810284Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:32.611702Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5639,10 +5419,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XfdfDGdISxWlx_2fa8cPeg"],
-        "issued_at": "2018-09-26T18:40:02.810304Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["22MO9eDwTeqGhXuKej1weA"],
+        "issued_at": "2018-10-25T18:24:32.611723Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5657,22 +5437,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f945e98fef4aa18bcdf08c2a5e9a7b
+      - aac7d2ab68a54e88a47d0066fd3af272
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a0e9810-dcb8-4424-abf5-a4f0619917d3
+      - req-7a748998-d9ab-40a8-9f53-6770dc466b07
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-7a0e9810-dcb8-4424-abf5-a4f0619917d3
+      - req-7a748998-d9ab-40a8-9f53-6770dc466b07
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5682,13 +5462,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5700,15 +5480,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2a43c0660a0d4f2f8997af78a8cac6cf
+      - 93acd59eed8647aab155ab7de513bb03
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64b2b529-b2e5-4d87-b5e4-e557804a232e
+      - req-b1d79e03-50ed-450b-85ff-6ee79ad7112a
       Content-Length:
       - '7311'
       Connection:
@@ -5720,7 +5500,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:03.251438Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:33.077352Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5799,48 +5579,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fZ0yEdupTYKG0slu96Kxiw"],
-        "issued_at": "2018-09-26T18:40:03.251457Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["V06A4ve2QEeXWfDz7WeSLA"],
+        "issued_at": "2018-10-25T18:24:33.077373Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2a43c0660a0d4f2f8997af78a8cac6cf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5852,15 +5600,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8665dcc6c372438d9c8def9da971e018
+      - 2109b32d5b344faab594377ae81f1bc8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a60c0936-da5f-4a1f-bb35-7b1afb7ec78d
+      - req-c10f2e1c-7832-4c97-99c4-da8eee25c5a4
       Content-Length:
       - '7278'
       Connection:
@@ -5872,7 +5620,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:03.529241Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:33.278713Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5951,10 +5699,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UiIt6cmNSsC9oK7CpLIcPw"],
-        "issued_at": "2018-09-26T18:40:03.529261Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ylbHFN0tT8igZJNMKLDqBA"],
+        "issued_at": "2018-10-25T18:24:33.278734Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5969,7 +5717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8665dcc6c372438d9c8def9da971e018
+      - 2109b32d5b344faab594377ae81f1bc8
   response:
     status:
       code: 200
@@ -5980,22 +5728,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6c0ca4e5-fc8d-4ed5-8e3a-c3dbd0a6f146
+      - req-7380a4a1-7ebf-4f49-aa5e-d6a99bf361d4
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6007,15 +5755,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 346968c5eb854a5cae84ead069ee7cf3
+      - c5208794d7e54c319f90b9b15c1c21c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b7b94355-faee-4de7-816b-c85359a0e4de
+      - req-81ecdc49-29e8-40cf-b8ff-7e9141e30450
       Content-Length:
       - '7278'
       Connection:
@@ -6027,7 +5775,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:03.832708Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:33.612114Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6106,10 +5854,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5KGlnTNJTpCzCzQ62RV3HA"],
-        "issued_at": "2018-09-26T18:40:03.832727Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5N-cQOBsSg2dsdQ01K_0DA"],
+        "issued_at": "2018-10-25T18:24:33.612135Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6124,7 +5872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 346968c5eb854a5cae84ead069ee7cf3
+      - c5208794d7e54c319f90b9b15c1c21c5
   response:
     status:
       code: 200
@@ -6135,22 +5883,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0a1fedf1-7c15-448d-9dcd-8788dc288d6c
+      - req-ac9140d7-f077-4031-825f-c59f28153dd7
       Date:
-      - Wed, 26 Sep 2018 18:40:03 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6162,15 +5910,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 54b6dd6325f44cfb924fc153a291d3b7
+      - b78b80f4ca6849fa93ee3a3a5342a715
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50e8f965-2cd8-48f7-b233-b4ced7f5c398
+      - req-f9d6e4a9-460b-4cc1-80e9-79b98a7cf407
       Content-Length:
       - '7264'
       Connection:
@@ -6182,7 +5930,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:04.139888Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:33.940663Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6261,10 +6009,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y9F2h_60SIy1B2mDQ3d03w"],
-        "issued_at": "2018-09-26T18:40:04.139910Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jhcq8L0TTzKYsjnH2sAXqQ"],
+        "issued_at": "2018-10-25T18:24:33.940685Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6279,7 +6027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 54b6dd6325f44cfb924fc153a291d3b7
+      - b78b80f4ca6849fa93ee3a3a5342a715
   response:
     status:
       code: 200
@@ -6290,22 +6038,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f68c049d-9e16-4afa-8707-ebd75751054e
+      - req-dac9ce99-0ded-4043-92d0-7146d86a53ba
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6317,15 +6065,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 205748eeae7d424a98a5a27125cb8b65
+      - 3a9f104271d7491ca96b2d9231aafaae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-610ace4e-ae8d-4640-8878-13b5cbb9b621
+      - req-bd303004-0ef1-4a16-9d90-bd5c89492e0a
       Content-Length:
       - '7278'
       Connection:
@@ -6337,7 +6085,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:04.483975Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:34.251279Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6416,10 +6164,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ab1XEiqkQL61GYxEwGFrNA"],
-        "issued_at": "2018-09-26T18:40:04.483995Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tAS1SpPrRoCU_l-jWgTboA"],
+        "issued_at": "2018-10-25T18:24:34.251299Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6434,7 +6182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 205748eeae7d424a98a5a27125cb8b65
+      - 3a9f104271d7491ca96b2d9231aafaae
   response:
     status:
       code: 200
@@ -6445,16 +6193,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-63c9a7bd-8713-4f45-92d9-cadaf3942030
+      - req-2ba1db3d-a416-4269-8d33-619dd7c91bce
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6469,7 +6217,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a43c0660a0d4f2f8997af78a8cac6cf
+      - 93acd59eed8647aab155ab7de513bb03
   response:
     status:
       code: 200
@@ -6480,22 +6228,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-26083c6b-52c0-4361-b1f6-16a0b613fd74
+      - req-ddd1acfc-f637-4caa-a2c1-b289950d624c
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6507,15 +6255,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:04 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 32b9a15aa52b465ca8c31182de557e48
+      - 9d407b34c4744e9f974f920f80a87a77
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-960b14b1-47e8-4bf1-b0bc-e013458f576e
+      - req-40c7a3b7-4cf3-4846-96d4-75b89ad023f5
       Content-Length:
       - '7265'
       Connection:
@@ -6527,7 +6275,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:04.892344Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:34.673415Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6606,10 +6354,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m0Z0YIFrSeuuO8j5yPmyDg"],
-        "issued_at": "2018-09-26T18:40:04.892365Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pDpP0LCUS52nM0tDiDAWtA"],
+        "issued_at": "2018-10-25T18:24:34.673437Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6624,7 +6372,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 32b9a15aa52b465ca8c31182de557e48
+      - 9d407b34c4744e9f974f920f80a87a77
   response:
     status:
       code: 200
@@ -6635,22 +6383,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-843f8b81-0722-420b-810d-2c8f0ab58526
+      - req-21813421-7c5d-4188-a88b-dfb44da03882
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6662,15 +6410,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 92da98696f254493bdf6fd2f00d228ba
+      - 4fb7bb1c53b04382bb100113eaf333a1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c7f9345-d87b-43bf-90de-ea32b798bffb
+      - req-22abc5ca-5245-46e8-bb53-9e042f2bcfc4
       Content-Length:
       - '7278'
       Connection:
@@ -6682,7 +6430,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:05.201841Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:35.027548Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6761,10 +6509,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HhBYEuxlS_ysQ6eooKvGdQ"],
-        "issued_at": "2018-09-26T18:40:05.201861Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["esawokgwRTqa4InjR7M8kQ"],
+        "issued_at": "2018-10-25T18:24:35.027574Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6779,7 +6527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92da98696f254493bdf6fd2f00d228ba
+      - 4fb7bb1c53b04382bb100113eaf333a1
   response:
     status:
       code: 200
@@ -6790,16 +6538,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3fb87e8e-1acb-4896-a359-b999c8b05202
+      - req-c8efd62d-11ca-4cee-93f6-c3badfbbaed0
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6575,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-34ccd8e4-6c13-4dea-9ae9-ec498f1d6cf9
+      - req-6c70ad78-396b-4e9a-9c23-4a224688ce7f
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6610,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bcbd79c7-c575-4585-8e59-df8bc120fd2b
+      - req-f1cb8d83-0c3b-4558-ac76-1b811425b029
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6645,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-802a720e-70bb-45d9-809a-0e29c7bafc20
+      - req-a54b7bbb-4dd2-4765-bef7-4c7b21548a37
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6680,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8bb945db-395f-414f-b72d-ba5a77955adc
+      - req-a0d45b4c-c894-4ca7-894e-2e2f18ee099f
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6715,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-83be27f5-8607-47d7-b74d-7d33b64f6e61
+      - req-7c085150-9f34-4c40-b257-84eda70f29a9
       Date:
-      - Wed, 26 Sep 2018 18:40:05 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6989,7 +6737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,15 +6750,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-59ad556a-ccf8-4c24-ae93-a20bfda7d34e
+      - req-f86de59b-e1a6-46ea-8641-b561e65ef1f3
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7025,7 +6773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7038,14 +6786,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-60a32058-49a6-4970-b712-58984940c42e
+      - req-8f5406a2-9bee-4d10-84a5-b52783855e5b
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -7060,7 +6808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7073,15 +6821,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c009bbbd-a480-4896-bfef-7f5d7af9627b
+      - req-43d8b68b-ece7-43c8-a208-6002504f8929
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7096,7 +6844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7109,14 +6857,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-17f21c22-bf51-4768-b0f1-a3a75d28ceb9
+      - req-ed61ca1e-56bc-4e79-bb38-6e0fa5d6952d
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7131,7 +6879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7144,14 +6892,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-acbafd6c-5f28-4237-8576-c5ed938cb256
+      - req-c7d1828d-6cbc-4162-9870-3c784c0f84cb
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7166,7 +6914,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7179,20 +6927,20 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-396ac70f-25aa-45ca-9207-846e8e310d1d
+      - req-f92a690b-5562-4253-90dc-58a3b449d118
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7204,15 +6952,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:06 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e941b29984246d29995fd7c87ed360c
+      - bee97f4b98254588a1860feb803f2e61
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f48d04ec-1469-4cd8-af6a-f9b172fe050e
+      - req-72f01e88-2fa1-4109-8179-ecde86e6761d
       Content-Length:
       - '7311'
       Connection:
@@ -7224,7 +6972,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:06.894908Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:36.812457Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7303,16 +7051,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["22pBl1jARYmS1Uv0awo9ug"],
-        "issued_at": "2018-09-26T18:40:06.894928Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1HdPQuhrSiGtWbHYTORPGw"],
+        "issued_at": "2018-10-25T18:24:36.812478Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"8e941b29984246d29995fd7c87ed360c"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7324,135 +7072,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
+      - Thu, 25 Oct 2018 18:24:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8fa20f25d05546b9bf4558fb65702380
+      - f9fd674928294735a9e6f02d81603830
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b64e3cfa-0971-4cde-b1be-2a08b6615e58
-      Content-Length:
-      - '7346'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:06.894908Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9e6ZTg7xTYinWqS79xp7-w",
-        "22pBl1jARYmS1Uv0awo9ug"], "issued_at": "2018-09-26T18:40:07.076091Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 8a526bd88bb047fbb02af468a1921fab
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-26a53de3-a16c-4709-8334-2ecabea142b4
+      - req-a6fb3702-9991-47f4-b988-dc2e06316f66
       Content-Length:
       - '7311'
       Connection:
@@ -7464,7 +7092,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:07.271427Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:37.059973Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7543,130 +7171,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gpsgZYe_TrSjXW7UkN9qrw"],
-        "issued_at": "2018-09-26T18:40:07.271445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9dJGz-QzRwGhHoVuEGXfFg"],
+        "issued_at": "2018-10-25T18:24:37.060010Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"8a526bd88bb047fbb02af468a1921fab"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - a8cdc3f5639b4f04809fc9663efe788d
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-f0efd9b4-43cf-492b-96b6-1ea5998abdd4
-      Content-Length:
-      - '7346'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:07.271427Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["34uoosd_QwWyV8GI2nkXdg",
-        "gpsgZYe_TrSjXW7UkN9qrw"], "issued_at": "2018-09-26T18:40:07.448477Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -7681,7 +7189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2dea344e0964a7d8645589889992ad9
+      - 85dc3e037ff1478f99a91d0eec9026bd
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7694,14 +7202,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-162618bb-0133-4ecc-b532-2084378a7955
+      - req-72ba8f47-9d85-465e-be20-61fb9e17406d
       Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -7716,22 +7224,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c53e04a0-a329-418e-8408-6c8594dc5778
+      - req-1322c559-d290-4526-badc-25a2ab47b0fa
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-c53e04a0-a329-418e-8408-6c8594dc5778
+      - req-1322c559-d290-4526-badc-25a2ab47b0fa
       Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7764,7 +7272,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -7779,22 +7287,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bbdabdeb-73fe-4ab7-a77f-d517a08579fb
+      - req-31605f0b-a5b4-4ee2-8b28-522e30dd3b73
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-bbdabdeb-73fe-4ab7-a77f-d517a08579fb
+      - req-31605f0b-a5b4-4ee2-8b28-522e30dd3b73
       Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -7811,7 +7319,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -7826,27 +7334,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6483d048-2e7f-4f9c-b086-78da9bce9d96
+      - req-4cf9e29e-e9bb-4288-81ba-a23089d3c6e1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6483d048-2e7f-4f9c-b086-78da9bce9d96
+      - req-4cf9e29e-e9bb-4288-81ba-a23089d3c6e1
       Date:
-      - Wed, 26 Sep 2018 18:40:07 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -7861,22 +7369,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-321d6da7-f1d4-4fda-b61c-f04e6b8609ba
+      - req-5782a9b7-9ded-4d7f-8383-76f6a5017816
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-321d6da7-f1d4-4fda-b61c-f04e6b8609ba
+      - req-5782a9b7-9ded-4d7f-8383-76f6a5017816
       Date:
-      - Wed, 26 Sep 2018 18:40:08 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -7891,7 +7399,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -7906,22 +7414,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-83e110f4-ce45-4685-9020-abbf52daa9e3
+      - req-f43324c8-e3e3-46ae-96f1-2a5b9f8fb5ec
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-83e110f4-ce45-4685-9020-abbf52daa9e3
+      - req-f43324c8-e3e3-46ae-96f1-2a5b9f8fb5ec
       Date:
-      - Wed, 26 Sep 2018 18:40:08 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7954,7 +7462,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -7969,22 +7477,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fafb1420-b560-4572-a0f8-cf2ee6e12233
+      - req-b9957907-ddc5-4cae-99dc-168e50ab56e8
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-fafb1420-b560-4572-a0f8-cf2ee6e12233
+      - req-b9957907-ddc5-4cae-99dc-168e50ab56e8
       Date:
-      - Wed, 26 Sep 2018 18:40:08 GMT
+      - Thu, 25 Oct 2018 18:24:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -8025,7 +7533,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -8040,22 +7548,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e21de9f1-00d4-46dc-a043-f7321abef067
+      - req-ad84257d-e573-40ac-88a2-07b6e7f26783
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-e21de9f1-00d4-46dc-a043-f7321abef067
+      - req-ad84257d-e573-40ac-88a2-07b6e7f26783
       Date:
-      - Wed, 26 Sep 2018 18:40:08 GMT
+      - Thu, 25 Oct 2018 18:24:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -8089,7 +7597,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -8104,33 +7612,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b45cb8291e14fa28794423c7f3f9494
+      - e717ded0b812448380d7dd4ddb0bd929
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cef6e366-3979-4653-9694-e342f7044d6a
+      - req-d74769cd-b4a2-4c1b-a2ad-12570558cd87
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cef6e366-3979-4653-9694-e342f7044d6a
+      - req-d74769cd-b4a2-4c1b-a2ad-12570558cd87
       Date:
-      - Wed, 26 Sep 2018 18:40:08 GMT
+      - Thu, 25 Oct 2018 18:24:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8142,15 +7650,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:09 GMT
+      - Thu, 25 Oct 2018 18:24:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c368a1c8b10d4ae3bc24f43d30c65a40
+      - e9b99624860d4879977f409087aa95e5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aae3308e-28a6-4f9c-9b04-9627f71e7329
+      - req-5ca9dfc2-014c-4512-b393-c7a78347766b
       Content-Length:
       - '7311'
       Connection:
@@ -8162,7 +7670,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:09.852587Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.317680Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8241,16 +7749,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-bIjg9qUQqGIUupHgUCU-g"],
-        "issued_at": "2018-09-26T18:40:09.852607Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qfJDDJTMQzGpWlEXKxqHJQ"],
+        "issued_at": "2018-10-25T18:24:39.317700Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8262,15 +7770,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:09 GMT
+      - Thu, 25 Oct 2018 18:24:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a76626c8-7be9-4af0-8913-459218c58de4
+      - req-a1bdb101-803a-481c-9687-8ff52b93d839
       Content-Length:
       - '7311'
       Connection:
@@ -8282,7 +7790,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:10.064416Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.513114Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8361,10 +7869,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aJ3TGS2LSpm6rBYCdRfG4g"],
-        "issued_at": "2018-09-26T18:40:10.064436Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bp-qpZ14R_KTe2JmVM7RtQ"],
+        "issued_at": "2018-10-25T18:24:39.513144Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8379,7 +7887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -8390,32 +7898,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-3bf8ddb3-656d-4eb4-af6c-a7d7d9426294
+      - req-c9417962-370e-4699-a08f-50f8ba9a7476
       Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
+      - Thu, 25 Oct 2018 18:24:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
-        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -8455,20 +7948,35 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8480,15 +7988,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
+      - Thu, 25 Oct 2018 18:24:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8452773599664e0190a4d1270a1b9ffd
+      - 9f7cb741750147aaa6007116878b29dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-68ca88d4-df66-45cd-933c-56fc99d2dbf9
+      - req-50fbdbcc-330c-4187-9226-ec8e6b604178
       Content-Length:
       - '7311'
       Connection:
@@ -8500,7 +8008,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:10.409310Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:39.848896Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8579,16 +8087,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I2EcDTw6Qf-pzBoTFffVIA"],
-        "issued_at": "2018-09-26T18:40:10.409330Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K87rHEeoQ0W3ozSb-IVrgw"],
+        "issued_at": "2018-10-25T18:24:39.848918Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8600,15 +8108,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
+      - Thu, 25 Oct 2018 18:24:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 90b862ddcadb481b84967ab3032b6e8b
+      - c84eee5e7c854ef09ac5cb1bb7759abb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a24dff1c-19ce-45bf-9fc5-6babaab1fbbb
+      - req-cadda6d6-3250-4ba0-a531-2d1ccd7c70cc
       Content-Length:
       - '297'
       Connection:
@@ -8617,15 +8125,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:40:10.572131Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:40.021722Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tcD1OjcbQ3CbP5kdKep8JA"],
-        "issued_at": "2018-09-26T18:40:10.572150Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KCmagZR_QReASil9Kz9nxg"],
+        "issued_at": "2018-10-25T18:24:40.021740Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -8637,29 +8145,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90b862ddcadb481b84967ab3032b6e8b
+      - c84eee5e7c854ef09ac5cb1bb7759abb
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
+      - Thu, 25 Oct 2018 18:24:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2616de2-0bf5-4bcb-b475-56d0f1c2cf37
+      - req-e76d7994-8d9f-4f7b-821b-b625599ef542
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -8683,13 +8191,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"90b862ddcadb481b84967ab3032b6e8b"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8701,27 +8209,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
+      - Thu, 25 Oct 2018 18:24:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9809dc0d85fc492593526b635ad834fa
+      - 31f4838f14934028b30996e04edabbc9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3857cb10-047f-492d-ab57-8d514b814a00
+      - req-e52cedf7-d904-476c-b3cd-edb35d593fa7
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:10.572131Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:40.360982Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8800,77 +8308,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bu8W39rYRtSrrXYwtmLViw",
-        "tcD1OjcbQ3CbP5kdKep8JA"], "issued_at": "2018-09-26T18:40:10.884679Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LaNHOxHbTL-tKswuQ8f1Gg"],
+        "issued_at": "2018-10-25T18:24:40.361014Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:10 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9809dc0d85fc492593526b635ad834fa
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:10 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-3663a627-57aa-4277-bd50-ac8a3f7e8c8b
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8882,15 +8329,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:11 GMT
+      - Thu, 25 Oct 2018 18:24:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c922016a996e4da88d7d1739c23e6e32
+      - dd45f270fe1f40a7a82676a807df68dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9be56d70-fb68-42b6-89d7-5dd34f1e315e
+      - req-5f4e35b2-3397-4fff-8a5d-cbba89cae36c
       Content-Length:
       - '7278'
       Connection:
@@ -8902,127 +8349,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:11.174133Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9xpnV8YcQvyXLG1GYrjQ8g"],
-        "issued_at": "2018-09-26T18:40:11.174153Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:11 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - a0f8bea42e804737aafe4fd98e649ffa
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-dff727c1-6867-450f-8b02-652bdd72bd7d
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:11.361838Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:40.562344Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9101,16 +8428,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jSraMUmYSViu6qKlj_4Uuw"],
-        "issued_at": "2018-09-26T18:40:11.361857Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kc2Hh5VtSZGr0zg6OnI-CA"],
+        "issued_at": "2018-10-25T18:24:40.562363Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9122,15 +8449,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:11 GMT
+      - Thu, 25 Oct 2018 18:24:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eda4afe920504317a9314536cc6a9f8c
+      - f8d5f8d20a324d75a6905926ee2755a4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2abc79d9-3028-442e-b60b-893321f9e891
+      - req-642a1ec4-7c86-4d09-a36f-7b340b2cf022
       Content-Length:
       - '7264'
       Connection:
@@ -9142,7 +8469,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:11.552993Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:40.774485Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9221,16 +8548,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gHFLCtQMT4OzuG4S43gHdA"],
-        "issued_at": "2018-09-26T18:40:11.553023Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BJazglNJSdGBu5Kd02nUmw"],
+        "issued_at": "2018-10-25T18:24:40.774506Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9242,15 +8569,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:11 GMT
+      - Thu, 25 Oct 2018 18:24:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c27f19d5dada430d884533d93a63e3a6
+      - 9bb07db99770412981cd769521cd3469
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2d7faddb-8ef8-44d7-9750-4406c5ef9464
+      - req-43fada40-6e55-4b7d-b3ef-7d3ea4bbf631
       Content-Length:
       - '7278'
       Connection:
@@ -9262,7 +8589,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:11.742092Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:40.995333Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9341,16 +8668,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SEgD6xJnS-SOuD8uUYpiXQ"],
-        "issued_at": "2018-09-26T18:40:11.742131Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9jATdXfvRfeY4JZ--k28lg"],
+        "issued_at": "2018-10-25T18:24:40.995359Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9362,15 +8689,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:11 GMT
+      - Thu, 25 Oct 2018 18:24:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb6fde5dc4d7404abb6e1527feab189f
+      - 1db6de982d864a87b70abc95bb7ffe6c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ec98db34-6eb0-4c41-9054-772c33920b57
+      - req-d072044d-0919-445e-9d0b-5ff03d9c7410
       Content-Length:
       - '7265'
       Connection:
@@ -9382,7 +8709,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:11.928611Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:41.394349Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9461,16 +8788,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4wN__bPRT2mndj4v_lh0NQ"],
-        "issued_at": "2018-09-26T18:40:11.928630Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yWklFDHrT2KUJ5VsXCCM_w"],
+        "issued_at": "2018-10-25T18:24:41.394371Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9482,15 +8809,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 334c4c0148b349cdb68384613b5440dd
+      - ff009db10f7c47d5861d98e884acdd59
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-39a0c0bd-8bde-4383-9714-9461411b94cd
+      - req-bb1fa7af-267d-4559-ae71-ab713c2d3e38
       Content-Length:
       - '7278'
       Connection:
@@ -9502,7 +8829,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:12.118275Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:41.598202Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9581,16 +8908,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mZiz_FgaTOuL7RxWU36nog"],
-        "issued_at": "2018-09-26T18:40:12.118294Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2WHZfEnjSVKNcoMxu8B18w"],
+        "issued_at": "2018-10-25T18:24:41.598221Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9602,15 +8929,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 38868ad7a09c4214a0fa1ffe95792d55
+      - f5a0ad6d82de402cb41543adc8048b35
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-058e1c11-ae76-4125-98fe-127618cc5fda
+      - req-66442f00-feb1-4368-afa4-f28ff6c8bb33
       Content-Length:
       - '7278'
       Connection:
@@ -9622,7 +8949,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:12.310136Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:41.795164Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9701,10 +9028,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qqBXTif2TpyJRy6AxnD8TQ"],
-        "issued_at": "2018-09-26T18:40:12.310163Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oS_8lCAHQKeCh19k5J_mBw"],
+        "issued_at": "2018-10-25T18:24:41.795186Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -9719,7 +9046,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38868ad7a09c4214a0fa1ffe95792d55
+      - f5a0ad6d82de402cb41543adc8048b35
   response:
     status:
       code: 200
@@ -9730,20 +9057,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d42d651d-4acc-4294-b92c-c1ffc7debd2f
+      - req-b69fbfdc-a9eb-4d58-925c-f7eb60335f74
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9755,15 +9082,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fd3db633a330454498c0603c97a9f603
+      - 45bfced853114f97b03ca95eed68fef3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-13cefb4f-4a7f-43c3-a084-c02112e494e7
+      - req-d97332ba-b31a-4789-a659-7a346482455a
       Content-Length:
       - '7278'
       Connection:
@@ -9775,7 +9102,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:12.623550Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:42.113962Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9854,10 +9181,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cr9nSB5pTp6eNuQZbeqtqA"],
-        "issued_at": "2018-09-26T18:40:12.623570Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bZrkOcXKRCaTRTlxTUI7jQ"],
+        "issued_at": "2018-10-25T18:24:42.113983Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -9872,7 +9199,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd3db633a330454498c0603c97a9f603
+      - 45bfced853114f97b03ca95eed68fef3
   response:
     status:
       code: 200
@@ -9883,20 +9210,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-43227903-7674-4fdb-b967-92ea0e499a9a
+      - req-5737b34b-1135-43c6-b42d-c4c8f9cae82c
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9908,15 +9235,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:12 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-25445160-58cb-4a77-93e1-647e3470648e
+      - req-9ecda7f5-a160-4d05-993b-82ef9637ee3d
       Content-Length:
       - '7264'
       Connection:
@@ -9928,7 +9255,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:12.935203Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:42.431242Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10007,10 +9334,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OyfCB2UjQE2TrD-kLO828w"],
-        "issued_at": "2018-09-26T18:40:12.935223Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D4JxcW4DR3uHlm6fjhDQVA"],
+        "issued_at": "2018-10-25T18:24:42.431262Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -10025,7 +9352,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10036,9 +9363,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-1f0839b4-9ae5-4e77-91d1-d11cea05d669
+      - req-d2a5238d-1e6d-44d5-86f1-237633697b3c
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -10072,7 +9399,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -10087,7 +9414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10098,20 +9425,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5a4e0acc-0909-40df-918a-603df8713d3c
+      - req-d3b9e225-b6ff-4dd7-983d-9d98479f8323
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10123,15 +9450,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a9b7a5c7282b4c628cdafd6b09e9820a
+      - d7a4cd3f915941808f7052b44627ef6b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-151e1047-6581-4ec2-b26f-0ebf13efb190
+      - req-0bba8821-1979-4bf6-8a9e-c1213e5e5436
       Content-Length:
       - '7278'
       Connection:
@@ -10143,7 +9470,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:13.419556Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:42.875435Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10222,10 +9549,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-vYK_kbWQEGMLBjRYEFn5w"],
-        "issued_at": "2018-09-26T18:40:13.419575Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["924dF34gR1C6ofLEqPSQbQ"],
+        "issued_at": "2018-10-25T18:24:42.875457Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -10240,7 +9567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9b7a5c7282b4c628cdafd6b09e9820a
+      - d7a4cd3f915941808f7052b44627ef6b
   response:
     status:
       code: 200
@@ -10251,14 +9578,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8f42d776-1084-450a-87b5-6ca8df3a5937
+      - req-04f546c2-1412-4ead-a026-2e12fc9a9967
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -10273,7 +9600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8452773599664e0190a4d1270a1b9ffd
+      - 9f7cb741750147aaa6007116878b29dd
   response:
     status:
       code: 200
@@ -10284,20 +9611,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-44fa9322-6524-40f2-8d44-9479c9a647a5
+      - req-eabfdbe8-edcd-4793-ab6c-24fb6b218a5b
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10309,15 +9636,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bdf155a45b7c4d6ba84272a3ea50b582
+      - 515c1e2d336f46c4836a2dd9168b2ac2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3225f2bd-5f95-4a98-a5d6-dd956fadd4b8
+      - req-ea8d80fc-7db1-4f0a-9faa-4cb801a7a9c0
       Content-Length:
       - '7265'
       Connection:
@@ -10329,7 +9656,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:13.834946Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:43.344754Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10408,10 +9735,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dzKaOuReQsSw7bxcpa5xlQ"],
-        "issued_at": "2018-09-26T18:40:13.834966Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fyntQNjxQMWqdFtpCP-IUg"],
+        "issued_at": "2018-10-25T18:24:43.344802Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -10426,7 +9753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bdf155a45b7c4d6ba84272a3ea50b582
+      - 515c1e2d336f46c4836a2dd9168b2ac2
   response:
     status:
       code: 200
@@ -10437,20 +9764,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1855f27e-fd9f-4774-933f-25d14b881f7f
+      - req-67fc4dcd-22ef-4a4e-82ad-63b411cbbe0c
       Date:
-      - Wed, 26 Sep 2018 18:40:13 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10462,15 +9789,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:14 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5e92eb9573c344a7938ed2a0622377ed
+      - a3638bcf6e894322bd1bb3c5ec6612ee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b4e5b939-8e58-4567-920d-d0efc5f46cab
+      - req-10615d64-1386-47ec-91a8-9493469ad3e0
       Content-Length:
       - '7278'
       Connection:
@@ -10482,7 +9809,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:14.155709Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:43.684412Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10561,10 +9888,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vYfjSHCmRr2ZsM0KrsfGxg"],
-        "issued_at": "2018-09-26T18:40:14.155732Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EP-xOQP_TJyxYwO4mJ8Q_w"],
+        "issued_at": "2018-10-25T18:24:43.684436Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -10579,7 +9906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e92eb9573c344a7938ed2a0622377ed
+      - a3638bcf6e894322bd1bb3c5ec6612ee
   response:
     status:
       code: 200
@@ -10590,14 +9917,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9c5f0a3d-c8ef-4d17-a69f-b24ca54c8839
+      - req-8f818257-5899-4278-8666-f97a60490eb2
       Date:
-      - Wed, 26 Sep 2018 18:40:14 GMT
+      - Thu, 25 Oct 2018 18:24:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -10612,7 +9939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10623,9 +9950,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-668528fd-4c3f-4bc3-9b53-73cf29020151
+      - req-51f7d36f-5991-40d6-b47a-60ab40282816
       Date:
-      - Wed, 26 Sep 2018 18:40:14 GMT
+      - Thu, 25 Oct 2018 18:24:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10652,7 +9979,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -10667,7 +9994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10678,9 +10005,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-6b088b20-cf99-412b-8cd8-69b433454bee
+      - req-bb6aec30-7a0d-4964-bce3-f0e3a608fafa
       Date:
-      - Wed, 26 Sep 2018 18:40:14 GMT
+      - Thu, 25 Oct 2018 18:24:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10707,7 +10034,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -10722,7 +10049,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10733,9 +10060,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-29062900-a765-4efb-99ed-098180332118
+      - req-f80c1c2b-ec37-4008-9807-411e77aa0e3f
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -10762,7 +10089,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -10777,7 +10104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10788,9 +10115,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-cb75a3ab-e3c8-41fd-a93c-e91f6aab8db2
+      - req-1ecaa521-208d-460a-b684-b20fff6858cf
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10802,7 +10129,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -10817,7 +10144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10828,9 +10155,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-38d07016-ddc7-4e5d-a9e8-efb9cea08c0d
+      - req-56275585-af72-4b95-be27-119ced2fcc4b
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10842,7 +10169,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -10857,7 +10184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d24fd16988940948527d3ae54fee04e
+      - cb787a734c72415c8caf56b9965fb359
   response:
     status:
       code: 200
@@ -10868,9 +10195,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2762d40f-9384-4337-ba43-8bddc9751c96
+      - req-13aba2ce-2f13-465d-a0ff-2b1ec78fb066
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -10882,7 +10209,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -10897,7 +10224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -10908,9 +10235,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-84b8719a-ed5f-4aa4-9c8c-679ac1e83b50
+      - req-295996cb-7ddb-4fa5-83dd-c1166b77897c
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -11014,7 +10341,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -11029,7 +10356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -11040,23 +10367,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5bb1f0ae-d81e-4131-8b2b-667236a63f7b
+      - req-396e7740-d888-4a80-a7ee-83bdd0f5da0a
       Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -11068,11 +10424,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -11080,12 +10442,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -11103,168 +10459,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bc0d0001-16e0-4274-8910-f8836f6383eb
-      Date:
-      - Wed, 26 Sep 2018 18:40:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -11278,271 +10472,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8260fb65-485e-4e2f-b538-79644b306b5b
-      Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-982e4ac5-c8ee-483b-ba15-326b81038b96
-      Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -11557,7 +10487,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -11568,9 +10498,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-bf8d103b-a0da-456d-b7a9-2151c7dca743
+      - req-18c3bd1f-77ae-40ab-827d-42bb11dba711
       Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11612,7 +10542,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -11627,7 +10557,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -11638,9 +10568,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6d0c5366-7e73-4aac-b253-33549747b545
+      - req-8c811bd4-64d2-48d3-a1ac-eac592389d63
       Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11682,7 +10612,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -11697,7 +10627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -11708,9 +10638,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fdf2cb23-042a-4a24-8f77-cc92986c4721
+      - req-10a757e2-97c0-4f92-8d5c-871d9978d7fc
       Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12113,7 +11043,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -12128,7 +11058,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12139,9 +11069,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-18fefd80-109a-49c4-95ce-607634755c42
+      - req-570d4d80-0263-4c7e-92d0-ebed15bd78e8
       Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
+      - Thu, 25 Oct 2018 18:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12544,7 +11474,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -12559,7 +11489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12570,9 +11500,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e2f6fc3a-c989-4894-b991-0682695084ff
+      - req-11108833-40a1-4b06-a661-f922b688c0f4
       Date:
-      - Wed, 26 Sep 2018 18:40:16 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12604,7 +11534,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -12619,7 +11549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12630,9 +11560,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-86f9dfcb-2da3-4f75-b144-4e64fd93b595
+      - req-12fdd5da-b051-4528-992c-991467fcf1fa
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12664,7 +11594,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -12679,7 +11609,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12690,9 +11620,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-52acec09-70fd-4cb3-987e-52778dfde37e
+      - req-f03a65d1-2871-4d62-a76e-3cf27a7cc3ac
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -12727,7 +11657,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -12742,7 +11672,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12753,9 +11683,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-b3eedc4f-c82c-4a4f-94e9-9fa5f3f38669
+      - req-7020a4d5-2a38-47f9-92af-0fa974ec5c72
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -12798,7 +11728,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -12813,7 +11743,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12824,9 +11754,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-9fa72d1c-6e08-4bb7-bedf-2349cfd62437
+      - req-f2cc2358-900c-4573-8fa4-0a7a924be092
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -12869,7 +11799,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -12884,7 +11814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -12895,9 +11825,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-04b20c19-d06d-43b8-be2e-1f882275925f
+      - req-a9837746-038c-443c-846e-acb7329a29df
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -13004,7 +11934,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -13019,7 +11949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -13030,9 +11960,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-82113cb7-33b6-4dab-95e6-a84ab332e5c3
+      - req-3c29a382-c163-4104-87bd-8b62fce3ad63
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -13074,7 +12004,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -13089,7 +12019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a87bf09e89064325a6705c330d11d9ca
+      - 91bd1586cfbe4975af54c35a539820ba
   response:
     status:
       code: 200
@@ -13100,21 +12030,21 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-e18d0393-a3fe-42ae-9b6b-a0166011f296
+      - req-31e32d51-a98f-468f-b9ab-f17af7a489a7
       Date:
-      - Wed, 26 Sep 2018 18:40:17 GMT
+      - Thu, 25 Oct 2018 18:24:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13126,15 +12056,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:18 GMT
+      - Thu, 25 Oct 2018 18:24:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4405066708f4bb5ac9f977f2fca0fd0
+      - 50057eebd80f4b3699686afc4348e081
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0657699-786b-4b01-a82f-3fbf7525f866
+      - req-cf90b6f7-678d-4c2e-ae22-f1970cb1aa6c
       Content-Length:
       - '7311'
       Connection:
@@ -13146,7 +12076,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:18.413287Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:52.471127Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13225,16 +12155,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ATpj5dOVTvKA8plymRVHew"],
-        "issued_at": "2018-09-26T18:40:18.413307Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIf3Zt8ARKmLAj3v-gWSUw"],
+        "issued_at": "2018-10-25T18:24:52.471145Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13246,15 +12176,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:18 GMT
+      - Thu, 25 Oct 2018 18:24:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-102ef430-4995-44a2-96fd-e1ba42cdf30a
+      - req-84f44071-95a5-4015-99a6-47310a1140d6
       Content-Length:
       - '7311'
       Connection:
@@ -13266,7 +12196,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:18.621151Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:24:52.672406Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13345,16 +12275,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TtVSC86qTo-TEiG6jdLR_w"],
-        "issued_at": "2018-09-26T18:40:18.621171Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jkoP-0AYT3yn0MmiM_VDXA"],
+        "issued_at": "2018-10-25T18:24:52.672427Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13366,15 +12296,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:18 GMT
+      - Thu, 25 Oct 2018 18:24:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 407d1402c01d43a5b2f2d96129e281de
+      - 67852836223e49d0a4664c5c9f41b4e4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d9244c9-8feb-466a-8001-7d4a84fcedad
+      - req-2abdcbdf-6388-495b-9522-5f5a57d7af74
       Content-Length:
       - '297'
       Connection:
@@ -13383,15 +12313,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:40:18.797262Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:24:52.836352Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oJt5va5cSeKHxmobfkYWXw"],
-        "issued_at": "2018-09-26T18:40:18.797280Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2MAj7QleQvKx_hibETc1fQ"],
+        "issued_at": "2018-10-25T18:24:52.836372Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:52 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -13403,29 +12333,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 407d1402c01d43a5b2f2d96129e281de
+      - 67852836223e49d0a4664c5c9f41b4e4
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:18 GMT
+      - Thu, 25 Oct 2018 18:24:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c992008-51f9-4cfd-bb86-fc845f835e73
+      - req-28e16123-72b5-4121-944f-6836c968dd53
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -13449,13 +12379,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"407d1402c01d43a5b2f2d96129e281de"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13467,27 +12397,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
+      - Thu, 25 Oct 2018 18:24:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e4c188d3450846e8b0b8574cd9703864
+      - 6c30ecd132e940a7906391fc5783942d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3da5ea8c-e363-4405-b851-83f670b3aace
+      - req-7f2b6c28-f359-4354-9b6e-47690a9d46c8
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:18.797262Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:53.181255Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13566,77 +12496,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["So9SafALSX-nr6logT6NMA",
-        "oJt5va5cSeKHxmobfkYWXw"], "issued_at": "2018-09-26T18:40:19.112205Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k2ULu4cqT2KPV1hselgwiQ"],
+        "issued_at": "2018-10-25T18:24:53.181276Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e4c188d3450846e8b0b8574cd9703864
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ed7c2223-6778-4dbd-9c33-fe5b0d1cb29b
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13648,15 +12517,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
+      - Thu, 25 Oct 2018 18:24:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2004b08e69824949a0a7bd42d806ed1a
+      - ee425fc2bdad456194488a5b6d5cf054
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-241837b0-f17f-4c7f-840d-a70df12d899f
+      - req-146aba31-224d-40e0-a3be-6385fe86ea8d
       Content-Length:
       - '7278'
       Connection:
@@ -13668,127 +12537,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:19.433267Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sHX8R3SOST-LFIMHT5DpJg"],
-        "issued_at": "2018-09-26T18:40:19.433287Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:19 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 0afa8318fffd493891c0004f69d79904
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-afc7ecf2-8059-41d6-a1c2-94392a9d906e
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:19.629528Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:53.376041Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13867,16 +12616,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P1bI3HCgTyCNzvjh-C6ZbA"],
-        "issued_at": "2018-09-26T18:40:19.629549Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qGQUm6nzQHCbWAgPEI1mmA"],
+        "issued_at": "2018-10-25T18:24:53.376060Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13888,15 +12637,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
+      - Thu, 25 Oct 2018 18:24:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - da42cb7cddd14403a5960c5555dbc2fa
+      - 1ffd6cb779ab4c7f9359e1c98ae50570
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b6caa7cb-0d3c-4f20-8fb9-011d384dc0e7
+      - req-f0cd47ad-84df-4621-a125-a2c54db84e16
       Content-Length:
       - '7264'
       Connection:
@@ -13908,7 +12657,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:19.827386Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:53.562194Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13987,16 +12736,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z9iG5BctQrWMLlBOhOXh_A"],
-        "issued_at": "2018-09-26T18:40:19.827405Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2JjCQ3-cTRGSlqA6FeKaQw"],
+        "issued_at": "2018-10-25T18:24:53.562212Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14008,15 +12757,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:19 GMT
+      - Thu, 25 Oct 2018 18:24:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7614c8cec8c84f5ba10549b0b2ed1334
+      - 2b8da97001c246c798e5c1126604e308
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cd8a9a1d-f339-46e5-84db-b094523a29fa
+      - req-cd6a589d-4eee-4354-8cda-c521a0907997
       Content-Length:
       - '7278'
       Connection:
@@ -14028,7 +12777,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:20.043846Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:53.760071Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14107,16 +12856,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oS-IXgfuSpO6TNvhuhD2Eg"],
-        "issued_at": "2018-09-26T18:40:20.043867Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RBdozHpJQG-_ETyoLLm6gg"],
+        "issued_at": "2018-10-25T18:24:53.760091Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14128,15 +12877,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:20 GMT
+      - Thu, 25 Oct 2018 18:24:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 483efa1cb3cb4c22b0c5dd729631f3ce
+      - 18783c43739341c38611c928ee11cb37
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01b1cce9-7375-4fd1-a877-46b9807249e4
+      - req-bbb98e5a-a4ed-4a9f-9e52-92c565f74697
       Content-Length:
       - '7265'
       Connection:
@@ -14148,7 +12897,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:20.264710Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:53.970821Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14227,16 +12976,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rU4ik-BtQBSlvnih89eL3w"],
-        "issued_at": "2018-09-26T18:40:20.264732Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C6KOtLQeTbW-sALo9MvU8A"],
+        "issued_at": "2018-10-25T18:24:53.970842Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14248,15 +12997,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:20 GMT
+      - Thu, 25 Oct 2018 18:24:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dfc3dfb92ac147c5ae3c4d6542bb7e52
+      - 459a2c10cf894f0faa2f40434aeae98f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c20e936d-d265-4201-9a50-71596fa522c6
+      - req-c34be94f-f9e6-482f-93ba-0b0f1600b9bb
       Content-Length:
       - '7278'
       Connection:
@@ -14268,7 +13017,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:20.481601Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:54.174919Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14347,16 +13096,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ktxChEIpTiefkklaVHAayQ"],
-        "issued_at": "2018-09-26T18:40:20.481642Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jhacm6gKScmsaDzbHHzCEA"],
+        "issued_at": "2018-10-25T18:24:54.174953Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14368,15 +13117,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:20 GMT
+      - Thu, 25 Oct 2018 18:24:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0b22311-39ec-49c4-bf79-461785684870
+      - req-ca4f551c-84bb-42e1-ac32-d307bdf4959f
       Content-Length:
       - '7278'
       Connection:
@@ -14388,7 +13137,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:20.677525Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:54.398437Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14467,10 +13216,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CMYStNleQTu_QonbM12TSw"],
-        "issued_at": "2018-09-26T18:40:20.677545Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["62rCEuS4S6WNu7QI6ZskHw"],
+        "issued_at": "2018-10-25T18:24:54.398465Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -14485,33 +13234,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3a4f952b-a2f8-4c06-b6ad-6846ac2f5fdb
+      - req-ad832a30-16a9-42ce-888b-e787437aea23
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3a4f952b-a2f8-4c06-b6ad-6846ac2f5fdb
+      - req-ad832a30-16a9-42ce-888b-e787437aea23
       Date:
-      - Wed, 26 Sep 2018 18:40:20 GMT
+      - Thu, 25 Oct 2018 18:24:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14523,15 +13272,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:20 GMT
+      - Thu, 25 Oct 2018 18:24:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dce0ca61-009a-4a89-8063-7cdbf7fdfed4
+      - req-83a7b458-17ad-4ede-8a1b-2a9d1555b264
       Content-Length:
       - '7278'
       Connection:
@@ -14543,7 +13292,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:21.022652Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:54.763718Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14622,10 +13371,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vrgGaMr3R8238YQRc3n2Xw"],
-        "issued_at": "2018-09-26T18:40:21.022674Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g2fW1T-tSvCv8iXYrbAClw"],
+        "issued_at": "2018-10-25T18:24:54.763744Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -14640,33 +13389,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f12de6f-c1ae-4b4d-841c-c40539bac577
+      - req-c39ec7f8-1476-4227-88ee-9b60d93dfea7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5f12de6f-c1ae-4b4d-841c-c40539bac577
+      - req-c39ec7f8-1476-4227-88ee-9b60d93dfea7
       Date:
-      - Wed, 26 Sep 2018 18:40:21 GMT
+      - Thu, 25 Oct 2018 18:24:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14678,15 +13427,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:21 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ba923868-0109-4e50-8d83-6d71eeb9ce89
+      - req-4d1b1e05-3dda-4883-b7ea-91154b2bc3c0
       Content-Length:
       - '7264'
       Connection:
@@ -14698,7 +13447,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:21.370219Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:55.127517Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14777,10 +13526,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VgAEBB1nSyioDGOpdZHTCw"],
-        "issued_at": "2018-09-26T18:40:21.370251Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9Q8Wfm06TXGcYfMkwPsNnw"],
+        "issued_at": "2018-10-25T18:24:55.127539Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -14795,22 +13544,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37b5b365-232d-4b24-8da3-00a0fb2aa0b3
+      - req-82c26ebc-55e3-4973-81d5-d53974625eca
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-37b5b365-232d-4b24-8da3-00a0fb2aa0b3
+      - req-82c26ebc-55e3-4973-81d5-d53974625eca
       Date:
-      - Wed, 26 Sep 2018 18:40:21 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -14843,7 +13592,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -14858,22 +13607,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1abbce8c-7c14-49f9-84ab-2e27756fa2a4
+      - req-dc4d8c0d-1fad-4503-a6c9-ae45af443659
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-1abbce8c-7c14-49f9-84ab-2e27756fa2a4
+      - req-dc4d8c0d-1fad-4503-a6c9-ae45af443659
       Date:
-      - Wed, 26 Sep 2018 18:40:21 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -14914,7 +13663,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -14929,22 +13678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21171a57-0b3f-4e6a-8f11-5b2dd0b42668
+      - req-443070da-5b1c-4a70-bc7e-17ca96455c36
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-21171a57-0b3f-4e6a-8f11-5b2dd0b42668
+      - req-443070da-5b1c-4a70-bc7e-17ca96455c36
       Date:
-      - Wed, 26 Sep 2018 18:40:21 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -14978,7 +13727,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -14993,33 +13742,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c3b92ed-353f-4a42-ac47-f0ff029e05ff
+      - req-633e6d21-ef01-41cc-beff-c61bad6da9af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c3b92ed-353f-4a42-ac47-f0ff029e05ff
+      - req-633e6d21-ef01-41cc-beff-c61bad6da9af
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15031,15 +13780,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-319232dd-9733-4913-b6a2-b47b83ce14c4
+      - req-a21804b3-2f53-4c2f-90c3-37f71223ea96
       Content-Length:
       - '7278'
       Connection:
@@ -15051,7 +13800,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:22.270387Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:55.958472Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15130,10 +13879,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u7BtFr_aQY2Z-hrtT9WGcw"],
-        "issued_at": "2018-09-26T18:40:22.270419Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bNqsEUvbT964Xhb8us-JUA"],
+        "issued_at": "2018-10-25T18:24:55.958495Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -15148,27 +13897,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8ab6e53-ab74-4212-9a73-faa8eddaa2cb
+      - req-51d5b2c7-34bf-4d67-9387-a43195458f30
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f8ab6e53-ab74-4212-9a73-faa8eddaa2cb
+      - req-51d5b2c7-34bf-4d67-9387-a43195458f30
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -15183,33 +13932,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2a5f680-b86c-4b65-a133-e469ebdec8c6
+      - req-799b2fda-7c40-4033-9671-186189cded9b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a2a5f680-b86c-4b65-a133-e469ebdec8c6
+      - req-799b2fda-7c40-4033-9671-186189cded9b
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15221,15 +13970,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-67107634-cb6e-44b2-9722-89aab4970641
+      - req-c28ad2d9-618f-483b-9619-85761d670a4e
       Content-Length:
       - '7265'
       Connection:
@@ -15241,7 +13990,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:22.750786Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:56.439794Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15320,10 +14069,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mVaZRVzlSOSm1MnrK9oHAA"],
-        "issued_at": "2018-09-26T18:40:22.750806Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R1evFAgiQ2uNOpC9Ra5xIQ"],
+        "issued_at": "2018-10-25T18:24:56.439831Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -15338,33 +14087,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1f987b6-d401-47df-a465-6a5333361e42
+      - req-6ea054cf-e26e-494c-9cd2-a4405de2c127
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a1f987b6-d401-47df-a465-6a5333361e42
+      - req-6ea054cf-e26e-494c-9cd2-a4405de2c127
       Date:
-      - Wed, 26 Sep 2018 18:40:22 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15376,15 +14125,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-29d639a5-1eea-4a8b-b08e-47d215dc29dd
+      - req-73d3ec1a-abc1-416d-b8a8-65fd832b7f68
       Content-Length:
       - '7278'
       Connection:
@@ -15396,7 +14145,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:23.082296Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:24:56.774898Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15475,10 +14224,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P7vsTVabTF-cBvn310RyIg"],
-        "issued_at": "2018-09-26T18:40:23.082317Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WqnU36xnQDyVKytBYNO-ZA"],
+        "issued_at": "2018-10-25T18:24:56.774919Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -15493,27 +14242,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1fdf4a56-d14c-4c52-8f6c-7745c74f56fd
+      - req-90ea06b0-56c0-48e1-9ff8-b55b82707ea8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1fdf4a56-d14c-4c52-8f6c-7745c74f56fd
+      - req-90ea06b0-56c0-48e1-9ff8-b55b82707ea8
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -15528,27 +14277,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-04bda9fd-84f4-4bed-85a1-982a2e20f8c9
+      - req-cf02126b-ea9a-40dd-97c5-fab6ab762ef5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-04bda9fd-84f4-4bed-85a1-982a2e20f8c9
+      - req-cf02126b-ea9a-40dd-97c5-fab6ab762ef5
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -15563,27 +14312,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c33f5b62-f5ae-471b-8b88-bd402e34aa30
+      - req-673f75e5-82ff-476a-a805-2162aa307542
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c33f5b62-f5ae-471b-8b88-bd402e34aa30
+      - req-673f75e5-82ff-476a-a805-2162aa307542
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -15598,27 +14347,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ab75e27-a0c3-4de5-bc62-7ae78e811054
+      - req-02d3be93-e247-4f84-a825-684c6a14e664
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7ab75e27-a0c3-4de5-bc62-7ae78e811054
+      - req-02d3be93-e247-4f84-a825-684c6a14e664
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -15633,27 +14382,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a65d527-bef5-49ee-b013-0ef0e79da67a
+      - req-da8c15ce-6819-4b7a-9e1c-9d69a5b86b74
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0a65d527-bef5-49ee-b013-0ef0e79da67a
+      - req-da8c15ce-6819-4b7a-9e1c-9d69a5b86b74
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -15668,22 +14417,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b16a8751-7c1e-49c8-bbfc-d6b1b9d5168c
+      - req-32d9f022-ea10-480e-b495-301294b549d9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b16a8751-7c1e-49c8-bbfc-d6b1b9d5168c
+      - req-32d9f022-ea10-480e-b495-301294b549d9
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15698,7 +14447,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -15713,22 +14462,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-161a6f63-0764-4ee7-9492-f27b5e88e296
+      - req-73a34845-6da4-4141-954c-57e4d6667a58
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-161a6f63-0764-4ee7-9492-f27b5e88e296
+      - req-73a34845-6da4-4141-954c-57e4d6667a58
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15743,7 +14492,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -15758,27 +14507,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-398ab0d7-dd8c-4ede-be31-2e5a41935241
+      - req-1ac602c5-b19a-4098-bd02-aaafff099cfe
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-398ab0d7-dd8c-4ede-be31-2e5a41935241
+      - req-1ac602c5-b19a-4098-bd02-aaafff099cfe
       Date:
-      - Wed, 26 Sep 2018 18:40:23 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -15793,27 +14542,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a58dbe6-fd55-4ade-9db0-4febc3b96771
+      - req-027a3509-2240-4dab-aa69-d2219ae2c48e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4a58dbe6-fd55-4ade-9db0-4febc3b96771
+      - req-027a3509-2240-4dab-aa69-d2219ae2c48e
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -15828,27 +14577,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af81b837-29b1-4482-8815-e42ec0b7c46b
+      - req-2f2aeaa1-7782-4e60-b851-98f074350f83
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-af81b837-29b1-4482-8815-e42ec0b7c46b
+      - req-2f2aeaa1-7782-4e60-b851-98f074350f83
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -15863,27 +14612,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-98d75ee4-0e09-4e24-850b-83fba392ffc2
+      - req-2da8d19e-76fa-4a21-b131-2cfbe21612c5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-98d75ee4-0e09-4e24-850b-83fba392ffc2
+      - req-2da8d19e-76fa-4a21-b131-2cfbe21612c5
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -15898,27 +14647,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b7b9f217-3866-4d00-859d-2d08c4aeb68a
+      - req-556fce7b-1c25-4914-a7fa-8cad6fbf10a3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b7b9f217-3866-4d00-859d-2d08c4aeb68a
+      - req-556fce7b-1c25-4914-a7fa-8cad6fbf10a3
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -15933,27 +14682,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c746be8-dea5-4100-b852-9b2f5319ff1b
+      - req-a4881985-1299-40d8-a548-29ceb6a607fa
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3c746be8-dea5-4100-b852-9b2f5319ff1b
+      - req-a4881985-1299-40d8-a548-29ceb6a607fa
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -15968,27 +14717,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-85a060d2-d9c1-459f-be1d-e6e0336912f1
+      - req-ab3e4817-bbe6-4510-a359-26a3fe63ac16
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-85a060d2-d9c1-459f-be1d-e6e0336912f1
+      - req-ab3e4817-bbe6-4510-a359-26a3fe63ac16
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -16003,27 +14752,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25bafbed-c2e5-4713-91c0-89b0e76f849a
+      - req-6cdd7e13-7534-4065-8115-6498ef8be203
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-25bafbed-c2e5-4713-91c0-89b0e76f849a
+      - req-6cdd7e13-7534-4065-8115-6498ef8be203
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -16038,27 +14787,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-37f0e37c-99e1-4fd3-a24d-e7c06aecc69e
+      - req-f569146e-bbef-4061-a23f-f8d9ece0d09d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-37f0e37c-99e1-4fd3-a24d-e7c06aecc69e
+      - req-f569146e-bbef-4061-a23f-f8d9ece0d09d
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -16073,27 +14822,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0380d58b-81d0-4e1e-95a4-c6739b6bab06
+      - req-8bebdc10-909f-4e7f-b757-4f6a53b2e3c0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0380d58b-81d0-4e1e-95a4-c6739b6bab06
+      - req-8bebdc10-909f-4e7f-b757-4f6a53b2e3c0
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -16108,27 +14857,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89c2c58e-4efd-4b42-855c-7b46e30b70c6
+      - req-b9659a17-2032-45d0-82ed-6fa93846b8a8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-89c2c58e-4efd-4b42-855c-7b46e30b70c6
+      - req-b9659a17-2032-45d0-82ed-6fa93846b8a8
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -16143,27 +14892,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5d85bb3-cfe5-4264-8fbe-699e96e72ae0
+      - req-adb9f7b5-52bf-4938-a8c4-c01fbff9994d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b5d85bb3-cfe5-4264-8fbe-699e96e72ae0
+      - req-adb9f7b5-52bf-4938-a8c4-c01fbff9994d
       Date:
-      - Wed, 26 Sep 2018 18:40:24 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -16178,27 +14927,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e8adb6b-7f78-4d11-b418-9fc41411af26
+      - req-dc6f94bd-17cd-47c7-a5a2-d672713b28af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2e8adb6b-7f78-4d11-b418-9fc41411af26
+      - req-dc6f94bd-17cd-47c7-a5a2-d672713b28af
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -16213,27 +14962,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94e34c11-847d-4a5e-bbee-914daffbd7a9
+      - req-8d8eeb93-b2d3-43f9-a8ba-65542dbb019c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-94e34c11-847d-4a5e-bbee-914daffbd7a9
+      - req-8d8eeb93-b2d3-43f9-a8ba-65542dbb019c
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -16248,27 +14997,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-981b45df-3311-4c08-b71a-261cd78ae84a
+      - req-12726a8a-8ad9-444c-bf15-a07edb174774
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-981b45df-3311-4c08-b71a-261cd78ae84a
+      - req-12726a8a-8ad9-444c-bf15-a07edb174774
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -16283,27 +15032,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c04dde49-8bfe-4971-9da0-12882de7b1b0
+      - req-149d0623-29a3-4359-bdd9-e84f6afccb95
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c04dde49-8bfe-4971-9da0-12882de7b1b0
+      - req-149d0623-29a3-4359-bdd9-e84f6afccb95
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -16318,27 +15067,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16b43aa5-8f82-45ea-a60c-4fcd8e9ee20a
+      - req-c5c36d7d-b9c7-4b15-b474-587826463f47
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-16b43aa5-8f82-45ea-a60c-4fcd8e9ee20a
+      - req-c5c36d7d-b9c7-4b15-b474-587826463f47
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -16353,27 +15102,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-254520bc-8194-424a-a150-6f2edeff7c4a
+      - req-c81bb183-d350-4dc7-8492-f98f710bb57f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-254520bc-8194-424a-a150-6f2edeff7c4a
+      - req-c81bb183-d350-4dc7-8492-f98f710bb57f
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -16388,27 +15137,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21d36f52-025d-4dd0-8296-bf5bbcd13569
+      - req-936881dc-db37-47d2-9d3d-8dd443983bf2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-21d36f52-025d-4dd0-8296-bf5bbcd13569
+      - req-936881dc-db37-47d2-9d3d-8dd443983bf2
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -16423,27 +15172,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61620eb1-cd10-4e50-9cb0-8beb3d240586
+      - req-1e053a37-8d81-4d99-8cf6-690f2f9f91d8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-61620eb1-cd10-4e50-9cb0-8beb3d240586
+      - req-1e053a37-8d81-4d99-8cf6-690f2f9f91d8
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -16458,27 +15207,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e03d5135-1373-4937-9e28-712f85133bbc
+      - req-6cda575b-0cae-4179-a1d7-8360ec37198c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e03d5135-1373-4937-9e28-712f85133bbc
+      - req-6cda575b-0cae-4179-a1d7-8360ec37198c
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -16493,27 +15242,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7885fb0e-7286-4530-84e8-835b2deba871
+      - req-526dd69e-7f7b-48dc-a3a0-32e3a09df9a6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7885fb0e-7286-4530-84e8-835b2deba871
+      - req-526dd69e-7f7b-48dc-a3a0-32e3a09df9a6
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -16528,22 +15277,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1540164a-b093-4977-a9b5-268d7224698f
+      - req-067a7835-a9a0-4bfc-90b7-fd9f757c4dfc
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1540164a-b093-4977-a9b5-268d7224698f
+      - req-067a7835-a9a0-4bfc-90b7-fd9f757c4dfc
       Date:
-      - Wed, 26 Sep 2018 18:40:25 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16555,7 +15304,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16570,22 +15319,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50757aeda4c54f8e8e6a785e7e862b62
+      - 66d78d5372f34b039efb4bf9d45d6de7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-445e3b9d-51c3-4eb0-bb33-7ef989636a65
+      - req-4d867f30-b86b-473b-810b-f00ac0c0f4a8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-445e3b9d-51c3-4eb0-bb33-7ef989636a65
+      - req-4d867f30-b86b-473b-810b-f00ac0c0f4a8
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:24:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16597,7 +15346,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:24:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -16612,22 +15361,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8e0f5e9-6e9d-485b-b17d-5fdaf99888f0
+      - req-5e0739bd-dd04-458a-8259-5773eeea2cb4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d8e0f5e9-6e9d-485b-b17d-5fdaf99888f0
+      - req-5e0739bd-dd04-458a-8259-5773eeea2cb4
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16639,7 +15388,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16654,22 +15403,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61722997f8e8493292832ff12a10bef6
+      - 58d39212c3ae4750aa4abdfe6e7f15ad
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f79550a3-6a8c-4712-be56-0f3dbe5a17f6
+      - req-cd880e11-1160-4a98-bcbe-b9c67d560b6f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f79550a3-6a8c-4712-be56-0f3dbe5a17f6
+      - req-cd880e11-1160-4a98-bcbe-b9c67d560b6f
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16681,7 +15430,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -16696,22 +15445,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-503c66b6-59a8-41fd-b90d-084dd842ac46
+      - req-58aa7260-8941-4d1b-a3c0-024a7a15a7ab
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-503c66b6-59a8-41fd-b90d-084dd842ac46
+      - req-58aa7260-8941-4d1b-a3c0-024a7a15a7ab
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16723,7 +15472,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16738,22 +15487,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a6f1c90a42545e6adbfec33ae0fdeaa
+      - 8bbe93ed60bb4c8787cb615eb319dc7f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8f7247e-f53e-4ab8-b653-bf4ace4fe735
+      - req-ffcc44b1-4cbb-4a7c-8866-b6832dcaea46
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f8f7247e-f53e-4ab8-b653-bf4ace4fe735
+      - req-ffcc44b1-4cbb-4a7c-8866-b6832dcaea46
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16765,7 +15514,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -16780,22 +15529,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae3ee4a3-a271-4932-aafc-c1dfe117296d
+      - req-bc77b96b-f03c-4064-bf1e-69ee2b9ae908
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ae3ee4a3-a271-4932-aafc-c1dfe117296d
+      - req-bc77b96b-f03c-4064-bf1e-69ee2b9ae908
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16807,7 +15556,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16822,22 +15571,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b161075abe304b17bfc2178e131e82cf
+      - 0d584a6e72e0453ca655611babf4c1e0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7da51b46-e86d-4b4a-801c-36cbf0ee33b3
+      - req-18161b35-dc33-4fe9-9c56-d601df4857c6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7da51b46-e86d-4b4a-801c-36cbf0ee33b3
+      - req-18161b35-dc33-4fe9-9c56-d601df4857c6
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16849,7 +15598,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -16864,22 +15613,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61a192cb-0a5a-4a56-a74a-54681eb56b93
+      - req-8bcfef16-27fe-4925-b561-620d6d6506a1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-61a192cb-0a5a-4a56-a74a-54681eb56b93
+      - req-8bcfef16-27fe-4925-b561-620d6d6506a1
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16891,7 +15640,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16906,22 +15655,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5a18dc40c574633b5696e235c94dba7
+      - 97fb334395364de4841644a3658296f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94ae5d11-62f1-4abd-bf04-b200c6d13dae
+      - req-6db00f61-8dcf-40e0-acc8-49bbf4ea5f95
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-94ae5d11-62f1-4abd-bf04-b200c6d13dae
+      - req-6db00f61-8dcf-40e0-acc8-49bbf4ea5f95
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16933,7 +15682,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -16948,22 +15697,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e444b08-52fd-4c6e-9d22-efbb55e65f32
+      - req-1850cc80-6673-4220-8c70-b4b47375b78e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1e444b08-52fd-4c6e-9d22-efbb55e65f32
+      - req-1850cc80-6673-4220-8c70-b4b47375b78e
       Date:
-      - Wed, 26 Sep 2018 18:40:26 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16975,7 +15724,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16990,22 +15739,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ecfb1e37cae4eeb8e3962e5b06cdc86
+      - c2513f10c5e64fa58f4e2023691ba673
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd899c4a-c8d4-455e-8b26-85c3db1f2ff2
+      - req-692e2ae8-f19a-4dc1-aa17-220838021ce1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fd899c4a-c8d4-455e-8b26-85c3db1f2ff2
+      - req-692e2ae8-f19a-4dc1-aa17-220838021ce1
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17017,7 +15766,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -17032,22 +15781,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3af48ee6-a129-470e-9e36-aff65437f021
+      - req-61964cb3-525a-4f71-aa64-80fd44b1fdd5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3af48ee6-a129-470e-9e36-aff65437f021
+      - req-61964cb3-525a-4f71-aa64-80fd44b1fdd5
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17059,7 +15808,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -17074,22 +15823,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1819ed338fb441929310ccd2a1746cf0
+      - ec062c9b9a664f26b0fad1ef0d9b9423
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-24622d96-7154-45cd-9385-04145dee3430
+      - req-b336f21b-fa7d-4db7-8824-4b65fadbd1d2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-24622d96-7154-45cd-9385-04145dee3430
+      - req-b336f21b-fa7d-4db7-8824-4b65fadbd1d2
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17101,13 +15850,13 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17119,15 +15868,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2e94114e02904ff987ce97666362b05b
+      - d4b90b3dbb28415ebc17f646beebd2aa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2e862a6a-d4c2-4c92-82e8-cc7367cac15d
+      - req-fb75068b-d3e0-498e-9749-4b068981f2ce
       Content-Length:
       - '7311'
       Connection:
@@ -17139,7 +15888,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:27.497897Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:25:01.288180Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17218,16 +15967,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UlwPSfjCQu2dvT_V9uP6og"],
-        "issued_at": "2018-09-26T18:40:27.497924Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-mV5aVQiT3mBRz2jgdD4Tg"],
+        "issued_at": "2018-10-25T18:25:01.288201Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17239,15 +15988,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bbfda4d45d2d40b78722f2ad9136c1f2
+      - 744af499dd6f4376afe4356058b9277b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-71e220d5-fc3e-4546-a61e-2adecce879dc
+      - req-a71082c3-cdf4-4f82-bcae-0508124961ba
       Content-Length:
       - '7311'
       Connection:
@@ -17259,7 +16008,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:40:27.708026Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:25:01.510629Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17338,16 +16087,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4of5MqJQRM-M9u3r7fXdiw"],
-        "issued_at": "2018-09-26T18:40:27.708079Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DHXy9Hw6S9KPTuETkcpGWQ"],
+        "issued_at": "2018-10-25T18:25:01.510652Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17359,15 +16108,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e69f80c964640109d9cedba8c0aef2d
+      - d77bf615e1a74342bfa82822216bc60c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f453379b-3583-4de0-8d92-94a9f28fe92d
+      - req-1b73adb1-4118-4b7b-9655-f574cbc514b6
       Content-Length:
       - '297'
       Connection:
@@ -17376,15 +16125,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:40:27.873412Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:25:01.679574Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["erlcdUlbQ2ugPFBBFO9T6w"],
-        "issued_at": "2018-09-26T18:40:27.873431Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RNoToxvQRHeb3cDz0D1mtA"],
+        "issued_at": "2018-10-25T18:25:01.679596Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -17396,29 +16145,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e69f80c964640109d9cedba8c0aef2d
+      - d77bf615e1a74342bfa82822216bc60c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:27 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69afd3f5-2b16-41a6-94ca-e5e1fa679218
+      - req-e1deb9ed-0017-49d1-922f-d50d60045745
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -17442,13 +16191,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"8e69f80c964640109d9cedba8c0aef2d"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17460,27 +16209,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:28 GMT
+      - Thu, 25 Oct 2018 18:25:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b91ce6ae60234d8388951be2b809f497
+      - a8a2578e434e472da6c400d95d8b133a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-489e29bf-80f8-4d62-9e41-05c234f9adc6
+      - req-a73e7eee-e034-463b-a4c7-6df9324dab1f
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:27.873412Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:02.012001Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17559,77 +16308,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x8zfl7gUQhaMSgONeT_dcA",
-        "erlcdUlbQ2ugPFBBFO9T6w"], "issued_at": "2018-09-26T18:40:28.212922Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gJRSCUxRRvadZprW1kbuIQ"],
+        "issued_at": "2018-10-25T18:25:02.012029Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b91ce6ae60234d8388951be2b809f497
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:28 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a49082ad-e029-4ce3-a4d7-959639e893e8
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17641,15 +16329,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:28 GMT
+      - Thu, 25 Oct 2018 18:25:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5fafababb9ea48bf8782381236040b61
+      - 0cd55a50f29b4b3eaafb6167696a4f1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa795239-0b5f-4ed6-85d0-335144c952d7
+      - req-0b515586-37c5-4306-aee5-a97271712ba5
       Content-Length:
       - '7278'
       Connection:
@@ -17661,127 +16349,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:28.541416Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["glQBjytPQW-JGXj2W6aDJg"],
-        "issued_at": "2018-09-26T18:40:28.541436Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:28 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 836ade3325d74d97abf067ecaa159fef
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-574ac711-a26d-427a-a346-4e5099da2885
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:28.743926Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:02.222794Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17860,16 +16428,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EabCfAkHTGSmhNXqrONhwQ"],
-        "issued_at": "2018-09-26T18:40:28.743945Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v6zMFO7HTj6EG29Dq8ncNA"],
+        "issued_at": "2018-10-25T18:25:02.222816Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17881,15 +16449,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:28 GMT
+      - Thu, 25 Oct 2018 18:25:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cea0fe6dfc0c477f941f0a46ce2248e2
+      - f482c0f9c7b54a60a9c347bd20f44d34
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4620556e-6a4d-46be-8e64-6ff3bde0ceb8
+      - req-01f7a4ab-1c40-4496-8764-520a6567cad5
       Content-Length:
       - '7264'
       Connection:
@@ -17901,7 +16469,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:28.969156Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:02.424743Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17980,16 +16548,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6qo0jTm0QxiW4MhXrRtwlQ"],
-        "issued_at": "2018-09-26T18:40:28.969178Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NW08xRLRTC26NAhUVa4Bbw"],
+        "issued_at": "2018-10-25T18:25:02.424764Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18001,15 +16569,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:29 GMT
+      - Thu, 25 Oct 2018 18:25:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5f17196841214fdfa1f05457060c850d
+      - b0d9cabfa4bb41e395eb1134ab768304
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ba8229f4-42a2-474e-ad04-64d15433edc4
+      - req-11a24ff4-f084-4080-b3a7-cafb222edc78
       Content-Length:
       - '7278'
       Connection:
@@ -18021,7 +16589,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:29.193367Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:02.648004Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18100,16 +16668,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XbsepUghQ7OiS_VOh9jJ0Q"],
-        "issued_at": "2018-09-26T18:40:29.193401Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tJ5sns0eSZa5MHo18AT-yA"],
+        "issued_at": "2018-10-25T18:25:02.648024Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18121,15 +16689,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:29 GMT
+      - Thu, 25 Oct 2018 18:25:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e98bf84b4c754b9cb4d2fed096b49e0e
+      - 95d1254eb61b4beab0f99e283ddfd2c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-25512bc2-9379-429e-8ff6-2e9a1573be2a
+      - req-90fabb3d-ed60-426a-bb43-b6dc0bec69ab
       Content-Length:
       - '7265'
       Connection:
@@ -18141,7 +16709,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:29.439038Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:02.844953Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18220,16 +16788,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GD5ac8KJQg65z0U6hjs6pw"],
-        "issued_at": "2018-09-26T18:40:29.439087Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WsOfGh7UTRi2G0a1rom46Q"],
+        "issued_at": "2018-10-25T18:25:02.844973Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18241,15 +16809,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:29 GMT
+      - Thu, 25 Oct 2018 18:25:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9d98c371780844148922ead51bedc5c5
+      - 2152d533f66141e9b07327b7ab257f35
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c6460b7-9cec-4c37-bd0e-d8de1dc079e6
+      - req-2c620caa-a6cd-407a-af8c-dec0945c773b
       Content-Length:
       - '7278'
       Connection:
@@ -18261,7 +16829,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:29.649067Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:03.060421Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18340,16 +16908,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["joMhrxthQ4SP2hweGRDP2g"],
-        "issued_at": "2018-09-26T18:40:29.649091Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a8xN4qrORzSneLTJ4-_gYw"],
+        "issued_at": "2018-10-25T18:25:03.060445Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18361,15 +16929,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:29 GMT
+      - Thu, 25 Oct 2018 18:25:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9027346fe26442ddb913e33cb8ba07ba
+      - 9b4f4543f9714fb0bc2c362fc0aff212
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7250a12b-ad11-4303-ac62-a27659b6d2b3
+      - req-12821e81-4cf8-4334-9114-83b9c676d88f
       Content-Length:
       - '7278'
       Connection:
@@ -18381,7 +16949,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:29.858711Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:03.259946Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18460,10 +17028,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["E8IEjDU3QweV_0G7-XJiqw"],
-        "issued_at": "2018-09-26T18:40:29.858731Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SFUSPrrWTrSnttAGihIrQQ"],
+        "issued_at": "2018-10-25T18:25:03.259967Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -18478,7 +17046,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9027346fe26442ddb913e33cb8ba07ba
+      - 9b4f4543f9714fb0bc2c362fc0aff212
   response:
     status:
       code: 200
@@ -18491,28 +17059,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987229.98083'
+      - '1540491903.38693'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987229.98083'
+      - '1540491903.38693'
       X-Trans-Id:
-      - tx4039215885ef43d68b3b6-005babd29d
+      - txd373f8e5135a40fda5dd6-005bd20a7f
       Date:
-      - Wed, 26 Sep 2018 18:40:29 GMT
+      - Thu, 25 Oct 2018 18:25:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18524,15 +17092,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6cc48073f1524838ab0783c45184fb33
+      - 0ecd39c7812c4a0bb63baa5ccf6e84c0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-08112bbb-a414-4946-be95-745e381e95aa
+      - req-5d26573d-13cc-4792-8c6b-2d7533277083
       Content-Length:
       - '7278'
       Connection:
@@ -18544,7 +17112,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:30.180655Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:03.574794Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18623,10 +17191,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iu_l8oyhQFW3Pku9NmK4kQ"],
-        "issued_at": "2018-09-26T18:40:30.180678Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OjUV0TEETdqrmL17MhGDWQ"],
+        "issued_at": "2018-10-25T18:25:03.574814Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -18641,7 +17209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cc48073f1524838ab0783c45184fb33
+      - 0ecd39c7812c4a0bb63baa5ccf6e84c0
   response:
     status:
       code: 200
@@ -18654,28 +17222,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987230.31081'
+      - '1540491903.70125'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987230.31081'
+      - '1540491903.70125'
       X-Trans-Id:
-      - txcc58e70aabc54557ae57a-005babd29e
+      - tx7c7e093a25ad4b11b4884-005bd20a7f
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18687,15 +17255,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-214b239c-3938-4b85-bac3-23d793d0e788
+      - req-94e2bca6-09d1-4d86-a23d-666e28425359
       Content-Length:
       - '7264'
       Connection:
@@ -18707,7 +17275,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:30.509976Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:03.899294Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18786,10 +17354,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YDTJunfoR42FjfErpv_BIA"],
-        "issued_at": "2018-09-26T18:40:30.509997Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vIfoWvuERiKxN0AmL2MeqA"],
+        "issued_at": "2018-10-25T18:25:03.899317Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -18804,7 +17372,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
   response:
     status:
       code: 200
@@ -18833,15 +17401,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txccf38519332c4dd69d5b8-005babd29e
+      - tx6f1d78f4d5a448ac94e1f-005bd20a7f
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -18856,7 +17424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
   response:
     status:
       code: 200
@@ -18885,20 +17453,20 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf6d5767d8d324490a740a-005babd29e
+      - txccf7937a99e44785b4f47-005bd20a80
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18910,15 +17478,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:30 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ee784870108a4a8584d9669d3e2dd97c
+      - 053b8fe31abf46dc9ce4d128ae6bac09
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6d278d68-93c3-4935-83d2-53e10d27297a
+      - req-dad70928-2ac8-4e1a-8356-1cdceaec8618
       Content-Length:
       - '7278'
       Connection:
@@ -18930,7 +17498,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:30.902370Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:04.306216Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19009,10 +17577,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GL2cNaxsRACUEEmAaMB2ug"],
-        "issued_at": "2018-09-26T18:40:30.902390Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IPmd7ivTQpCIlCCaI3x8Jg"],
+        "issued_at": "2018-10-25T18:25:04.306236Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -19027,7 +17595,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee784870108a4a8584d9669d3e2dd97c
+      - 053b8fe31abf46dc9ce4d128ae6bac09
   response:
     status:
       code: 200
@@ -19040,22 +17608,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987231.02353'
+      - '1540491904.44033'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987231.02353'
+      - '1540491904.44033'
       X-Trans-Id:
-      - txd6f805850dc44f8d825d1-005babd29e
+      - txb5db464df8ca4c42a82bf-005bd20a80
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -19070,7 +17638,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bbfda4d45d2d40b78722f2ad9136c1f2
+      - 744af499dd6f4376afe4356058b9277b
   response:
     status:
       code: 200
@@ -19083,28 +17651,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987231.16755'
+      - '1540491904.54913'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987231.16755'
+      - '1540491904.54913'
       X-Trans-Id:
-      - txa705a00d566041bcbd773-005babd29f
+      - tx769fe5bfa46843b68914f-005bd20a80
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -19116,15 +17684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1e3111cf3cad44a2b55892223860ee22
+      - 744abf2e498645f9968950d8de125c4f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9a2e5c41-6899-4613-bc21-728e5379ad2a
+      - req-423237c0-606a-4a2c-ba55-797a433a5f8f
       Content-Length:
       - '7265'
       Connection:
@@ -19136,7 +17704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:31.350148Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:04.741361Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -19215,10 +17783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0E3mRKA-Qi2GAMtkpLbqrw"],
-        "issued_at": "2018-09-26T18:40:31.350168Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_uuEaGwdSIuLcavHX73Bew"],
+        "issued_at": "2018-10-25T18:25:04.741381Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -19233,7 +17801,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e3111cf3cad44a2b55892223860ee22
+      - 744abf2e498645f9968950d8de125c4f
   response:
     status:
       code: 200
@@ -19246,28 +17814,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987231.47200'
+      - '1540491904.87761'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987231.47200'
+      - '1540491904.87761'
       X-Trans-Id:
-      - tx3507684f168948c28943d-005babd29f
+      - txe9b1618b91444020a8c04-005bd20a80
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -19279,15 +17847,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8c4f5a6e5f1343caaa23b8cfcfde0e61
+      - c6b333322d52418bad34755e6c21d703
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-089f86b6-d236-46b7-ab9a-31fc73bf4c8f
+      - req-c03106bb-5d91-42e4-9533-1318dd7c1036
       Content-Length:
       - '7278'
       Connection:
@@ -19299,7 +17867,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:40:31.652885Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:25:05.083680Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19378,10 +17946,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZYjLYFh1RTKQzTk6s7UBDA"],
-        "issued_at": "2018-09-26T18:40:31.652904Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NT0Lp-EiR0Cnrcqi13zxgQ"],
+        "issued_at": "2018-10-25T18:25:05.083699Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -19396,7 +17964,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c4f5a6e5f1343caaa23b8cfcfde0e61
+      - c6b333322d52418bad34755e6c21d703
   response:
     status:
       code: 200
@@ -19409,22 +17977,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987231.77301'
+      - '1540491905.21053'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987231.77301'
+      - '1540491905.21053'
       X-Trans-Id:
-      - tx4dff4811bbe64b00bf80c-005babd29f
+      - tx3b6a449f63a24242995f6-005bd20a81
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -19439,7 +18007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
   response:
     status:
       code: 200
@@ -19460,9 +18028,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7c6255a1dcbc401a8ed99-005babd29f
+      - tx39174810508f4b28ae123-005bd20a81
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -19472,7 +18040,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -19487,7 +18055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
   response:
     status:
       code: 200
@@ -19508,14 +18076,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txdd41c7c01caf4e5b9d9fb-005babd29f
+      - txbe76fbce4cce47e8a2fc8-005bd20a81
       Date:
-      - Wed, 26 Sep 2018 18:40:31 GMT
+      - Thu, 25 Oct 2018 18:25:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -19530,7 +18098,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bce10568ad8490e9caee68151dbc934
+      - f7a729d23187437396350e3b549696ae
   response:
     status:
       code: 200
@@ -19551,12 +18119,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx96c9ae0192e34b66bdc2b-005babd2a0
+      - tx8fffc41eb7b443f5a5e45-005bd20a81
       Date:
-      - Wed, 26 Sep 2018 18:40:32 GMT
+      - Thu, 25 Oct 2018 18:25:05 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:25:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
+      - Thu, 25 Oct 2018 18:22:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c83aabc-466f-4058-8b7f-0a882ab8dcb6
+      - req-18533d3f-afc0-4955-8b52-8b1fd28650f6
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:02.237378Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.219019Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8xQ2kSA0SiarLahmIBp1Ng"],
-        "issued_at": "2018-09-26T18:39:02.237412Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eVhLnFseRpCYq4XgFYSj8Q"],
+        "issued_at": "2018-10-25T18:22:22.219041Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
+      - Thu, 25 Oct 2018 18:22:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,13 +154,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
+      - Thu, 25 Oct 2018 18:22:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 116e69a6f55c479fa470aaf6b41b7d2d
+      - 91fcf3848c964188815a274cb6062deb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bce6db92-38a7-4d7c-bd58-83eeb9eea9c2
+      - req-2eefb1c3-e0e7-4818-9886-44ed1d3dab5d
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:02.529714Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.514874Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,48 +271,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p_e-WAWtToqado5iHZ73mw"],
-        "issued_at": "2018-09-26T18:39:02.529734Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eX4TU3FJSKK7sW2uYavsag"],
+        "issued_at": "2018-10-25T18:22:22.514894Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 116e69a6f55c479fa470aaf6b41b7d2d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -324,15 +292,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
+      - Thu, 25 Oct 2018 18:22:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 532fefb9a5754e8fb9538f5f3c438507
+      - 630d0150087049f6aa2275d627a16c4f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-31799d5b-2502-4751-8ffe-4ca0652c1507
+      - req-214b46fa-777d-4cca-8675-c1eb09b5b44d
       Content-Length:
       - '7311'
       Connection:
@@ -344,7 +312,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:02.812930Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.706812Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -423,16 +391,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kaHcRrPYTCaAcmqRmoGH7w"],
-        "issued_at": "2018-09-26T18:39:02.812951Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tvWwo4NLSQuHIBbHJsAiBQ"],
+        "issued_at": "2018-10-25T18:22:22.706830Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"532fefb9a5754e8fb9538f5f3c438507"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -444,135 +412,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:02 GMT
+      - Thu, 25 Oct 2018 18:22:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 37aae0d2e53e4fe2b5136f8f5757cb9b
+      - 36b6f29c59bf47458d04bf115e27e853
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e67ddf1e-3a37-4e23-bef2-7a69eee2e468
-      Content-Length:
-      - '7346'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:02.812930Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MLiO5u3GS8KMTnXsrVSN9Q",
-        "kaHcRrPYTCaAcmqRmoGH7w"], "issued_at": "2018-09-26T18:39:02.996880Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:03 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:03 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-469bc80c-98b0-4300-8b8c-eff8be891c7f
+      - req-0c6070a7-f76d-4128-bb44-61088f2141f2
       Content-Length:
       - '7311'
       Connection:
@@ -584,7 +432,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:03.198003Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:22.908544Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -663,55 +511,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vViEc_PKSvORWbdoQ1dhuA"],
-        "issued_at": "2018-09-26T18:39:03.198022Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D1Tw52kRSpqk6XHc7iY13g"],
+        "issued_at": "2018-10-25T18:22:22.908563Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:39:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.206:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.206:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.206:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.206:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -723,15 +532,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:03 GMT
+      - Thu, 25 Oct 2018 18:22:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aea5d35fa63b48f3adafada129c69fcd
+      - a1b4e66dd577428086a09243c0307fa4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ff442459-6458-4c9a-9a01-3c2bf41fa380
+      - req-c98073b9-11b7-4a72-912f-9a74615ec736
       Content-Length:
       - '7311'
       Connection:
@@ -743,7 +552,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:03.479311Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.118865Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -822,16 +631,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xo3gQoLWR6GCIUomnP5Ryw"],
-        "issued_at": "2018-09-26T18:39:03.479332Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["T84pCiw8R0yJy0dM0mXwsg"],
+        "issued_at": "2018-10-25T18:22:23.118886Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -843,15 +652,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:03 GMT
+      - Thu, 25 Oct 2018 18:22:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c7409d2066ca434dbe8270d502db1d26
+      - 40ed08ea20d34fcf885d7f17f951e54c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c2b1516e-005d-4c2f-bcaf-98721c11265c
+      - req-a5a5cbb0-5058-4c1e-90b9-815909d6df48
       Content-Length:
       - '7311'
       Connection:
@@ -863,7 +672,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:04.024879Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.332056Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -942,16 +751,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cD0TMcaIRZyas2x8SVR33Q"],
-        "issued_at": "2018-09-26T18:39:04.024899Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b6xXX16gQ_6JYDhO_LI0wg"],
+        "issued_at": "2018-10-25T18:22:23.332076Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -963,15 +772,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:04 GMT
+      - Thu, 25 Oct 2018 18:22:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7d4347748b72403b94e12f3044448296
+      - 4ae5caee37854569bb35e7f8dfe116b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d0d37468-1121-4b13-a944-f7020f2cdf52
+      - req-90cc2379-c318-468a-9ca8-00811370c350
       Content-Length:
       - '7311'
       Connection:
@@ -983,7 +792,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:04.237770Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.686291Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1062,16 +871,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cRKPjPfcQfOhPJhQu3tMIA"],
-        "issued_at": "2018-09-26T18:39:04.237790Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h_89j19JSkaT0osjf13i-A"],
+        "issued_at": "2018-10-25T18:22:23.686313Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1083,15 +892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:04 GMT
+      - Thu, 25 Oct 2018 18:22:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6e206a0e550349428fe87e3092fdddf1
+      - 1ca552d7955a475cb4e5ad6ab71b445a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cb6a9e75-f03d-4e45-a581-4e04f842b7e9
+      - req-f134ef67-311a-433c-8bf9-b7298b931268
       Content-Length:
       - '7311'
       Connection:
@@ -1103,7 +912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:04.435946Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:23.917985Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1182,16 +991,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["V4sCWucFQq6PLAHghJUiPg"],
-        "issued_at": "2018-09-26T18:39:04.435965Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EaijN67lTvqSmN3_pc_gog"],
+        "issued_at": "2018-10-25T18:22:23.918006Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1203,15 +1012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:04 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0662f7a6440d490a99cb5c66b73ead3f
+      - 823bc6b7c9bb46eb91859ceccaf3db70
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc607380-a5fc-4d1c-98db-0e5a76b023f0
+      - req-7ccf3420-f2a0-483d-bb66-0da028f6549c
       Content-Length:
       - '297'
       Connection:
@@ -1220,15 +1029,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:39:04.596994Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:24.095227Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xNsDveiJQ_uyMKu4HoZYeg"],
-        "issued_at": "2018-09-26T18:39:04.597012Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OJBiF3UXSiKWtbpl6cSvHw"],
+        "issued_at": "2018-10-25T18:22:24.095246Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -1240,29 +1049,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0662f7a6440d490a99cb5c66b73ead3f
+      - 823bc6b7c9bb46eb91859ceccaf3db70
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:04 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a48b22ed-8487-44b1-b835-335319e1ffb3
+      - req-1bc4931c-728f-424c-8e2a-5395da290f7f
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -1286,13 +1095,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"0662f7a6440d490a99cb5c66b73ead3f"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1304,196 +1113,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:04 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 19bcc7f8331c48e88144985d8a71dc36
+      - 2a855951192c4ceab849dca2a5eaa435
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-efa5e9fe-da4a-4adf-ae0e-c03a1dec942c
-      Content-Length:
-      - '7313'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:04.596994Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pJyYq8UPR6efUUH6FZj1Pw",
-        "xNsDveiJQ_uyMKu4HoZYeg"], "issued_at": "2018-09-26T18:39:04.906331Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:04 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 19bcc7f8331c48e88144985d8a71dc36
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-1677cf29-93ac-417d-94b6-4b280459085d
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - a7beb99066f944229d4c6a4c291bc198
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-959b0811-3cd7-4d07-b10b-8eb0ed8ade2c
+      - req-97df81cb-7d86-4494-a81b-bdf7c8563a85
       Content-Length:
       - '7278'
       Connection:
@@ -1505,7 +1133,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:05.214174Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:24.444661Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1584,10 +1212,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mi0jsk_xRGuTiEyWMqP1YQ"],
-        "issued_at": "2018-09-26T18:39:05.214198Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rfjpJ8XnRIqVxRjpnkR9yw"],
+        "issued_at": "2018-10-25T18:22:24.444682Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1602,7 +1230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7beb99066f944229d4c6a4c291bc198
+      - 2a855951192c4ceab849dca2a5eaa435
   response:
     status:
       code: 200
@@ -1613,7 +1241,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1622,13 +1250,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1640,15 +1268,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e25d5cf5e4014295ae48a194ff95c9b2
+      - 3973913b005d45869badb592a073865c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-40aab62c-7675-47f5-8977-45861c2341f7
+      - req-a0ac4897-9999-4b65-bd04-bf3043350f2f
       Content-Length:
       - '7278'
       Connection:
@@ -1660,7 +1288,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:05.498619Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:24.727425Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1739,10 +1367,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YUF2wLfNSKaJhiWcnEXe0g"],
-        "issued_at": "2018-09-26T18:39:05.498639Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zAppBYiKQ4ON_fx30UqJJw"],
+        "issued_at": "2018-10-25T18:22:24.727457Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1757,7 +1385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25d5cf5e4014295ae48a194ff95c9b2
+      - 3973913b005d45869badb592a073865c
   response:
     status:
       code: 200
@@ -1768,7 +1396,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1777,13 +1405,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1795,15 +1423,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3862b8d6848a4ae9a824391d0175e20d
+      - e725f10b870d40f6b553a3e099427814
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ac806afb-63d6-4abe-acbc-e72b85aee817
+      - req-dddc2fd2-3a28-452b-9ab9-4dd376e45da5
       Content-Length:
       - '7264'
       Connection:
@@ -1815,7 +1443,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:05.774320Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:25.045405Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1894,10 +1522,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fm7NntptTcCDL91zFzyXgg"],
-        "issued_at": "2018-09-26T18:39:05.774340Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jEaUH4RjTSGDeeK1PXoY-Q"],
+        "issued_at": "2018-10-25T18:22:25.045429Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1912,7 +1540,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3862b8d6848a4ae9a824391d0175e20d
+      - e725f10b870d40f6b553a3e099427814
   response:
     status:
       code: 200
@@ -1923,7 +1551,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1932,13 +1560,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1950,15 +1578,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:05 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb1a5b149e3d44098abfbc1fead14029
+      - 2be3fc38002b49cfa2684c1bffd8cc8a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ace19d2d-6f62-40b9-8154-a7ba9f18c484
+      - req-0d409d99-e3f0-4420-bf03-324761846efd
       Content-Length:
       - '7278'
       Connection:
@@ -1970,7 +1598,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:06.048721Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:25.326766Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2049,10 +1677,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JclUJWWwReK1fgwJPanT6Q"],
-        "issued_at": "2018-09-26T18:39:06.048742Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SGmrlEPHQcu1z-zMIjWNrw"],
+        "issued_at": "2018-10-25T18:22:25.326797Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2067,7 +1695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb1a5b149e3d44098abfbc1fead14029
+      - 2be3fc38002b49cfa2684c1bffd8cc8a
   response:
     status:
       code: 200
@@ -2078,7 +1706,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:06 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2087,13 +1715,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2105,15 +1733,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a5c07093de204a73aa4f0c41de7057d5
+      - 4b5704090f3442449577f7b2f60d6f80
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9d6c87c-c05b-434d-81af-bdb24eb49c3e
+      - req-f52146f8-04b8-4f7c-a072-fe52ec0e5d45
       Content-Length:
       - '7265'
       Connection:
@@ -2125,7 +1753,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:11.382953Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:25.606437Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2204,10 +1832,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h30oV0XUR6-zb28wUBBE4g"],
-        "issued_at": "2018-09-26T18:39:11.382973Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7o0w06DCSR6zmuvFydURKg"],
+        "issued_at": "2018-10-25T18:22:25.606458Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2222,7 +1850,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5c07093de204a73aa4f0c41de7057d5
+      - 4b5704090f3442449577f7b2f60d6f80
   response:
     status:
       code: 200
@@ -2233,7 +1861,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2242,13 +1870,13 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -2260,15 +1888,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0f165f88c9d14987a3a458e003411c18
+      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-16367922-be4a-4184-961f-1c32c7387498
+      - req-8fd2eca7-5b37-43c7-bd49-1aa1b8554a7b
       Content-Length:
       - '7278'
       Connection:
@@ -2280,7 +1908,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:11.654682Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:25.934966Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2359,10 +1987,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VKXHcPuCSamVI7aVm0hxlg"],
-        "issued_at": "2018-09-26T18:39:11.654702Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["44GNQzObQDKW2qgGg9jBbw"],
+        "issued_at": "2018-10-25T18:22:25.934999Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2377,7 +2005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f165f88c9d14987a3a458e003411c18
+      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
   response:
     status:
       code: 200
@@ -2388,7 +2016,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2397,7 +2025,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2412,7 +2040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2425,9 +2053,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-abed5938-2621-4703-8a5e-936a6e1914f3
+      - req-dafffb78-10e8-4d4b-bd70-20ca8481f8eb
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2441,7 +2069,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2456,7 +2084,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2469,9 +2097,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-e90913b8-5b19-4c52-938d-c2e4aaa2f9f2
+      - req-cb7d1355-c170-49d5-98bf-829e70ac3e22
       Date:
-      - Wed, 26 Sep 2018 18:39:11 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2485,7 +2113,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2500,7 +2128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2513,9 +2141,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-714f6922-2744-4a23-8262-18415deebc49
+      - req-887af60a-d6e8-4d27-a3b9-abfc98065181
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2530,7 +2158,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2545,7 +2173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2558,9 +2186,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-bc36fe9c-253b-48ce-b0eb-35176a3c86dc
+      - req-f6ec65ba-4d29-4197-a09e-7360b52a3adc
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2570,7 +2198,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2585,7 +2213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2598,15 +2226,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d38866dc-d28d-4c27-8aa4-b56c4e0fc256
+      - req-9662da46-c2ce-4357-9ce3-01f7b8524dfd
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -2621,7 +2249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2634,15 +2262,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-358740c6-06d9-44d8-aa5c-8ce8b0465cd4
+      - req-f08e1182-9c57-4956-ab8a-ca5268037884
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -2657,28 +2285,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aea5d35fa63b48f3adafada129c69fcd
+      - a1b4e66dd577428086a09243c0307fa4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-11e94e82-5bb2-48af-923a-16d71a915044
+      - req-538efe8c-f1db-41fb-ab46-1221012e8595
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-11e94e82-5bb2-48af-923a-16d71a915044
+      - req-538efe8c-f1db-41fb-ab46-1221012e8595
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -2693,7 +2321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2706,14 +2334,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-c1e0a373-44a8-46b1-8f88-183654acefa5
+      - req-4cf6f518-11c0-4cb8-aa72-eafe388f43a4
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2728,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7beb99066f944229d4c6a4c291bc198
+      - 2a855951192c4ceab849dca2a5eaa435
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2741,9 +2369,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-015e2263-8989-4ce6-a7b0-4064399657ae
+      - req-9325481d-52b0-4ba0-b1db-9af29fabd325
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2752,7 +2380,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2767,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25d5cf5e4014295ae48a194ff95c9b2
+      - 3973913b005d45869badb592a073865c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2780,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-482e7376-9d24-45d0-8b52-183fa894d03d
+      - req-f49abd96-80bf-4ee3-9f8d-a7e627d93cb0
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2791,7 +2419,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2806,7 +2434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3862b8d6848a4ae9a824391d0175e20d
+      - e725f10b870d40f6b553a3e099427814
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2819,9 +2447,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c21ce97f-246a-4be7-9986-4df0e8aca3dc
+      - req-301aeb86-47f6-41ee-ab5a-75b0c5d0dd22
       Date:
-      - Wed, 26 Sep 2018 18:39:12 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2830,7 +2458,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2845,7 +2473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb1a5b149e3d44098abfbc1fead14029
+      - 2be3fc38002b49cfa2684c1bffd8cc8a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2858,9 +2486,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-67dd64b6-6e8d-4399-af66-4735560fb846
+      - req-009af2c3-eaca-4fdc-b7e7-6b5419ca7eee
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2869,7 +2497,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2884,7 +2512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2897,9 +2525,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c8182104-0762-4bc5-8c0d-13b9dac49bc3
+      - req-20d186aa-c540-4875-aeff-51d7871002c7
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2908,7 +2536,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2923,7 +2551,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5c07093de204a73aa4f0c41de7057d5
+      - 4b5704090f3442449577f7b2f60d6f80
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2936,9 +2564,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9afbaa07-d1c6-4051-8758-7150031a5173
+      - req-4e40ee5a-9e6e-442f-a0d1-1534befa9d11
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2947,7 +2575,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2962,7 +2590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0f165f88c9d14987a3a458e003411c18
+      - 1446d2cfcd0149d18b6e1e3db7ee0fb7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2975,9 +2603,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c21e8adb-6795-4163-be88-0783058c310d
+      - req-89c2d1a6-f021-4010-bcd5-021366a1022b
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2986,13 +2614,13 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3004,15 +2632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d71ba4861aa94075a6b66cd2ec3f01e0
+      - 668f838b9a62404c96c56b87ef49fc39
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-073e7d5b-4524-4d3e-be67-57af71174418
+      - req-c094a232-cc39-4bd1-8ec8-99e64452a4ec
       Content-Length:
       - '7278'
       Connection:
@@ -3024,7 +2652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:13.548833Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:27.982329Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3103,10 +2731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ppnwdNquRo6pb4jmxYUvbQ"],
-        "issued_at": "2018-09-26T18:39:13.548854Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zyrzmbl6ToablfslGQ6a-Q"],
+        "issued_at": "2018-10-25T18:22:27.982351Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3121,22 +2749,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d71ba4861aa94075a6b66cd2ec3f01e0
+      - 668f838b9a62404c96c56b87ef49fc39
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d30616cd-481c-4a95-b120-c230260e1ddf
+      - req-38c63bf0-3385-4817-acf1-2601575e56fc
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d30616cd-481c-4a95-b120-c230260e1ddf
+      - req-38c63bf0-3385-4817-acf1-2601575e56fc
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3146,13 +2774,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3164,15 +2792,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:13 GMT
+      - Thu, 25 Oct 2018 18:22:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5d3c6fd310244f4bbfef415d1db46da0
+      - eef6fdf6077c4aaaa3aad31601c30bb4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ef11b5dd-2296-4c5c-91a1-64548860c5ad
+      - req-af992878-b252-4a19-83c5-88bac901ddb7
       Content-Length:
       - '7278'
       Connection:
@@ -3184,7 +2812,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:13.984808Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:28.538832Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3263,10 +2891,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fO8m9msmRKS1H3z8wXRTMg"],
-        "issued_at": "2018-09-26T18:39:13.984828Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GMXp7GjrTSurg3akMorIJw"],
+        "issued_at": "2018-10-25T18:22:28.538853Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3281,22 +2909,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5d3c6fd310244f4bbfef415d1db46da0
+      - eef6fdf6077c4aaaa3aad31601c30bb4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-596e2f39-2095-4b09-9c7a-5bba541f855d
+      - req-5e39e15b-e0a8-47ab-9270-b94d330f3403
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-596e2f39-2095-4b09-9c7a-5bba541f855d
+      - req-5e39e15b-e0a8-47ab-9270-b94d330f3403
       Date:
-      - Wed, 26 Sep 2018 18:39:14 GMT
+      - Thu, 25 Oct 2018 18:22:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3306,13 +2934,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3324,15 +2952,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:14 GMT
+      - Thu, 25 Oct 2018 18:22:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d3bbff00cdfe4290847cea40ce7485fd
+      - bc8408788a264c4cb365378037c36b8d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-62eac622-d86d-4792-80b2-3201c614e128
+      - req-8deb6f30-2d80-463e-ab20-6e497abe7309
       Content-Length:
       - '7264'
       Connection:
@@ -3344,7 +2972,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:14.753207Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:29.030756Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3423,10 +3051,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xuc4Jzq9RbyjvQlMhGKYvA"],
-        "issued_at": "2018-09-26T18:39:14.753230Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nI0tWavETde5n1oCJM5Yaw"],
+        "issued_at": "2018-10-25T18:22:29.030794Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3441,22 +3069,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3bbff00cdfe4290847cea40ce7485fd
+      - bc8408788a264c4cb365378037c36b8d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5c10e720-e32e-4117-ab4a-38a2440c01fc
+      - req-95ec3e03-b53a-4e77-9a59-64735cab9467
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5c10e720-e32e-4117-ab4a-38a2440c01fc
+      - req-95ec3e03-b53a-4e77-9a59-64735cab9467
       Date:
-      - Wed, 26 Sep 2018 18:39:15 GMT
+      - Thu, 25 Oct 2018 18:22:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3466,13 +3094,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3484,15 +3112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:15 GMT
+      - Thu, 25 Oct 2018 18:22:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b839ff8ad624c5ca7095bcf18904b85
+      - db662ad583834974918c01f7f15b44a7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f175a88d-934c-404e-914e-8b08129db06d
+      - req-a9dd501b-bdbc-4773-a7c7-32312b4f477a
       Content-Length:
       - '7278'
       Connection:
@@ -3504,7 +3132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:15.206287Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:29.507612Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3583,10 +3211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7OQA5I_-Qxi_MC98aotqmA"],
-        "issued_at": "2018-09-26T18:39:15.206307Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-fYJqvBnQkOBJkJRnh-i-Q"],
+        "issued_at": "2018-10-25T18:22:29.507632Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3601,22 +3229,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b839ff8ad624c5ca7095bcf18904b85
+      - db662ad583834974918c01f7f15b44a7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-964db3d2-3bbc-44b5-90a4-7bb80c0fbcfc
+      - req-27a06c1c-0b4d-4f99-b126-b0f7e38bee6c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-964db3d2-3bbc-44b5-90a4-7bb80c0fbcfc
+      - req-27a06c1c-0b4d-4f99-b126-b0f7e38bee6c
       Date:
-      - Wed, 26 Sep 2018 18:39:15 GMT
+      - Thu, 25 Oct 2018 18:22:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3626,7 +3254,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3641,22 +3269,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aea5d35fa63b48f3adafada129c69fcd
+      - a1b4e66dd577428086a09243c0307fa4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1ffb06f-b70e-4241-bd77-93f1bcb54ba7
+      - req-03d3bdd3-7e97-4522-959b-67fab1bd012c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-e1ffb06f-b70e-4241-bd77-93f1bcb54ba7
+      - req-03d3bdd3-7e97-4522-959b-67fab1bd012c
       Date:
-      - Wed, 26 Sep 2018 18:39:15 GMT
+      - Thu, 25 Oct 2018 18:22:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3666,13 +3294,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3684,15 +3312,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:15 GMT
+      - Thu, 25 Oct 2018 18:22:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ff6342cc48f5489d89b06eeb55a68fb7
+      - a9032f2af86248b69dc3957df2069bb0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2a13ee7e-01d8-4baa-9afa-222118f790b7
+      - req-c2125637-395d-4ab6-8b75-f2e53a73ce20
       Content-Length:
       - '7265'
       Connection:
@@ -3704,7 +3332,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:15.897193Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:30.265007Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3783,10 +3411,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8rXrhkgXSdSABYfTvwJObA"],
-        "issued_at": "2018-09-26T18:39:15.897211Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cePaKZXpRJ6nIi12CDRwtg"],
+        "issued_at": "2018-10-25T18:22:30.265029Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3801,22 +3429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff6342cc48f5489d89b06eeb55a68fb7
+      - a9032f2af86248b69dc3957df2069bb0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9da7c504-d438-480e-8a00-d5c700a5011e
+      - req-fe90600b-2902-4882-a268-59f7c8b6748c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9da7c504-d438-480e-8a00-d5c700a5011e
+      - req-fe90600b-2902-4882-a268-59f7c8b6748c
       Date:
-      - Wed, 26 Sep 2018 18:39:16 GMT
+      - Thu, 25 Oct 2018 18:22:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3826,13 +3454,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -3844,15 +3472,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:16 GMT
+      - Thu, 25 Oct 2018 18:22:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 284374dff1fd455780d921f718ef1b0e
+      - 62ef31a2548941e8aff76f3334a72006
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5072fbcd-2db3-40e4-b820-0f89a482c206
+      - req-3968602c-8d7c-4a2a-ae03-bf34b9be8aec
       Content-Length:
       - '7278'
       Connection:
@@ -3864,7 +3492,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:16.357865Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:30.725358Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3943,10 +3571,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UGZ6v1pbQACp5dpljwARpQ"],
-        "issued_at": "2018-09-26T18:39:16.357884Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O4zLOCyIQ82RvNKckvJhFg"],
+        "issued_at": "2018-10-25T18:22:30.725377Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3961,22 +3589,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 284374dff1fd455780d921f718ef1b0e
+      - 62ef31a2548941e8aff76f3334a72006
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7b0ac84-25af-4130-a8b0-97daf2af8807
+      - req-9eaf0290-4bb5-4835-92bd-47c205eb3308
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c7b0ac84-25af-4130-a8b0-97daf2af8807
+      - req-9eaf0290-4bb5-4835-92bd-47c205eb3308
       Date:
-      - Wed, 26 Sep 2018 18:39:16 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3986,13 +3614,13 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4004,15 +3632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:16 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9f89c81007e5431bb1333322f016bb37
+      - 3aa9c5a323a14e9ca44467a8502b46de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a67e7359-fd00-4c2a-a702-6946c9b4ee9c
+      - req-e5862bd0-45cf-4349-a5f6-3856506be84b
       Content-Length:
       - '7278'
       Connection:
@@ -4024,7 +3652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:16.795945Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:31.212393Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4103,10 +3731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t4pH6p11Rj2xUNjTcFfcpA"],
-        "issued_at": "2018-09-26T18:39:16.795964Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bnN6ytMVR_a1rJDgfNTBrA"],
+        "issued_at": "2018-10-25T18:22:31.212415Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4121,7 +3749,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f89c81007e5431bb1333322f016bb37
+      - 3aa9c5a323a14e9ca44467a8502b46de
   response:
     status:
       code: 200
@@ -4132,22 +3760,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3b5634a1-30cd-43c3-923c-910cd3362611
+      - req-56e7775d-e3b5-4e7c-9828-56f25272824e
       Date:
-      - Wed, 26 Sep 2018 18:39:16 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4159,15 +3787,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7b04e9448d78432c9334275d470d66c3
+      - e9089c1246334756885e9ce3dd46cd29
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-988f9f92-745b-46d7-8b62-9f5e98bdc072
+      - req-54e826ca-66c4-45a0-a93d-b7e2226a7424
       Content-Length:
       - '7278'
       Connection:
@@ -4179,7 +3807,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:17.103272Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:31.523000Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4258,10 +3886,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6yBefxvjSOu-btRSjVqKsQ"],
-        "issued_at": "2018-09-26T18:39:17.103307Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3_FSSiwUTG6MShhvE2_cFw"],
+        "issued_at": "2018-10-25T18:22:31.523021Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4276,7 +3904,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b04e9448d78432c9334275d470d66c3
+      - e9089c1246334756885e9ce3dd46cd29
   response:
     status:
       code: 200
@@ -4287,22 +3915,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-32728721-57b2-4347-b425-55a071aa01bc
+      - req-ee51deb4-80ac-4d18-b5da-96a6504cb7a2
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4314,15 +3942,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 86afc5f835a0427ca9bb2d1a97beacf9
+      - 65a87cdeaf364b41b1b0da85ae353c41
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa8e941c-2df0-4b62-8fad-d0de90eaaae2
+      - req-7ac7d7e7-3abe-4906-8eee-2706854195ef
       Content-Length:
       - '7264'
       Connection:
@@ -4334,7 +3962,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:17.412831Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:31.835476Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4413,10 +4041,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7mIDX7K9QhmEKEVhkxqbTw"],
-        "issued_at": "2018-09-26T18:39:17.412851Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ha8BpZWhRiC3QhrnoamhjA"],
+        "issued_at": "2018-10-25T18:22:31.835497Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4431,7 +4059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 86afc5f835a0427ca9bb2d1a97beacf9
+      - 65a87cdeaf364b41b1b0da85ae353c41
   response:
     status:
       code: 200
@@ -4442,22 +4070,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a3a45ce8-225c-4ae4-98ec-0aaa805d1ad2
+      - req-77e6004c-ff24-46b8-9e4a-65ff137161ea
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4469,15 +4097,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2ded7d9af85a4651956decc19c7aa5a5
+      - 3683d8f0ac6f46b78ee5f8bd5b032d73
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01be17ee-daef-402b-8641-424f4facc4cb
+      - req-62de84f3-1a9b-4b9b-9067-096616a5c519
       Content-Length:
       - '7278'
       Connection:
@@ -4489,7 +4117,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:17.713518Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:32.148323Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4568,10 +4196,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XE8bsVgfRsO7yvewBsmlBA"],
-        "issued_at": "2018-09-26T18:39:17.713536Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mRIbFfKiSvu8ZUF95jRThA"],
+        "issued_at": "2018-10-25T18:22:32.148343Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4586,7 +4214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ded7d9af85a4651956decc19c7aa5a5
+      - 3683d8f0ac6f46b78ee5f8bd5b032d73
   response:
     status:
       code: 200
@@ -4597,16 +4225,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9d315458-3dbb-43ed-b557-c6ed1aab36f5
+      - req-bc545e17-aac4-4ab2-9a75-0caa7b04aaf3
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4621,7 +4249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 116e69a6f55c479fa470aaf6b41b7d2d
+      - 91fcf3848c964188815a274cb6062deb
   response:
     status:
       code: 200
@@ -4632,22 +4260,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c516bbad-f379-42c8-9366-7f229c998b15
+      - req-b2f6d236-6700-4d7e-b448-4cff47f9382d
       Date:
-      - Wed, 26 Sep 2018 18:39:17 GMT
+      - Thu, 25 Oct 2018 18:22:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4659,15 +4287,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0357cd8ff76041f2b624506b7dbd8b73
+      - 8a10d8753ae94feeb9299ed94106b12b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17d5bf5e-51e8-488d-8f5e-0f327ca4658a
+      - req-18698374-f990-4481-8a64-49513b6a7f9a
       Content-Length:
       - '7265'
       Connection:
@@ -4679,7 +4307,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:18.121146Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:32.822465Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4758,10 +4386,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IwGUEoTHR8CPyntdFqZAcw"],
-        "issued_at": "2018-09-26T18:39:18.121166Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A9PBO1mKTmiwM7bdjF-Wqg"],
+        "issued_at": "2018-10-25T18:22:32.822497Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4776,7 +4404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0357cd8ff76041f2b624506b7dbd8b73
+      - 8a10d8753ae94feeb9299ed94106b12b
   response:
     status:
       code: 200
@@ -4787,22 +4415,22 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a5bb958d-41f1-42a4-9779-73e5fbcba196
+      - req-5a44abe5-ab11-48ae-bd1f-753b0ad28a04
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4814,15 +4442,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e678c7b26d3b4bfe999ee7e76399d920
+      - 7b36ed44ac2b4da58e47edf879eac0f5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdcbbb97-5758-45bd-9b5f-a72d23264d93
+      - req-a5481ee6-f2fd-4c56-8f00-7664086b1c30
       Content-Length:
       - '7278'
       Connection:
@@ -4834,7 +4462,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:18.429816Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:33.150362Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4913,10 +4541,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xWpPescTTCiNP5YZ1i8K8w"],
-        "issued_at": "2018-09-26T18:39:18.429836Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0EVi8H5TTh-gSmq0u_Pxuw"],
+        "issued_at": "2018-10-25T18:22:33.150380Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4931,7 +4559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e678c7b26d3b4bfe999ee7e76399d920
+      - 7b36ed44ac2b4da58e47edf879eac0f5
   response:
     status:
       code: 200
@@ -4942,16 +4570,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b5d8f059-1998-4467-956f-93e1931f8323
+      - req-18c54d1a-333e-4732-ab0c-62fa6344132d
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4966,7 +4594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4979,9 +4607,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-acb24337-4bc0-4fcc-91cc-d759dd3ad396
+      - req-981e0bc4-e50f-49fb-9343-b772aa45f64a
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4991,7 +4619,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5006,7 +4634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5019,9 +4647,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-aa2b2eff-5cc7-47fe-836e-d06cc064cafb
+      - req-82e924f8-39ce-4163-8ad9-1ad8e11d0438
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5031,13 +4659,13 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5049,15 +4677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:18 GMT
+      - Thu, 25 Oct 2018 18:22:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a3ab7cd6bb204564947f2a4b60ce69bd
+      - 8d4b3cc8453b4c95b188a5fafe710698
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-114b34ae-6b70-45bb-be5a-599420e19660
+      - req-a6415c29-797e-4cab-8680-8332581c0e43
       Content-Length:
       - '7278'
       Connection:
@@ -5069,7 +4697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:18.953971Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:33.931345Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5148,10 +4776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DDWSRzkHQP-A26Oy0_WYWg"],
-        "issued_at": "2018-09-26T18:39:18.954004Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QeX_jqdmTYuLYftFlwB3Ug"],
+        "issued_at": "2018-10-25T18:22:33.931365Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5166,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a3ab7cd6bb204564947f2a4b60ce69bd
+      - 8d4b3cc8453b4c95b188a5fafe710698
   response:
     status:
       code: 200
@@ -5177,20 +4805,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-053998f0-dd53-4f0f-a846-121d9420866f
+      - req-8296632f-56b8-486a-a43a-daf08cd00961
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5202,15 +4830,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b0035b639cea493a924a6bfbe138815b
+      - fd18cf0716cf493d9b3fb7d979dd4703
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a452ed44-2f42-495d-9c09-d4e33ec74e44
+      - req-cbf10c39-4036-4052-84ba-c2f0e582de54
       Content-Length:
       - '7278'
       Connection:
@@ -5222,7 +4850,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:19.263877Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:34.382680Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5301,10 +4929,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Bb-pAoSMTVWsumDeO5ui8A"],
-        "issued_at": "2018-09-26T18:39:19.263897Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mfXO-KZuRkyfPxKUYyvmVg"],
+        "issued_at": "2018-10-25T18:22:34.382701Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5319,7 +4947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0035b639cea493a924a6bfbe138815b
+      - fd18cf0716cf493d9b3fb7d979dd4703
   response:
     status:
       code: 200
@@ -5330,20 +4958,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9cfc344a-3477-4b4c-8d03-3bcfdcb8a6ac
+      - req-afa9590b-b171-49b2-b099-c7fda43ec7da
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5355,15 +4983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1023a4c3-0b68-4dd9-add0-382867ccf890
+      - req-75cb29eb-ebb4-4fd0-84e2-219eb2be491e
       Content-Length:
       - '7264'
       Connection:
@@ -5375,7 +5003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:19.615544Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:34.727508Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5454,10 +5082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ilVPLvwXQgi2sAKXheLV7A"],
-        "issued_at": "2018-09-26T18:39:19.615563Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UmP_QVFlTGaV8aYj2U3mYQ"],
+        "issued_at": "2018-10-25T18:22:34.727529Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5472,7 +5100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -5483,9 +5111,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-8b8c3329-bef9-4ffe-a112-1d80e219fa15
+      - req-0ae81d2f-eb8e-4287-aa94-361c2a153210
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5519,7 +5147,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5534,7 +5162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -5545,20 +5173,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-be35dff5-dbbc-4667-a3f9-1895d3ff787d
+      - req-9e144d8f-95f2-44d3-8520-d7549b481145
       Date:
-      - Wed, 26 Sep 2018 18:39:19 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5570,15 +5198,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '08021929af484ad791249bab63e6d8d6'
+      - 59ebe0cb67004dff95508d37289fa923
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-679cd5d2-63be-4a51-a61a-80e1a5a49d6e
+      - req-df2f5772-f3e0-4b63-ba8a-b63aafe1d705
       Content-Length:
       - '7278'
       Connection:
@@ -5590,7 +5218,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:20.068738Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:35.208685Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5669,10 +5297,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4rfXi9L0R1Klzl8Rp8tR1A"],
-        "issued_at": "2018-09-26T18:39:20.068770Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hs9ZlmGTSbC6skik1BcuTA"],
+        "issued_at": "2018-10-25T18:22:35.208706Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5687,7 +5315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '08021929af484ad791249bab63e6d8d6'
+      - 59ebe0cb67004dff95508d37289fa923
   response:
     status:
       code: 200
@@ -5698,14 +5326,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5dd33748-76fa-4334-afd9-d12ff43682e4
+      - req-ebb4c259-9df9-4217-bb21-2af040f61e30
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5720,7 +5348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e206a0e550349428fe87e3092fdddf1
+      - 1ca552d7955a475cb4e5ad6ab71b445a
   response:
     status:
       code: 200
@@ -5731,20 +5359,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2f8414a2-0291-48ea-8920-c8d03d88424f
+      - req-971e4d47-22b6-41c5-a7dc-3c82785e0902
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5756,15 +5384,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5e1584276d4849138e2b541d864e921e
+      - d22ab4befc924627a86a313bd78347f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1b4cbf2f-6884-4b77-a2d4-37778925e3a7
+      - req-3346a57e-8749-42f5-9535-d002de340cb2
       Content-Length:
       - '7265'
       Connection:
@@ -5776,7 +5404,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:20.531521Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:35.654168Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5855,10 +5483,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qy1oFlm9T5qQRl94rp8GSA"],
-        "issued_at": "2018-09-26T18:39:20.531540Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d4qqBQOLQw--TTsl6KeurQ"],
+        "issued_at": "2018-10-25T18:22:35.654191Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5873,7 +5501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5e1584276d4849138e2b541d864e921e
+      - d22ab4befc924627a86a313bd78347f0
   response:
     status:
       code: 200
@@ -5884,20 +5512,20 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-87697c31-90ac-496e-a98d-61537f73d945
+      - req-48d5f5ac-6223-4fa2-b411-29fc761916f1
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5909,15 +5537,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1b2bab8a7d564948990d449b789e93ed
+      - 220c3a2ae4384cd7a229e27c914e3593
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8cd5749d-b5b8-481d-a103-cd1af060ea19
+      - req-17a49c25-270a-4ee3-95cf-51e2420772cb
       Content-Length:
       - '7278'
       Connection:
@@ -5929,7 +5557,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:20.851207Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:35.980734Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6008,10 +5636,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wx1Qc_epTJuCswYfQ7Tk6Q"],
-        "issued_at": "2018-09-26T18:39:20.851226Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Sgp8hJg5RByQoxTlhUgMWQ"],
+        "issued_at": "2018-10-25T18:22:35.980755Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -6026,7 +5654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b2bab8a7d564948990d449b789e93ed
+      - 220c3a2ae4384cd7a229e27c914e3593
   response:
     status:
       code: 200
@@ -6037,14 +5665,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cb5c1339-3ed0-4322-a896-485ec33d3606
+      - req-61b322b5-c907-46be-8197-e011233f5b6d
       Date:
-      - Wed, 26 Sep 2018 18:39:20 GMT
+      - Thu, 25 Oct 2018 18:22:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -6059,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6070,9 +5698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bfd3ec43-0bd8-493e-bc95-ffc16b325f24
+      - req-8649f54d-86a9-4dbf-aca6-26197365df44
       Date:
-      - Wed, 26 Sep 2018 18:39:21 GMT
+      - Thu, 25 Oct 2018 18:22:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6099,7 +5727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -6114,7 +5742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6125,9 +5753,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-981abdd6-ae12-4e97-8595-0409c16d7efe
+      - req-e9711200-b5e3-4e55-90cf-59c23b2d761f
       Date:
-      - Wed, 26 Sep 2018 18:39:21 GMT
+      - Thu, 25 Oct 2018 18:22:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6154,7 +5782,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -6169,7 +5797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6180,9 +5808,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fc8d2707-d69b-4c9e-b3b3-6d0a03d3ca90
+      - req-8bad15cc-eceb-47fd-9d38-74026241ae56
       Date:
-      - Wed, 26 Sep 2018 18:39:21 GMT
+      - Thu, 25 Oct 2018 18:22:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6209,7 +5837,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -6224,7 +5852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6235,9 +5863,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-34c47645-001f-4524-9cd6-0742eeb2bbd5
+      - req-735de1bb-7559-484e-ac76-3fc583806c0d
       Date:
-      - Wed, 26 Sep 2018 18:39:21 GMT
+      - Thu, 25 Oct 2018 18:22:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6249,7 +5877,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -6264,7 +5892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6275,9 +5903,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d753687b-55c8-4b80-967d-659e5ec506b5
+      - req-293a3ed3-0cb5-40af-84bd-7a52dc9304ff
       Date:
-      - Wed, 26 Sep 2018 18:39:21 GMT
+      - Thu, 25 Oct 2018 18:22:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6333,7 +5961,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6348,7 +5976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6359,9 +5987,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-78eea78d-c4e3-429a-83e0-a9195548c777
+      - req-4aadbe6d-8d7e-4c05-86f6-3aa219ebac8f
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6373,7 +6001,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6388,7 +6016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6399,9 +6027,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-48da00ea-50be-41c0-8d67-001dc4248b38
+      - req-8c7e6fdf-48c8-427a-82d1-6ccdcc51c852
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6457,7 +6085,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6472,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6483,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1d68d3cc-be7d-4b3f-8007-55c8a462cd2c
+      - req-1dc901c7-a24f-4eea-8aea-021270424702
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6497,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6512,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8076c24b37de41ceb60f695c26d36162
+      - c062937adb0840a79341ccb1379d179a
   response:
     status:
       code: 200
@@ -6523,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-aedbf680-a677-4ac5-a403-6a3010384da1
+      - req-fc8bae3a-9134-4c7e-a38d-b4aa5ea06af6
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6581,7 +6209,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6596,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6607,14 +6235,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ec8e1d88-d6ad-48de-97c9-a9f7af3f7947
+      - req-1d48d881-36a4-4fcd-8967-c659ab7d80d6
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6629,7 +6257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6640,9 +6268,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8a674dca-8f4a-43ce-80bf-9badf256426a
+      - req-86f389ee-0210-4bb5-a36a-4c7859be456e
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6684,7 +6312,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6699,7 +6327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6710,14 +6338,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8c469093-842b-47d6-9341-0a991e477c59
+      - req-d94b9c32-1956-4f45-b618-76f364f6a0a2
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6732,7 +6360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6743,14 +6371,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ffd558a9-9eef-47b0-af06-623fb4ff1071
+      - req-a6ff63f2-a677-4d68-94a2-ed335cdaa9f4
       Date:
-      - Wed, 26 Sep 2018 18:39:22 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6765,7 +6393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6776,14 +6404,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-033800ec-984c-4b0c-9130-d8ba155663eb
+      - req-b379ab04-cfe3-42be-9d56-25af41360d35
       Date:
-      - Wed, 26 Sep 2018 18:39:23 GMT
+      - Thu, 25 Oct 2018 18:22:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6798,7 +6426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd73b0265ac4ef4b516b077d45f8f4d
+      - 36b6f29c59bf47458d04bf115e27e853
   response:
     status:
       code: 200
@@ -6809,14 +6437,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c36f27d9-a47d-4b32-bb6f-b42e345cf4c9
+      - req-24e5adf9-d73b-4f34-96ab-983b815c83ca
       Date:
-      - Wed, 26 Sep 2018 18:39:23 GMT
+      - Thu, 25 Oct 2018 18:22:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6831,7 +6459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6844,13 +6472,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-632949da-42ad-4915-859a-baf5d8ba238b
+      - req-bbd74793-ca60-4208-ab06-34f2de4ff372
       Date:
-      - Wed, 26 Sep 2018 18:39:23 GMT
+      - Thu, 25 Oct 2018 18:22:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:53:02Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -6892,7 +6520,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6907,7 +6535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6920,9 +6548,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-1fae9467-7c7c-483b-9da7-614926526e23
+      - req-b5340773-833b-46ba-9ab0-1525d218db31
       Date:
-      - Wed, 26 Sep 2018 18:39:23 GMT
+      - Thu, 25 Oct 2018 18:22:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6946,7 +6574,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:53:07Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -6968,7 +6596,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6983,7 +6611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6996,13 +6624,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-5151adc3-9628-4453-b20e-2608db198486
+      - req-168c184f-c2e7-498c-8ebf-0c1fe77147e9
       Date:
-      - Wed, 26 Sep 2018 18:39:23 GMT
+      - Thu, 25 Oct 2018 18:22:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:52:52Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -7023,7 +6651,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:52:47Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -7046,7 +6674,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -7061,7 +6689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7074,9 +6702,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-429dd777-8bbc-4309-a6bc-058bc93be425
+      - req-afbacc6f-1f0a-44a9-9e3d-b09d00b9ff03
       Date:
-      - Wed, 26 Sep 2018 18:39:24 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -7118,7 +6746,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -7133,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7146,9 +6774,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-2a8c7f88-1b2f-44d0-98c4-6ce336ad7e7b
+      - req-6dc77e40-b2af-4a0f-95ed-22a8a8b708fd
       Date:
-      - Wed, 26 Sep 2018 18:39:24 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -7171,7 +6799,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7186,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7199,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2aa2ae5a-445c-417b-a17d-2316496b32ce
+      - req-2ebae9cc-635b-441e-8e2b-0fbe4689fe98
       Date:
-      - Wed, 26 Sep 2018 18:39:24 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7221,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7234,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b442e022-031d-4bb4-81b5-5628867fa1f1
+      - req-13e0877a-836c-48fd-9154-c9cde202f1ae
       Date:
-      - Wed, 26 Sep 2018 18:39:24 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7256,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7269,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b81b4822-47ca-48e1-b038-db7e1ed87ada
+      - req-1ab76fee-f7a3-4000-bcf7-7bf4907a2f09
       Date:
-      - Wed, 26 Sep 2018 18:39:24 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7291,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7304,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-aede57e5-1444-4ead-a698-8d4e2d8611da
+      - req-7b48047e-ac74-4090-a57a-296c3145cf3f
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7326,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7339,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7468c6c4-5029-44c9-9ead-5dc4f9ce270f
+      - req-49e2489d-562b-4532-9549-7e633bb366ff
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7361,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7374,14 +7002,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5ac36d19-6318-4760-b4e2-d5dd1477afb7
+      - req-d2bf32f1-df1f-494a-9350-074bfbc69640
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7396,7 +7024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7409,14 +7037,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-82ce3b4a-eb5b-4222-a4af-a0c0cbcdd429
+      - req-30c71f63-fc9b-4847-88e4-1ac6aaa5dbde
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7431,7 +7059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7444,14 +7072,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f1dca801-f389-4b41-80bb-87b27c59776a
+      - req-f3282bfb-65d0-488e-bfe1-b8fc4b1eb663
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7466,7 +7094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7479,14 +7107,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-01b5c750-de5c-44ae-9a64-f70595db9209
+      - req-67c2212d-e033-4703-a6b1-10d13443982b
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7501,7 +7129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7514,26 +7142,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3a1504fd-d032-45bd-845d-153c34617c96
+      - req-295971be-734a-45d2-8af7-bec2f3b6c2c5
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:39:19.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:22:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:39:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:22:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:39:22.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:22:33.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:39:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:22:35.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:39:20.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:22:36.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7548,7 +7176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ce6c5c1510541c2941dd242abb56aa3
+      - d76a653d8e4441508612294af96ce283
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7561,32 +7189,32 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ca162e24-2cc7-450d-b2ca-a02b59e91626
+      - req-23de3684-1b06-4dbf-9f05-782390fa968b
       Date:
-      - Wed, 26 Sep 2018 18:39:25 GMT
+      - Thu, 25 Oct 2018 18:22:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:39:19.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:22:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:39:19.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:22:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:39:22.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:22:33.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-09-26T18:39:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:22:35.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-26T18:39:20.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-10-25T18:22:36.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7598,15 +7226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 140772e5787b426ba945dd19b4245520
+      - 7e427e3c954e418e9b1f03635c863990
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-53a16103-db14-4497-82ba-3e78534eb113
+      - req-3c6f648f-5378-47c0-864c-ef87e88ef87d
       Content-Length:
       - '7311'
       Connection:
@@ -7618,7 +7246,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:27.259155Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:44.168940Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7697,16 +7325,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FneoTEIISmyWOvXxgUeKhg"],
-        "issued_at": "2018-09-26T18:39:27.259176Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kZPczLYAQGGlV-8rf-rwfA"],
+        "issued_at": "2018-10-25T18:22:44.168971Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7718,15 +7346,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-22669b69-e1f8-4904-a93a-421496757423
+      - req-485353f1-279b-4e99-a557-f98abf5bf73e
       Content-Length:
       - '7311'
       Connection:
@@ -7738,7 +7366,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:27.469363Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:44.375877Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7817,10 +7445,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-ujRJpglRuybzMMpuuiATw"],
-        "issued_at": "2018-09-26T18:39:27.469383Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DZ4ryE8rQTyT7aSTpii6fQ"],
+        "issued_at": "2018-10-25T18:22:44.375897Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7835,7 +7463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -7846,9 +7474,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-5d03c6fd-bf12-44dc-828f-2827532df83b
+      - req-b86409c7-4243-4537-919f-a24ef1db27c2
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7883,7 +7511,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7898,7 +7526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -7909,9 +7537,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-3efebed7-34b8-4b12-8a3c-a06ffc7cfbe5
+      - req-214e3439-ed85-4443-b7f0-0af6e18a32eb
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7954,7 +7582,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7969,7 +7597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -7980,9 +7608,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-667b60a7-c51f-4cdd-a4b6-0f22c80d236a
+      - req-bc978f8a-0c5b-4df7-8112-5699721a1dd8
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -8025,7 +7653,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -8040,7 +7668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8051,9 +7679,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-8d0ba866-5d0f-4512-974c-080e002696d9
+      - req-3553e3f2-405f-4960-aec4-4239beceee6b
       Date:
-      - Wed, 26 Sep 2018 18:39:27 GMT
+      - Thu, 25 Oct 2018 18:22:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -8160,7 +7788,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -8175,7 +7803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8186,9 +7814,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-a2153c32-fa49-4951-86bb-ebc22d0a193a
+      - req-7ac8998c-c9b4-4289-b694-cea032244755
       Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -8230,7 +7858,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -8245,7 +7873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8256,15 +7884,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-664ed140-c686-4c4e-a585-20b44b5cb1f4
+      - req-fb279582-9673-4d38-88bc-92c54753388d
       Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8279,7 +7907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8290,32 +7918,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-82ae3ce9-eddf-4bf8-8910-dd256c8db54c
+      - req-21f7e40a-a85e-4d74-a152-483b1ddcf37d
       Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
-        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -8355,14 +7968,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8377,7 +8005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8388,23 +8016,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0745d87c-b975-4d2f-ae5b-036263cc4dbd
+      - req-01abb499-1074-453b-b3a5-8308b9b3b21c
       Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
+        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.51.0/24", "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
         "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -8416,11 +8073,17 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
@@ -8428,12 +8091,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
@@ -8451,53 +8108,23 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -8509,7 +8136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8520,9 +8147,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0475cd29-b899-4c57-851f-1d8b47436d10
+      - req-2f1a30b0-f369-45bc-8758-a6c5dc02e7f1
       Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
@@ -8626,271 +8253,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-514724ac-194f-459e-a052-d77024635c29
-      Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ddf36b83-a821-4082-a044-329a5dddd6c5
-      Date:
-      - Wed, 26 Sep 2018 18:39:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11",
-        "end": "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
-        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.20.0/24", "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8905,7 +8268,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8916,9 +8279,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-44d529bf-4a0e-4b36-be7c-ff04fe0df35d
+      - req-efe445a8-b7eb-477d-81fa-002fc18dadbc
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8950,7 +8313,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8965,7 +8328,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -8976,9 +8339,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-302aa882-d48d-4bec-9a07-8e37a055fc91
+      - req-3bee337d-1a21-477a-950e-65fd05bf5167
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -9010,7 +8373,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -9025,7 +8388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -9036,9 +8399,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7b31a0c4-29f5-49ed-a669-d73fa6140c6f
+      - req-0f50908d-be0f-48de-8248-ffe334de22fc
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9441,7 +8804,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9456,7 +8819,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -9467,9 +8830,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7efd8bad-c916-4cf1-b924-a2d1b7823b84
+      - req-b619d89e-f4d4-4be4-b015-f440d7e1605b
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9872,7 +9235,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9887,7 +9250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -9898,9 +9261,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9cf59fa3-4914-4b64-ae73-c557eca8b0cd
+      - req-97cfd14e-1514-435b-add1-6e7ebcf2598b
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9942,7 +9305,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9957,7 +9320,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa358f515e2e4cd499d444a45a8c6d88
+      - d2027c3ea4e64c3a8a1fa2d1362f1fa7
   response:
     status:
       code: 200
@@ -9968,9 +9331,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-03cf7bbc-2dbc-4bfe-8de6-2490aab6771e
+      - req-7d853ebc-e23c-4641-bef3-322b82e56bdc
       Date:
-      - Wed, 26 Sep 2018 18:39:29 GMT
+      - Thu, 25 Oct 2018 18:22:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -10012,13 +9375,13 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10030,15 +9393,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:30 GMT
+      - Thu, 25 Oct 2018 18:22:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d3029ea47407402aa1f991112e5f5069
+      - 03f6b128b4a046bb9c4242031c6e6dc6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f6ab1a4f-1cad-4611-bf7e-4733ea8abee7
+      - req-520b7328-50dd-4185-8bd4-f4039021b20c
       Content-Length:
       - '7311'
       Connection:
@@ -10050,7 +9413,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:30.677878Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:47.288504Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10129,16 +9492,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["19SK5d4GSRumpWK7kcQSZg"],
-        "issued_at": "2018-09-26T18:39:30.677898Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kHFyS_glScuRaFS8YSufjw"],
+        "issued_at": "2018-10-25T18:22:47.288524Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10150,15 +9513,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:30 GMT
+      - Thu, 25 Oct 2018 18:22:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b34e3260-5682-434d-8c52-f7952fb5c437
+      - req-1017d03a-94ec-41d2-93b8-e405bc7ff5a0
       Content-Length:
       - '7311'
       Connection:
@@ -10170,7 +9533,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:30.878903Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:47.485294Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10249,16 +9612,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QVJEWg4tT56fmIRFzPIGkg"],
-        "issued_at": "2018-09-26T18:39:30.878922Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["snFA1v0PRyufudMw9nMuFg"],
+        "issued_at": "2018-10-25T18:22:47.485315Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10270,15 +9633,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
+      - Thu, 25 Oct 2018 18:22:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1b9b989d27c84b75b0501cf5b2cc26a2
+      - 967dc97408fb4a2b9a0248a76834af41
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2fc189fc-31db-46b6-9afb-7a07fa9fdc8c
+      - req-972ec8ae-b44e-4b2b-a907-6dbdfcb1329e
       Content-Length:
       - '297'
       Connection:
@@ -10287,15 +9650,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:39:31.045474Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:47.652002Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9tlvJoPpS1aZsornKQTEEQ"],
-        "issued_at": "2018-09-26T18:39:31.045492Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w3OBZCXMT0aK3CzDkdAmQQ"],
+        "issued_at": "2018-10-25T18:22:47.652023Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -10307,29 +9670,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b9b989d27c84b75b0501cf5b2cc26a2
+      - 967dc97408fb4a2b9a0248a76834af41
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
+      - Thu, 25 Oct 2018 18:22:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-224c1b1a-4f69-4873-8c9a-afaaa70bc833
+      - req-bea0eb7c-b551-4bb2-9887-f2f868219b6f
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -10353,13 +9716,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"1b9b989d27c84b75b0501cf5b2cc26a2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10371,27 +9734,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
+      - Thu, 25 Oct 2018 18:22:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e00d0dd2a6204c4d8adb78ee66b8a2ea
+      - 465b88062e7e45ac97db3ce8f1fd56b0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c0e44c46-4df2-4a41-a61b-fb01a420f7e3
+      - req-69f68b5c-c24c-4686-9dfb-2dbe055bc923
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:31.045474Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:47.977968Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10470,77 +9833,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["To0iSr94TgGuLzeLic9NZA",
-        "9tlvJoPpS1aZsornKQTEEQ"], "issued_at": "2018-09-26T18:39:31.354407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zyLpNmFBRH-xkOjeL7rS5Q"],
+        "issued_at": "2018-10-25T18:22:47.977993Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e00d0dd2a6204c4d8adb78ee66b8a2ea
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-4083393e-3792-4991-95c8-88f236a3fb49
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10552,15 +9854,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
+      - Thu, 25 Oct 2018 18:22:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb6aecd7d09a4eef861c03e0f0896d22
+      - 1a1919b2284041f782d71ebf4e46d3b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1c29f1b4-81e5-4d37-b97e-10b2e5368ac4
+      - req-ce3049d3-85c1-4dec-9a16-35f652b4fbee
       Content-Length:
       - '7278'
       Connection:
@@ -10572,127 +9874,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:31.649185Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1bC5WSpNQkC_TE8x8t-3EQ"],
-        "issued_at": "2018-09-26T18:39:31.649204Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 9fccf531c1ec4c0ebb479d8298e520f0
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-768c04fe-4268-41be-9060-f8f5df942ed7
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:31.838285Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:48.179186Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10771,16 +9953,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zwuFiiHpSfSao9GiR2KrrA"],
-        "issued_at": "2018-09-26T18:39:31.838304Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_YXRyAgYShWzIKAPS1HEfA"],
+        "issued_at": "2018-10-25T18:22:48.179207Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10792,15 +9974,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:31 GMT
+      - Thu, 25 Oct 2018 18:22:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 78d5168e0af942baa67d7766e4932faf
+      - 45b78f07fe8a4b50a16c301e23622ce7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-703eef1f-9431-456e-8483-097b00f6747d
+      - req-a6b7d563-f1f6-4b8c-9c4b-f7d8481c2fc1
       Content-Length:
       - '7264'
       Connection:
@@ -10812,7 +9994,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:32.023284Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:48.379124Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10891,16 +10073,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["epMIatyOQHGBJXTyLlUWPw"],
-        "issued_at": "2018-09-26T18:39:32.023302Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3e4SJxTsTG6jOQlGELb9UA"],
+        "issued_at": "2018-10-25T18:22:48.379144Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10912,15 +10094,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:32 GMT
+      - Thu, 25 Oct 2018 18:22:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 41d3cc58e11b4ccdb351c892a1001da8
+      - ee2616ba7dfd4c34a8b21fb0b65fd743
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa5a20bc-88f0-4c70-9be2-02e1e3a9660d
+      - req-20721b7a-088e-499e-bfe8-c11f707c8251
       Content-Length:
       - '7278'
       Connection:
@@ -10932,7 +10114,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:32.243808Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:48.576585Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11011,16 +10193,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hnaoPHdfRhGYW8sZRQb2jg"],
-        "issued_at": "2018-09-26T18:39:32.243829Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KCKVLGn1RIiCSjKg-ypAlQ"],
+        "issued_at": "2018-10-25T18:22:48.576605Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11032,15 +10214,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:32 GMT
+      - Thu, 25 Oct 2018 18:22:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2547e1380f12427798104826fe1773a8
+      - d73f94041c1647ee8a965906d3cef602
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-31837033-b736-4348-960c-282702abfc93
+      - req-700c0b05-04f5-446e-9461-8d235129cc57
       Content-Length:
       - '7265'
       Connection:
@@ -11052,7 +10234,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:32.437115Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:48.772997Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11131,16 +10313,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q8IM67JkQoyt5vzo1wRUVg"],
-        "issued_at": "2018-09-26T18:39:32.437135Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nHdYH0_MTiKD6Ds4EyrbGw"],
+        "issued_at": "2018-10-25T18:22:48.773016Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11152,15 +10334,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:32 GMT
+      - Thu, 25 Oct 2018 18:22:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3cb4b04c9f94ca48c285114b9dc715d
+      - d572af06df1e4835819c400fb4158997
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4f0c2221-422c-4717-816d-2d13abf60f03
+      - req-cf486589-439a-4ea7-833b-7b6ff5619b60
       Content-Length:
       - '7278'
       Connection:
@@ -11172,7 +10354,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:32.635551Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:48.995980Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11251,16 +10433,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["s3wwhBU1Sne9baDg__aS-Q"],
-        "issued_at": "2018-09-26T18:39:32.635570Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pUOd6e8uTT6pArpZwHaJWQ"],
+        "issued_at": "2018-10-25T18:22:48.996006Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11272,15 +10454,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:32 GMT
+      - Thu, 25 Oct 2018 18:22:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f59aa94b-7c64-4f48-910b-a331104f0793
+      - req-bfd534a6-ee9c-47ee-a6fd-0a5699abbd2e
       Content-Length:
       - '7278'
       Connection:
@@ -11292,7 +10474,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:32.834364Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:49.211228Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11371,10 +10553,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8TfqoBZsTqif0VCcfmvRpQ"],
-        "issued_at": "2018-09-26T18:39:32.834393Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hnBSrRqiQ5qUhJra33bYVg"],
+        "issued_at": "2018-10-25T18:22:49.211248Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11389,33 +10571,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa84c7c4-e994-4b6c-a2ac-50e5e7c2be6d
+      - req-bbf52ee9-e3f3-40a0-b8fa-4779070085e5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aa84c7c4-e994-4b6c-a2ac-50e5e7c2be6d
+      - req-bbf52ee9-e3f3-40a0-b8fa-4779070085e5
       Date:
-      - Wed, 26 Sep 2018 18:39:32 GMT
+      - Thu, 25 Oct 2018 18:22:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11427,15 +10609,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:33 GMT
+      - Thu, 25 Oct 2018 18:22:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c133167c-29d3-46a1-80a7-bfb13fd3128c
+      - req-f674b7ea-72d6-4ba0-9c63-a5f7a2695b6b
       Content-Length:
       - '7278'
       Connection:
@@ -11447,7 +10629,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:33.157686Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:49.556129Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11526,10 +10708,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6KIkK14WQJi__OaoRouGOg"],
-        "issued_at": "2018-09-26T18:39:33.157705Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nrl6mFhPROOK38pacmUWZA"],
+        "issued_at": "2018-10-25T18:22:49.556151Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11544,33 +10726,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2df28cd-84e1-4c7a-a732-33452d9791aa
+      - req-85ac093b-d94e-47a1-9f2d-6b11b50dfae0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a2df28cd-84e1-4c7a-a732-33452d9791aa
+      - req-85ac093b-d94e-47a1-9f2d-6b11b50dfae0
       Date:
-      - Wed, 26 Sep 2018 18:39:34 GMT
+      - Thu, 25 Oct 2018 18:22:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11582,15 +10764,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:34 GMT
+      - Thu, 25 Oct 2018 18:22:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-031987d8-2d55-4974-80d8-47f5f32a1ef2
+      - req-4bec1ec0-522a-4641-9703-872d86d496b6
       Content-Length:
       - '7264'
       Connection:
@@ -11602,7 +10784,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:34.503683Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:49.896090Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11681,10 +10863,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dKT8HzdXRM2jD63jMQgpKA"],
-        "issued_at": "2018-09-26T18:39:34.503703Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sBrgA12-RnmCGUYQOZgSAw"],
+        "issued_at": "2018-10-25T18:22:49.896109Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11699,22 +10881,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b3776a0-4d26-4f0b-8a8e-0f0aa619648b
+      - req-16f219a1-c67a-47c1-8773-056a2aa4bdc7
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-0b3776a0-4d26-4f0b-8a8e-0f0aa619648b
+      - req-16f219a1-c67a-47c1-8773-056a2aa4bdc7
       Date:
-      - Wed, 26 Sep 2018 18:39:34 GMT
+      - Thu, 25 Oct 2018 18:22:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11747,7 +10929,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11762,22 +10944,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28ed9df4-1bfc-4f55-b40e-0656f7636840
+      - req-0e1d144d-4a25-4cff-9786-1fb9cf1f2179
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-28ed9df4-1bfc-4f55-b40e-0656f7636840
+      - req-0e1d144d-4a25-4cff-9786-1fb9cf1f2179
       Date:
-      - Wed, 26 Sep 2018 18:39:34 GMT
+      - Thu, 25 Oct 2018 18:22:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11818,7 +11000,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11833,22 +11015,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a909c1a-c545-4a11-a0c8-89b5a647a440
+      - req-a55a8ee2-21ce-4522-98b6-7fc115a0189a
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-9a909c1a-c545-4a11-a0c8-89b5a647a440
+      - req-a55a8ee2-21ce-4522-98b6-7fc115a0189a
       Date:
-      - Wed, 26 Sep 2018 18:39:34 GMT
+      - Thu, 25 Oct 2018 18:22:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11882,7 +11064,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11897,33 +11079,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6cdde2ad-1588-4109-bf09-a23ce5f8f272
+      - req-08066e46-ea32-4c67-9cef-d2451e4730c9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6cdde2ad-1588-4109-bf09-a23ce5f8f272
+      - req-08066e46-ea32-4c67-9cef-d2451e4730c9
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -11935,15 +11117,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1422693b-d5a2-44d8-9cc5-216c060ea22a
+      - req-96ad0403-ca2a-4f96-986d-66ee7785645a
       Content-Length:
       - '7278'
       Connection:
@@ -11955,7 +11137,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:35.267335Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:51.032595Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12034,10 +11216,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sjfv5ZWjRV6bzcnpZwnzmA"],
-        "issued_at": "2018-09-26T18:39:35.267355Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vEswN6jBQXW97FhPFT-Ymg"],
+        "issued_at": "2018-10-25T18:22:51.032621Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -12052,27 +11234,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc3dc0bb-b103-4f3b-98be-80e71eb9bb78
+      - req-7fd5d6af-c6e3-4687-8d1b-1a6e3865a122
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dc3dc0bb-b103-4f3b-98be-80e71eb9bb78
+      - req-7fd5d6af-c6e3-4687-8d1b-1a6e3865a122
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -12087,33 +11269,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-06b38dc8-d031-4791-9905-33246bc28872
+      - req-46e999da-b2e1-4d4e-861c-9000d339274a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-06b38dc8-d031-4791-9905-33246bc28872
+      - req-46e999da-b2e1-4d4e-861c-9000d339274a
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12125,15 +11307,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e617af05-843d-4d0d-8945-93fac99c5bc7
+      - req-5d3721f4-1d46-49e4-8b8b-7a789f847c88
       Content-Length:
       - '7265'
       Connection:
@@ -12145,7 +11327,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:35.730036Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:51.514362Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12224,10 +11406,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4n0rPCUzTK6CTF9WfYWloA"],
-        "issued_at": "2018-09-26T18:39:35.730077Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dd83ET2OQFKa0vh1BdN-Pw"],
+        "issued_at": "2018-10-25T18:22:51.514382Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -12242,33 +11424,33 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-042d970d-d51f-44bf-baa9-d9baced13957
+      - req-e8a393b5-5654-4070-af5b-850a808ca1b7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-042d970d-d51f-44bf-baa9-d9baced13957
+      - req-e8a393b5-5654-4070-af5b-850a808ca1b7
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12280,15 +11462,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:35 GMT
+      - Thu, 25 Oct 2018 18:22:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2eb76711-0f9a-4826-b514-d50641925ca1
+      - req-ed352e31-8364-40db-b535-26cab79d496a
       Content-Length:
       - '7278'
       Connection:
@@ -12300,7 +11482,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:36.053098Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:51.859656Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12379,10 +11561,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MoaUFTPSSsScLAPa1aSQYQ"],
-        "issued_at": "2018-09-26T18:39:36.053120Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8hZz9owzQOmgigpFajr7fw"],
+        "issued_at": "2018-10-25T18:22:51.859689Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -12397,27 +11579,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c952b868-d443-437f-be54-01350c1f7c1b
+      - req-e75f8f73-ee79-44a3-8a07-ad3779121c6f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c952b868-d443-437f-be54-01350c1f7c1b
+      - req-e75f8f73-ee79-44a3-8a07-ad3779121c6f
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -12432,27 +11614,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-985e7be6-9b42-4fd6-b40c-06e5b62ee50b
+      - req-d9ee535d-f727-4501-ba11-2348ddc2c85c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-985e7be6-9b42-4fd6-b40c-06e5b62ee50b
+      - req-d9ee535d-f727-4501-ba11-2348ddc2c85c
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -12467,27 +11649,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ebf9dfe6-5401-4c22-a00a-1fab50e8f13a
+      - req-f86cf1d9-e94c-4244-a40c-9272ad23fc6e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ebf9dfe6-5401-4c22-a00a-1fab50e8f13a
+      - req-f86cf1d9-e94c-4244-a40c-9272ad23fc6e
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -12502,27 +11684,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7ff6023-4a46-4d31-9c8d-8270a1fd3469
+      - req-ae3623bc-7fb7-41ae-8595-84e7522d52f5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f7ff6023-4a46-4d31-9c8d-8270a1fd3469
+      - req-ae3623bc-7fb7-41ae-8595-84e7522d52f5
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -12537,27 +11719,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f99cbc6-c33f-46eb-b149-76896a67fd5d
+      - req-aa2e7a5e-f05d-488d-9688-f77c5b25b076
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8f99cbc6-c33f-46eb-b149-76896a67fd5d
+      - req-aa2e7a5e-f05d-488d-9688-f77c5b25b076
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12572,22 +11754,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8ad70835-4f19-4fd1-a813-a7daf6b2d4b2
+      - req-816e7604-d411-4c2a-8f89-fa3e2094dd48
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-8ad70835-4f19-4fd1-a813-a7daf6b2d4b2
+      - req-816e7604-d411-4c2a-8f89-fa3e2094dd48
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12602,7 +11784,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12617,22 +11799,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd2589f8-a1dd-4edc-b01a-e4da191cabf5
+      - req-f1449d23-b94b-4c09-a0a8-b32a27a67e64
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-dd2589f8-a1dd-4edc-b01a-e4da191cabf5
+      - req-f1449d23-b94b-4c09-a0a8-b32a27a67e64
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12647,7 +11829,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12662,27 +11844,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0b7f888-72b4-432c-9a83-3d69e4c89c83
+      - req-f65b1b28-edd1-4b42-990e-1077bd3f1091
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b0b7f888-72b4-432c-9a83-3d69e4c89c83
+      - req-f65b1b28-edd1-4b42-990e-1077bd3f1091
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12697,27 +11879,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ca0dca7-a139-43fe-964b-4affac15a943
+      - req-af2be1b9-108f-47aa-aba0-1ba56b7460bb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6ca0dca7-a139-43fe-964b-4affac15a943
+      - req-af2be1b9-108f-47aa-aba0-1ba56b7460bb
       Date:
-      - Wed, 26 Sep 2018 18:39:36 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12732,27 +11914,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa8b90c1-34e2-48d9-a942-eda2f2389ad5
+      - req-27f05967-c17b-456a-a787-a15018a7d98d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fa8b90c1-34e2-48d9-a942-eda2f2389ad5
+      - req-27f05967-c17b-456a-a787-a15018a7d98d
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12767,27 +11949,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7a2265a-a224-4063-a384-1aca1799e1c9
+      - req-9c680337-326f-4b17-a7c8-bfee90b61782
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f7a2265a-a224-4063-a384-1aca1799e1c9
+      - req-9c680337-326f-4b17-a7c8-bfee90b61782
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12802,27 +11984,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be2d270d-1388-4373-9d57-6ba922f5715e
+      - req-2e7c698d-7596-408c-a785-e3513d984705
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-be2d270d-1388-4373-9d57-6ba922f5715e
+      - req-2e7c698d-7596-408c-a785-e3513d984705
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12837,27 +12019,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1659d262-052f-4b2d-b970-41f09ea80993
+      - req-8310c7c9-67b6-403e-b954-f5897d270666
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1659d262-052f-4b2d-b970-41f09ea80993
+      - req-8310c7c9-67b6-403e-b954-f5897d270666
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12872,27 +12054,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-01da5d2b-878d-492c-be19-7fbe6e1e7e73
+      - req-598af5ae-d7fc-4320-865b-5eadab967f8a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-01da5d2b-878d-492c-be19-7fbe6e1e7e73
+      - req-598af5ae-d7fc-4320-865b-5eadab967f8a
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12907,27 +12089,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c01b6c0f-d034-41e6-be3f-885c525aa557
+      - req-a972ec25-00d3-4c60-be48-af7cb1d7c6b9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c01b6c0f-d034-41e6-be3f-885c525aa557
+      - req-a972ec25-00d3-4c60-be48-af7cb1d7c6b9
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12942,27 +12124,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c8976aa-935b-468f-adfc-1a6df62d21e1
+      - req-054ebe52-4165-474a-be41-1dc4908bd809
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3c8976aa-935b-468f-adfc-1a6df62d21e1
+      - req-054ebe52-4165-474a-be41-1dc4908bd809
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12977,27 +12159,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f511253a-3bf9-4c84-9449-99a46d993509
+      - req-15a57c2a-db94-4a5e-b9af-a312c48578c2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f511253a-3bf9-4c84-9449-99a46d993509
+      - req-15a57c2a-db94-4a5e-b9af-a312c48578c2
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -13012,27 +12194,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-951ea47b-42a6-4503-a869-5ae467c32608
+      - req-04359ef7-4fd1-4092-a608-6a81d97250f8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-951ea47b-42a6-4503-a869-5ae467c32608
+      - req-04359ef7-4fd1-4092-a608-6a81d97250f8
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -13047,27 +12229,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2f997ab-fe99-4c3e-a174-bbfdc63cb3f1
+      - req-bb8b69ba-afea-4bd6-934d-8578c631a5f0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b2f997ab-fe99-4c3e-a174-bbfdc63cb3f1
+      - req-bb8b69ba-afea-4bd6-934d-8578c631a5f0
       Date:
-      - Wed, 26 Sep 2018 18:39:37 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -13082,27 +12264,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bfd2ffd1-c371-46d7-aac4-077cfda09701
+      - req-5dca3e7c-4266-49e8-9ef3-411316f8dc05
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bfd2ffd1-c371-46d7-aac4-077cfda09701
+      - req-5dca3e7c-4266-49e8-9ef3-411316f8dc05
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -13117,27 +12299,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4185a91e-679c-4ebe-866e-8325755a962a
+      - req-71ad6868-08fb-484c-b268-cfaa9a94997e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4185a91e-679c-4ebe-866e-8325755a962a
+      - req-71ad6868-08fb-484c-b268-cfaa9a94997e
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -13152,27 +12334,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ac6686b7-1a3e-4134-98a4-95911c534bb2
+      - req-c2f60501-3850-47ce-9d43-f086bf719a64
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ac6686b7-1a3e-4134-98a4-95911c534bb2
+      - req-c2f60501-3850-47ce-9d43-f086bf719a64
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -13187,27 +12369,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39176930-6ece-4308-b185-8f1ef3431ba8
+      - req-a97828c8-ebc2-4a0c-8516-03af1c44f82f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-39176930-6ece-4308-b185-8f1ef3431ba8
+      - req-a97828c8-ebc2-4a0c-8516-03af1c44f82f
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -13222,27 +12404,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-35c34d42-990e-4ab9-beab-fb347007c6d7
+      - req-8cbaed5a-d06c-4b4b-957d-0ebdab8aa964
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-35c34d42-990e-4ab9-beab-fb347007c6d7
+      - req-8cbaed5a-d06c-4b4b-957d-0ebdab8aa964
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -13257,27 +12439,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb38c65f-6c81-468b-b2be-d75f107d2086
+      - req-f5c1da76-c9ab-43dc-8bac-3b9e9a0824d8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bb38c65f-6c81-468b-b2be-d75f107d2086
+      - req-f5c1da76-c9ab-43dc-8bac-3b9e9a0824d8
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -13292,27 +12474,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb0208fb-a66b-47de-ac9d-5bcd2b02f03c
+      - req-a5229314-8a6e-4afe-9f02-0ad46e5a7832
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bb0208fb-a66b-47de-ac9d-5bcd2b02f03c
+      - req-a5229314-8a6e-4afe-9f02-0ad46e5a7832
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -13327,27 +12509,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-08ab355c-35e8-411b-be72-9d45e3cb30cb
+      - req-b34bcb44-4c77-401a-a164-e28d86706e74
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-08ab355c-35e8-411b-be72-9d45e3cb30cb
+      - req-b34bcb44-4c77-401a-a164-e28d86706e74
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -13362,27 +12544,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94690953-807b-46c4-8553-e138e4eec55c
+      - req-5e3973a6-f825-436f-8b89-0261a4ec1cf4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-94690953-807b-46c4-8553-e138e4eec55c
+      - req-5e3973a6-f825-436f-8b89-0261a4ec1cf4
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -13397,27 +12579,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d9843706-b248-4b8f-b319-6ec60b9f29ed
+      - req-76c960db-357d-41ee-ba63-03350577de50
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d9843706-b248-4b8f-b319-6ec60b9f29ed
+      - req-76c960db-357d-41ee-ba63-03350577de50
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -13432,22 +12614,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e55e003-33b0-48c3-bc4f-f8997c586e38
+      - req-816e90c0-d8f9-4d7f-907c-1b74425a7476
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-2e55e003-33b0-48c3-bc4f-f8997c586e38
+      - req-816e90c0-d8f9-4d7f-907c-1b74425a7476
       Date:
-      - Wed, 26 Sep 2018 18:39:38 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13459,7 +12641,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13474,22 +12656,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98daba724ec741f19f1d3bd6be3a22da
+      - b3f59ad033b1499ca257cd30eca7708c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a6f94f59-f301-46fb-8d0f-d112e2b34db1
+      - req-18422950-cad2-476e-90a8-f95a32687fb0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a6f94f59-f301-46fb-8d0f-d112e2b34db1
+      - req-18422950-cad2-476e-90a8-f95a32687fb0
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13501,7 +12683,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -13516,22 +12698,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ccd89144-b601-4318-991d-023aebaac9d2
+      - req-1936253c-7004-4cfd-abd7-697eeac493c9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ccd89144-b601-4318-991d-023aebaac9d2
+      - req-1936253c-7004-4cfd-abd7-697eeac493c9
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13543,7 +12725,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13558,22 +12740,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c99528d957a146e0a1cf8e2e18212723
+      - 9b2757c7af3b48b0b61126ed274f796f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3bb3595-99e5-4a3b-bdbb-56362da80571
+      - req-5f82276e-4a89-442c-8b7e-a75e42e24356
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b3bb3595-99e5-4a3b-bdbb-56362da80571
+      - req-5f82276e-4a89-442c-8b7e-a75e42e24356
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13585,7 +12767,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -13600,22 +12782,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e6228c87-a88c-40be-9ae2-243364aa6129
+      - req-a7072438-842e-4581-af84-e89ef23eb197
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e6228c87-a88c-40be-9ae2-243364aa6129
+      - req-a7072438-842e-4581-af84-e89ef23eb197
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13627,7 +12809,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13642,22 +12824,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b6b0f67b3374763b228753a2d2614e6
+      - f544b491a1014192a262c6bc53a569ba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-67ea9dde-0479-4f53-a98a-5ee862900671
+      - req-2fc757c1-2b42-48c6-acb8-4fe456a5133f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-67ea9dde-0479-4f53-a98a-5ee862900671
+      - req-2fc757c1-2b42-48c6-acb8-4fe456a5133f
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13669,7 +12851,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -13684,22 +12866,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fbae30fe-cef1-4c08-ab58-c56350441fc8
+      - req-b5574609-7afc-4ae1-bf21-53b46080f7cf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fbae30fe-cef1-4c08-ab58-c56350441fc8
+      - req-b5574609-7afc-4ae1-bf21-53b46080f7cf
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13711,7 +12893,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13726,22 +12908,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8be16b677f7645a7842dde4737e3ff50
+      - 2889cfd6299d41e2be5a0bd461c6ac1a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c954cf4-bad5-474d-b042-2b44750836cb
+      - req-c9173df7-c958-45c5-8a54-8303c6f236f3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7c954cf4-bad5-474d-b042-2b44750836cb
+      - req-c9173df7-c958-45c5-8a54-8303c6f236f3
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13753,7 +12935,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -13768,22 +12950,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f4308d44-edc1-4a92-bfd9-21461ba8bdab
+      - req-18084c93-db11-47a7-852a-0c2ed4aadc88
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f4308d44-edc1-4a92-bfd9-21461ba8bdab
+      - req-18084c93-db11-47a7-852a-0c2ed4aadc88
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13795,7 +12977,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13810,22 +12992,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881eaa3d10f446f086476cbd1f4e9d8d
+      - c5a7911dde30482ab43ddb64b6f8e000
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91a4ff5c-8a63-45b9-8347-3944f42fa8de
+      - req-8ed1608f-e232-45b9-a37e-b3a8ddd27fd3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-91a4ff5c-8a63-45b9-8347-3944f42fa8de
+      - req-8ed1608f-e232-45b9-a37e-b3a8ddd27fd3
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13837,7 +13019,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13852,22 +13034,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48286b72-2e75-459b-8738-89a6858c55b5
+      - req-a5040719-aab1-4ad4-ab7c-2eb203d7b6d1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-48286b72-2e75-459b-8738-89a6858c55b5
+      - req-a5040719-aab1-4ad4-ab7c-2eb203d7b6d1
       Date:
-      - Wed, 26 Sep 2018 18:39:39 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13879,7 +13061,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13894,22 +13076,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 994ee711d7f347d7a0f485fab9f8f18f
+      - ced41b29d94b44dcb6859d2130e9d670
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0530a68-7c3a-44da-bb35-97ebe912bd1e
+      - req-cbc9f36e-4f99-4f00-b1d8-7236d4889bc3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b0530a68-7c3a-44da-bb35-97ebe912bd1e
+      - req-cbc9f36e-4f99-4f00-b1d8-7236d4889bc3
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13921,7 +13103,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13936,22 +13118,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd926271-7f76-4670-bbba-beea4fa1cf84
+      - req-4e02fac8-a802-408a-a10e-437e7451bc94
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dd926271-7f76-4670-bbba-beea4fa1cf84
+      - req-4e02fac8-a802-408a-a10e-437e7451bc94
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13963,7 +13145,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13978,22 +13160,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b53aac8b74684c97b7139e269f8bf4b0
+      - 72517ec57a154677b723f279cd7d153f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2bb058c0-b1f9-4843-b2a9-329b7abab5ca
+      - req-b806bd11-afe6-4cc1-b78b-eb40707ccd95
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-2bb058c0-b1f9-4843-b2a9-329b7abab5ca
+      - req-b806bd11-afe6-4cc1-b78b-eb40707ccd95
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -14005,13 +13187,13 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14023,15 +13205,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9981f1ca886c4623ae39dfdacdf76880
+      - 9fec64dec3094533812ad026184d2127
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8ec4d466-047e-4045-90b9-109faf012382
+      - req-5eec544c-d7b6-45dd-ab4c-214131e734f4
       Content-Length:
       - '7311'
       Connection:
@@ -14043,7 +13225,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:40.499948Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:56.434356Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14122,16 +13304,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hOkdVsraQPyQHY4vuvLi5Q"],
-        "issued_at": "2018-09-26T18:39:40.499969Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c9wrYX3nTwaTkm1UDZQJPw"],
+        "issued_at": "2018-10-25T18:22:56.434376Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14143,15 +13325,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - afb5ccbd89eb4415899e50840a3808c7
+      - 8753591aa21d464f8bf26dec4d6ad7b4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fec70fed-5c3f-49da-a411-28f187b89804
+      - req-7d569647-922a-45f7-bc23-7e52ce677efe
       Content-Length:
       - '7311'
       Connection:
@@ -14163,7 +13345,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-09-26T19:39:40.705502Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-10-25T19:22:56.636581Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14242,16 +13424,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0hc68ig3QZKSLvESag1IRA"],
-        "issued_at": "2018-09-26T18:39:40.705521Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p-gr-ErYRs67eBQlHptWtQ"],
+        "issued_at": "2018-10-25T18:22:56.636601Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14263,15 +13445,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 820dd1a06f8c403b94d791d4704fb2b1
+      - 5d9d62919631472ab8419291fb156431
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d800795b-5e19-4ba5-9b1a-8552970bb854
+      - req-e554a2d5-7d97-443e-b928-3715a8e184b7
       Content-Length:
       - '297'
       Connection:
@@ -14280,15 +13462,15 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-26T19:39:40.869306Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-10-25T19:22:56.803574Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FOV4GZXkTjKvHVumnKvA1Q"],
-        "issued_at": "2018-09-26T18:39:40.869324Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R0CngDPcTdCx-ui87Xg1cA"],
+        "issued_at": "2018-10-25T18:22:56.803593Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:40 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: get
-    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
+    uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
     body:
       encoding: US-ASCII
       string: ''
@@ -14300,29 +13482,29 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 820dd1a06f8c403b94d791d4704fb2b1
+      - 5d9d62919631472ab8419291fb156431
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:40 GMT
+      - Thu, 25 Oct 2018 18:22:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2ad98df3-8f56-4d5e-9e56-7f9c314bb6b9
+      - req-03b641db-9937-485d-847c-b2cb3e52c204
       Content-Length:
-      - '2457'
+      - '2475'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects",
+      string: '{"links": {"self": "http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
         "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
         "", "links": {"self": "http://11.22.33.44:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
         "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
@@ -14346,13 +13528,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"820dd1a06f8c403b94d791d4704fb2b1"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14364,27 +13546,27 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:41 GMT
+      - Thu, 25 Oct 2018 18:22:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e4663303e2cd4e8bad66e406c231d0e0
+      - 5ad7119b280d4cbe9869665cfdd969c0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-72abcc48-72b5-48ea-87cb-9a7c0924cf9e
+      - req-678fdb5f-2022-4896-bd07-133cac3e81bf
       Content-Length:
-      - '7313'
+      - '7278'
       Connection:
       - close
       Content-Type:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:40.869306Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:57.157321Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14463,77 +13645,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aSPJXa41TaWxbV_in2wErQ",
-        "FOV4GZXkTjKvHVumnKvA1Q"], "issued_at": "2018-09-26T18:39:41.210191Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zmcZ35kbRimBHpuszweQRA"],
+        "issued_at": "2018-10-25T18:22:57.157353Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e4663303e2cd4e8bad66e406c231d0e0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:41 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-87626698-3899-4e03-a76d-a6519a2ceefc
-      Content-Length:
-      - '2179'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"links": {"self": "http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default",
-        "previous": null, "next": null}, "projects": [{"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/0098405163cd4c9dbb42c2cb43eb6fd3"},
-        "enabled": true, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "parent_id": "ef2a3405d1ef4dfd9a3616993ef46a4d",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-3"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/28db8f69ba9e4305b7fad82da4c86e74"},
-        "enabled": true, "id": "28db8f69ba9e4305b7fad82da4c86e74", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/4637c33fee924ebea81f8d209e452c91"},
-        "enabled": true, "id": "4637c33fee924ebea81f8d209e452c91", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project"}, {"is_domain": false,
-        "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/52c452d7763a4295950527948232a3e5"},
-        "enabled": true, "id": "52c452d7763a4295950527948232a3e5", "parent_id": "d09cbe26295d47ff848ea73c74264e23",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-1"}, {"is_domain":
-        false, "description": "admin tenant", "links": {"self": "http://10.8.99.206:5000/v3/projects/88ae57d444fd485ab2dfddd5a2615d52"},
-        "enabled": true, "id": "88ae57d444fd485ab2dfddd5a2615d52", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"is_domain": false, "description":
-        "", "links": {"self": "http://10.8.99.206:5000/v3/projects/d09cbe26295d47ff848ea73c74264e23"},
-        "enabled": true, "id": "d09cbe26295d47ff848ea73c74264e23", "parent_id": null,
-        "domain_id": "default", "name": "EmsRefreshSpec-Project2"}, {"is_domain":
-        false, "description": "", "links": {"self": "http://10.8.99.206:5000/v3/projects/ef2a3405d1ef4dfd9a3616993ef46a4d"},
-        "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
-        "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14545,15 +13666,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:41 GMT
+      - Thu, 25 Oct 2018 18:22:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 13fb02ab26b84eaea82c4f82f70965ca
+      - 9c52ab11bae24c4e88515ecaa9d7daa9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35544663-ff30-4edb-82fa-0533d857c16d
+      - req-a6c27b63-adca-495a-99db-bc7d7e300668
       Content-Length:
       - '7278'
       Connection:
@@ -14565,127 +13686,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:41.504711Z", "project": {"domain": {"id":
-        "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
-        "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
-        "public", "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface":
-        "admin", "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5-oqvhuQRNSPgADXSgx4sQ"],
-        "issued_at": "2018-09-26T18:39:41.504730Z"}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:39:41 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - b8033489ae1b4fef91870175793ef08a
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-261443e9-ede3-4323-8b67-fb837be7218b
-      Content-Length:
-      - '7278'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
-        "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
-        "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:41.708724Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:57.353975Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14764,16 +13765,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yd2-V7XgRRWlyV13Ny-pWw"],
-        "issued_at": "2018-09-26T18:39:41.708743Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hW4t4AHiT5aSQYIGelTGaQ"],
+        "issued_at": "2018-10-25T18:22:57.353994Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14785,15 +13786,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:41 GMT
+      - Thu, 25 Oct 2018 18:22:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7a9dd95e047c43f2a4522b3a01a73161
+      - 01be84e64e7c434091102c6f9d011834
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a8ed7fb1-7d1b-4e6f-992f-0206d7db9ef5
+      - req-2f72e19d-0d96-4f28-beaa-9fa65a2766b7
       Content-Length:
       - '7264'
       Connection:
@@ -14805,7 +13806,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:41.905154Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:57.559778Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14884,16 +13885,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FXBPW8dgTja1SSrfljg6Ag"],
-        "issued_at": "2018-09-26T18:39:41.905173Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q6ON5LSdT7Cb1QtHkAR2yg"],
+        "issued_at": "2018-10-25T18:22:57.559805Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14905,15 +13906,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d25e6a171b5a44b0b0b6087143fc93a5
+      - 221948b62e004fcb8326ec1e953a0875
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e7518d98-57ca-42fb-84fe-fda4357d9cd7
+      - req-98a0b1bc-7850-431b-a518-77424211956a
       Content-Length:
       - '7278'
       Connection:
@@ -14925,7 +13926,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:42.105536Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:57.759346Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15004,16 +14005,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lQsn2jz8QdCrd7l9AQqaAg"],
-        "issued_at": "2018-09-26T18:39:42.105554Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wGkc3tP8Sq-yPwKhVYUhtg"],
+        "issued_at": "2018-10-25T18:22:57.759368Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15025,15 +14026,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ced854a508b544bbb331c4e8d4e7267b
+      - aa5a7e64e1fd473db87f61d9a63df358
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1ef4a722-8b07-4887-9bc1-9939870534ba
+      - req-6c857173-1e83-45f4-be9c-69b0bd800660
       Content-Length:
       - '7265'
       Connection:
@@ -15045,7 +14046,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:42.299452Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:57.961204Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15124,16 +14125,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GWyyTD5qQpqhp1mROYoN-w"],
-        "issued_at": "2018-09-26T18:39:42.299473Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tmEvn6z1QIyo149BKHjypQ"],
+        "issued_at": "2018-10-25T18:22:57.961224Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15145,15 +14146,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6ac8add1c0f5480b85bc3ec25c68e4e1
+      - 2c4cd69bc15a4397b1c9908ffb1be77a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ec2f1fa-e190-47d7-9095-2ed37cfd999b
+      - req-adeb4795-c00f-4bbf-b7f6-6422d6cf7501
       Content-Length:
       - '7278'
       Connection:
@@ -15165,7 +14166,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:42.489232Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:58.163184Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15244,16 +14245,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HpZNZNOCQ_SW7iPtElRYRQ"],
-        "issued_at": "2018-09-26T18:39:42.489252Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vxV5x-iXQ_qyTNUMuhPAFQ"],
+        "issued_at": "2018-10-25T18:22:58.163217Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-3","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15265,15 +14266,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 461e7b00b0fd46008ae7e9ac36f246b2
+      - 0aff51ea3c644efb91e7a1d4d3c594fc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-742e753e-61d5-41fb-b0ab-c90912a1e45c
+      - req-43babebe-1874-4456-ad25-e595ac7ee178
       Content-Length:
       - '7278'
       Connection:
@@ -15285,7 +14286,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:42.683575Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:58.380274Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15364,10 +14365,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UuturtW_SPOihz2Zzydx5Q"],
-        "issued_at": "2018-09-26T18:39:42.683594Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LQKzM7DZT9y4ynxd3TONZg"],
+        "issued_at": "2018-10-25T18:22:58.380299Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -15382,7 +14383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 461e7b00b0fd46008ae7e9ac36f246b2
+      - 0aff51ea3c644efb91e7a1d4d3c594fc
   response:
     status:
       code: 200
@@ -15395,28 +14396,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987182.80680'
+      - '1540491778.56614'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987182.80680'
+      - '1540491778.56614'
       X-Trans-Id:
-      - txeb3d0b4833964fed858ba-005babd26e
+      - txdbe9a7a196cd40cf963d4-005bd20a02
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:58 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-No-Admin-Role","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15428,15 +14429,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:42 GMT
+      - Thu, 25 Oct 2018 18:22:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c3ce3f23fd384f58a695892a0b530935
+      - db2e095c867948fe88fe38f82772dbb9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2bec923e-fd41-404a-b948-da2515b830db
+      - req-e9c8f9df-a9de-4b05-a1e0-9563ce66c763
       Content-Length:
       - '7278'
       Connection:
@@ -15448,7 +14449,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:42.986426Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:58.756619Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15527,10 +14528,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7LRXJk7lTlihEq0nfWUVTg"],
-        "issued_at": "2018-09-26T18:39:42.986446Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u3VUD9kVSgetvHwMY5D9uA"],
+        "issued_at": "2018-10-25T18:22:58.756639Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -15545,7 +14546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c3ce3f23fd384f58a695892a0b530935
+      - db2e095c867948fe88fe38f82772dbb9
   response:
     status:
       code: 200
@@ -15558,28 +14559,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987183.15728'
+      - '1540491778.88714'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987183.15728'
+      - '1540491778.88714'
       X-Trans-Id:
-      - tx6e13e6cab2894dd0aa09d-005babd26f
+      - txda6adbdbb38e42879c0f0-005bd20a02
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:58 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15591,15 +14592,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1e952243-b9be-4ba8-81aa-302666e9c7c2
+      - req-e61e79d8-b6f5-4fea-90f8-9ac66a213d40
       Content-Length:
       - '7264'
       Connection:
@@ -15611,7 +14612,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:43.341697Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:59.081223Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15690,10 +14691,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HrVlEwwiTkOjissULekRFg"],
-        "issued_at": "2018-09-26T18:39:43.341717Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4sklUnGtQ6KTboghUCpQVw"],
+        "issued_at": "2018-10-25T18:22:59.081245Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -15708,7 +14709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
   response:
     status:
       code: 200
@@ -15737,15 +14738,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx65be1cc422f849259f24f-005babd26f
+      - tx5f1a6323600f4b1599e98-005bd20a03
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -15760,7 +14761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
   response:
     status:
       code: 200
@@ -15789,20 +14790,20 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx4d71e452fd764fb6afab0-005babd26f
+      - tx50243ffefbc6466280609-005bd20a03
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-1","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15814,15 +14815,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 51f5b544a6d74a7780d880eaf0cc9190
+      - 0cec305458214e1cb01ddb815933ba74
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-42840bdc-63d7-473b-9a14-78f793e2637d
+      - req-1b6828a6-ce3d-4a12-ac28-21841ca887b4
       Content-Length:
       - '7278'
       Connection:
@@ -15834,7 +14835,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:43.728287Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:59.551141Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15913,10 +14914,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QbphlTURRzy6hnXqmTNyzA"],
-        "issued_at": "2018-09-26T18:39:43.728307Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qVjbBujfQTO_S3ve-MfYyA"],
+        "issued_at": "2018-10-25T18:22:59.551166Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -15931,7 +14932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51f5b544a6d74a7780d880eaf0cc9190
+      - 0cec305458214e1cb01ddb815933ba74
   response:
     status:
       code: 200
@@ -15944,22 +14945,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987183.85658'
+      - '1540491779.68125'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987183.85658'
+      - '1540491779.68125'
       X-Trans-Id:
-      - txafefe979ea8c4203bcada-005babd26f
+      - txca1ffcbf7d8146f9a2675-005bd20a03
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -15974,7 +14975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - afb5ccbd89eb4415899e50840a3808c7
+      - 8753591aa21d464f8bf26dec4d6ad7b4
   response:
     status:
       code: 200
@@ -15987,28 +14988,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987183.96195'
+      - '1540491779.79574'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987183.96195'
+      - '1540491779.79574'
       X-Trans-Id:
-      - tx7f436e76e97b49838949e-005babd26f
+      - tx6bc28a73bc024d1c85470-005bd20a03
       Date:
-      - Wed, 26 Sep 2018 18:39:43 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:22:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16020,15 +15021,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:22:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 761e69bf534c44839dff656624897b42
+      - b01d690c2c364a60a223c556fc7c1375
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf136552-f823-434c-907f-9e8fb6b6f490
+      - req-77cfbcb7-c478-4105-a587-3a8494f934c0
       Content-Length:
       - '7265'
       Connection:
@@ -16040,7 +15041,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:44.162984Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:22:59.987729Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16119,10 +15120,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TlbPqgoHQFyp7rXazfeKoA"],
-        "issued_at": "2018-09-26T18:39:44.163019Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N9g17dVjSWKASSrS-hNfkg"],
+        "issued_at": "2018-10-25T18:22:59.987751Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -16137,7 +15138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 761e69bf534c44839dff656624897b42
+      - b01d690c2c364a60a223c556fc7c1375
   response:
     status:
       code: 200
@@ -16150,28 +15151,28 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987184.29098'
+      - '1540491780.11591'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987184.29098'
+      - '1540491780.11591'
       X-Trans-Id:
-      - txdee96465db714f4faf531-005babd270
+      - tx05482d307b264fc792b27-005bd20a04
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"password":"password_2WpEraURh","domain":{"id":"default"},"name":"admin"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"EmsRefreshSpec-Project-parent-test-2","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16183,15 +15184,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7d1cc90e295545408f55e37a693bc473
+      - cd7bdf8051dc490882c15f14fc077c0c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d2f88e69-2148-496a-811d-3386f6c15118
+      - req-561d37df-3514-4261-a5a1-386382c0d068
       Content-Length:
       - '7278'
       Connection:
@@ -16203,7 +15204,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-09-26T19:39:44.472860Z", "project": {"domain": {"id":
+        "expires_at": "2018-10-25T19:23:00.311000Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16282,10 +15283,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GcKGV4_qTxqeiFb5uzVQAA"],
-        "issued_at": "2018-09-26T18:39:44.472881Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eGZ9JVJoQPebeJqhDiOhDg"],
+        "issued_at": "2018-10-25T18:23:00.311025Z"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -16300,7 +15301,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d1cc90e295545408f55e37a693bc473
+      - cd7bdf8051dc490882c15f14fc077c0c
   response:
     status:
       code: 200
@@ -16313,22 +15314,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987184.62975'
+      - '1540491780.44213'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987184.62975'
+      - '1540491780.44213'
       X-Trans-Id:
-      - txd87c10ca2c144ff1ba71f-005babd270
+      - tx5bc79494fda44cb993e13-005bd20a04
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -16343,7 +15344,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
   response:
     status:
       code: 200
@@ -16364,9 +15365,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbbee6c733cde40bdb1f80-005babd270
+      - tx8fe2a5e7b9124b359f914-005bd20a04
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -16376,7 +15377,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -16391,7 +15392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
   response:
     status:
       code: 200
@@ -16412,14 +15413,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx5540024da94841849710d-005babd270
+      - tx9cd65f3c289e4054acdba-005bd20a04
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -16434,7 +15435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb71abf9f0fc4aea8d8e46b2f86cac9c
+      - f91c54f710b64497b08ce8b25d0bf03f
   response:
     status:
       code: 200
@@ -16455,12 +15456,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txb54a1cd648bc40898405f-005babd270
+      - tx15cc09f77e78469687a3b-005bd20a04
       Date:
-      - Wed, 26 Sep 2018 18:39:44 GMT
+      - Thu, 25 Oct 2018 18:23:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:39:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:23:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
+      - Thu, 25 Oct 2018 18:18:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0f1092fb-e682-4a94-a5f4-0392a545bcc8
+      - req-4a999528-d230-4d85-99ec-9c33765eb315
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:43.161945", "expires":
-        "2018-09-26T19:40:43Z", "id": "16f9545d275e42a6b4f73abce2430314", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.008906", "expires":
+        "2018-10-25T19:18:50Z", "id": "f62a708414a54311af58f113b00a65b3", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["dU9aqLg5QAuhvvIz19pJfg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["H76FoWlETAOPiIzXSeJDxQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
+      - Thu, 25 Oct 2018 18:18:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
+      - Thu, 25 Oct 2018 18:18:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-09eda317-fe8b-4f46-9b77-769c87a61ba0
+      - req-779d8a9a-2eba-4478-a2ee-080e8a407e2a
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:43.434308", "expires":
-        "2018-09-26T19:40:43Z", "id": "f38fc93b63fc4a90832a5f80887db9b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.628044", "expires":
+        "2018-10-25T19:18:51Z", "id": "f64906fa09424f9684c8339b5679811b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QXL5rLb9QwuYKK6KymKo3w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Xc1xS6reRBKwGWX89ot3vQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,39 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f38fc93b63fc4a90832a5f80887db9b3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
+      - Thu, 25 Oct 2018 18:18:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ce2ec5b8-20eb-4006-a9e2-b7faa9424af1
+      - req-105cceba-3a2b-4a98-a950-baa10f67bebc
       Content-Length:
       - '4170'
       Connection:
@@ -261,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:43.698660", "expires":
-        "2018-09-26T19:40:43Z", "id": "0fbbae813c7f4e43b91c81ce8a60564f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:51.827692", "expires":
+        "2018-10-25T19:18:51Z", "id": "b7b81a82496443559c43d00a3463ae10", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6U3fDku7SIWenIuDdC2dTg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["RLkeTXCGQZSPfSnU-XixvA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -309,88 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"0fbbae813c7f4e43b91c81ce8a60564f"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:43 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-6a279b11-2e9b-4f0e-8a30-cd6e554a29b3
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:43.871610", "expires":
-        "2018-09-26T19:40:43Z", "id": "aa38a712c024425cbea4e4b0c1787773", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["p-lAhairSBO4s7fRGIADGw", "6U3fDku7SIWenIuDdC2dTg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -408,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
+      - Thu, 25 Oct 2018 18:18:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6339cb0b-ebdd-41dc-8241-ba3ebf0b1922
+      - req-d55f148c-61de-4657-9049-feb19959b8f3
       Content-Length:
       - '4170'
       Connection:
@@ -423,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:44.049720", "expires":
-        "2018-09-26T19:40:44Z", "id": "7edb4831a1574f92aaf7ca47a551260e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.046951", "expires":
+        "2018-10-25T19:18:52Z", "id": "3e98b31fe83541bca8af8b6614b5c870", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1VmCj43TQ3C8Mn774b9f5Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["rzaxB68SRfyZZyUAmbhnqA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -471,46 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.233:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.233:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
+      - Thu, 25 Oct 2018 18:18:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f971379c-d663-4a31-b7c5-91c697fa2aef
+      - req-02ac5d35-592f-4ed2-9682-32e228038e49
       Content-Length:
       - '4170'
       Connection:
@@ -543,10 +391,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:44.336154", "expires":
-        "2018-09-26T19:40:44Z", "id": "2dfe8e0d60514c048b02e19f5c11b08a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.404729", "expires":
+        "2018-10-25T19:18:52Z", "id": "2387293e47d04a44a2b29e7b10b4cac8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tOg454WQT82AKqiucz-_mg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sewJfXQPRhmmrBQ7P3lJnw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -591,7 +439,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -609,13 +457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
+      - Thu, 25 Oct 2018 18:18:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-03e7316d-73e3-4224-82ce-9233563b8de9
+      - req-281ea2ac-7963-484b-a274-84bfe91b5aa9
       Content-Length:
       - '4170'
       Connection:
@@ -624,10 +472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:44.526723", "expires":
-        "2018-09-26T19:40:44Z", "id": "11d77ca8a6ef45999430600e1420ef8f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.636814", "expires":
+        "2018-10-25T19:18:52Z", "id": "3cdf759937994bfda9cb8180d582cefc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zJvplW4BRlqC3nwMWLoq7A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["iBKKdzOJRWqcgpy8Wrzt0Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -672,7 +520,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +538,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
+      - Thu, 25 Oct 2018 18:18:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9e62ab33-8591-404f-86c5-c883ae813863
+      - req-b6eb48fd-38ea-44fb-b436-dc4cbbd41bf9
       Content-Length:
       - '4170'
       Connection:
@@ -705,10 +553,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:44.748978", "expires":
-        "2018-09-26T19:40:44Z", "id": "c476027321fb4b68a1b259029a8f5135", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:52.882045", "expires":
+        "2018-10-25T19:18:52Z", "id": "fc93cfea992141b2b3f33861e00ccc11", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yhsKTqEpR6mDwwoDHcBMIQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["-wUPuMa4Q9iabw8zqAjcRw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -753,7 +601,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -771,13 +619,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:44 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e62cd356-f4bf-4046-846d-8c1a3b8ccd64
+      - req-01ccd17d-bbdb-4d5d-9023-c57b468eaea6
       Content-Length:
       - '4170'
       Connection:
@@ -786,10 +634,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:44.930874", "expires":
-        "2018-09-26T19:40:44Z", "id": "07dd19f93b0f4d85b490d52e90c7f8af", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.142221", "expires":
+        "2018-10-25T19:18:53Z", "id": "41cc0054e6014e34adc973534935eeed", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3u3L2Uj8S_ic2xRfF2wQAA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["yY6U2Pp4SEueGzMkZFvPEw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -834,13 +682,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -852,13 +700,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-23f64e7f-cea4-456b-b0fe-35915a28c61f
+      - req-f144ca7a-a5f3-402b-afb3-99ee82d36058
       Content-Length:
       - '370'
       Connection:
@@ -867,13 +715,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:45.084337", "expires":
-        "2018-09-26T19:40:45Z", "id": "9d5a61d1c0974b87b9832827cd6db387", "audit_ids":
-        ["Rmct0GFIQfaEQ5cS2gxUBg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.308760", "expires":
+        "2018-10-25T19:18:53Z", "id": "08cae195023c487a9f9fa2010670f8a4", "audit_ids":
+        ["2SPTj15CRsiYYRfr0KSALg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -888,20 +736,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d5a61d1c0974b87b9832827cd6db387
+      - '08cae195023c487a9f9fa2010670f8a4'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54111487-1f99-4aa0-82a3-d3f7c376401c
+      - req-a09db42a-8512-4026-b80a-337c6178c17f
       Content-Length:
       - '500'
       Connection:
@@ -918,133 +766,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"9d5a61d1c0974b87b9832827cd6db387"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a6929bac-6866-4275-a3ac-60cffc37d34d
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:45.381954", "expires":
-        "2018-09-26T19:40:45Z", "id": "c6546b81b0ac4ec2978038512a2e231c", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uUK6clf_RUKvaTOVv-SIug",
-        "Rmct0GFIQfaEQ5cS2gxUBg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9d5a61d1c0974b87b9832827cd6db387
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-0013c388-2460-4334-9d2f-40342dfee74d
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1062,13 +784,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c4a7e59e-1fca-42d6-badb-cab549e02116
+      - req-7a7acff4-5414-40ee-9a3f-7d218c690456
       Content-Length:
       - '4117'
       Connection:
@@ -1077,10 +799,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:45.700958", "expires":
-        "2018-09-26T19:40:45Z", "id": "4785cbdd97e34e0fb7c31750930f37d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.630615", "expires":
+        "2018-10-25T19:18:53Z", "id": "81cabbfb9d39459299262bf35b482ead", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IyExAsFCSi6lfI6mumN_9g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EYGqaRmLTt-rI04qstOlQw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1124,7 +846,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1139,7 +861,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4785cbdd97e34e0fb7c31750930f37d5
+      - 81cabbfb9d39459299262bf35b482ead
   response:
     status:
       code: 200
@@ -1150,7 +872,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1159,7 +881,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1177,13 +899,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:45 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-677f1c90-3646-4d4d-84c7-654cd3adcfb4
+      - req-565569f3-cfe4-4df2-8c3b-00ddf2d03c80
       Content-Length:
       - '4131'
       Connection:
@@ -1192,10 +914,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:45.966943", "expires":
-        "2018-09-26T19:40:45Z", "id": "4bbafa16d0b345b5afaad03804c88e96", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:53.895536", "expires":
+        "2018-10-25T19:18:53Z", "id": "a3aa2cad4b4c4dada157d26b2e68a4a4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["n7l6ac29Q8iU3ee50wPPLA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gXR0n8QbR1afOMu_YZGeTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1239,7 +961,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1254,7 +976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4bbafa16d0b345b5afaad03804c88e96
+      - a3aa2cad4b4c4dada157d26b2e68a4a4
   response:
     status:
       code: 200
@@ -1265,7 +987,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1274,7 +996,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1292,13 +1014,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-31a3bec5-d6ed-4f14-80cc-6ffb72e3ee60
+      - req-0362ea23-c315-47db-a630-6ea75a0161e7
       Content-Length:
       - '4118'
       Connection:
@@ -1307,10 +1029,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:46.230686", "expires":
-        "2018-09-26T19:40:46Z", "id": "4239aee82e9f4a75bdaffc10e71dc9f2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:54.157571", "expires":
+        "2018-10-25T19:18:54Z", "id": "b6200c7d10824ffb97f5892f251eb64b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["woMs4saUR3yOqTK2-wj3Xg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3fFFy93yScWfhmZad_2jYw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1354,7 +1076,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1369,7 +1091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4239aee82e9f4a75bdaffc10e71dc9f2
+      - b6200c7d10824ffb97f5892f251eb64b
   response:
     status:
       code: 200
@@ -1380,7 +1102,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1389,7 +1111,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1404,7 +1126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1417,9 +1139,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-d2f4a835-b22f-4a62-9611-d46d018dae2f
+      - req-a0241c5c-06c1-40ff-afbe-7b36eb240bef
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1433,7 +1155,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1448,7 +1170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1461,9 +1183,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-bb94925b-5de0-482c-8643-7d235ab46c8f
+      - req-e7cb45fe-4feb-4035-80df-08351c43ecac
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1477,7 +1199,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1492,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1505,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-52fc37ea-af00-4f4a-9a12-05c2dccb5511
+      - req-38160db3-12eb-4ab8-b333-9742f58644c9
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1522,7 +1244,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1537,7 +1259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1550,9 +1272,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-9ab23962-06c8-42bc-83eb-ef9a77e103e4
+      - req-ade3117c-9ec4-4b7a-82ba-3a66cfad3f62
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1562,7 +1284,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1577,7 +1299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1590,15 +1312,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-b40c3343-2055-45d1-b9ff-7a17afa5c9f2
+      - req-1b84f8c9-4784-4f28-8acf-16be83d66aa8
       Date:
-      - Wed, 26 Sep 2018 18:40:46 GMT
+      - Thu, 25 Oct 2018 18:18:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -1613,7 +1335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1626,15 +1348,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-1e7208a7-9f53-4597-869c-e51ac5ccfb12
+      - req-8c9baae5-ff3d-4968-b14d-ee50bb1b7c3e
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1649,28 +1371,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dfe8e0d60514c048b02e19f5c11b08a
+      - 2387293e47d04a44a2b29e7b10b4cac8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b82d21f-b70b-4c2e-96d7-d24d89a22b45
+      - req-74cafb47-185e-4901-aa20-9fc35e61243a
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-8b82d21f-b70b-4c2e-96d7-d24d89a22b45
+      - req-74cafb47-185e-4901-aa20-9fc35e61243a
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1685,7 +1407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1698,14 +1420,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-44738fc9-5808-4924-87a9-04840b9f8e99
+      - req-dc876100-d665-4101-a6e4-518fecb705bf
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1720,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4785cbdd97e34e0fb7c31750930f37d5
+      - 81cabbfb9d39459299262bf35b482ead
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1733,9 +1455,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d92aa458-208d-4f45-badf-f61241814403
+      - req-87232b66-a844-4948-adab-f04e3b9ee9e5
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1744,7 +1466,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1759,7 +1481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4bbafa16d0b345b5afaad03804c88e96
+      - a3aa2cad4b4c4dada157d26b2e68a4a4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1772,9 +1494,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-6ecd136b-13b6-41e1-8545-e6e72272cdd4
+      - req-da8434ad-f4b8-4f8e-a879-ef03d0eb439c
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1783,7 +1505,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1798,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1811,9 +1533,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3671b86c-f139-492d-939a-838050544f86
+      - req-8308d2bf-aecb-4e18-8bbb-875d29ed8697
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1822,7 +1544,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1837,7 +1559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4239aee82e9f4a75bdaffc10e71dc9f2
+      - b6200c7d10824ffb97f5892f251eb64b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1850,9 +1572,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a3e4618a-0cca-485e-b20a-6b14ad34de16
+      - req-df7a012c-34ba-422e-a454-4f1840bc7d5d
       Date:
-      - Wed, 26 Sep 2018 18:40:47 GMT
+      - Thu, 25 Oct 2018 18:18:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1861,7 +1583,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1879,13 +1601,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:48 GMT
+      - Thu, 25 Oct 2018 18:18:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5603fbc4-f57b-4b67-b1e8-864513cdc9a3
+      - req-5c3acd7c-86b3-4cad-9082-a7be8a76590b
       Content-Length:
       - '4117'
       Connection:
@@ -1894,10 +1616,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:48.108544", "expires":
-        "2018-09-26T19:40:48Z", "id": "2f28636171484fef9cba9d18272dffd7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:56.129245", "expires":
+        "2018-10-25T19:18:56Z", "id": "d79950dccdbb40b088d24456211d5c31", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PxSXjBE_T2a_XlENYER6xg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sNbRbcLMSNOUXGFbZ-Ka9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1941,7 +1663,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1956,22 +1678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f28636171484fef9cba9d18272dffd7
+      - d79950dccdbb40b088d24456211d5c31
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7ee0375-e69b-4c39-9a04-4585710c063a
+      - req-95767645-ad4a-4741-a87e-b8c53b8c416c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d7ee0375-e69b-4c39-9a04-4585710c063a
+      - req-95767645-ad4a-4741-a87e-b8c53b8c416c
       Date:
-      - Wed, 26 Sep 2018 18:40:48 GMT
+      - Thu, 25 Oct 2018 18:18:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1981,7 +1703,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1999,13 +1721,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:48 GMT
+      - Thu, 25 Oct 2018 18:18:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e340006-2b93-4fb6-8c37-beb376b3fb0a
+      - req-e3512c73-9e40-43b7-bc52-57a3e5d59f40
       Content-Length:
       - '4131'
       Connection:
@@ -2014,10 +1736,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:48.625325", "expires":
-        "2018-09-26T19:40:48Z", "id": "f407bdead82b47a3bce6c55faf058b9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:56.667355", "expires":
+        "2018-10-25T19:18:56Z", "id": "0bdb892631cb42f8a6a6ec00bdc0100d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ajk9Ibi8SR26jDaYbfz8CA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["g6y45KcTQPCAvq7s5XNIUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2061,7 +1783,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2076,22 +1798,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f407bdead82b47a3bce6c55faf058b9a
+      - 0bdb892631cb42f8a6a6ec00bdc0100d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c72eb7cf-79e9-4351-b05f-14b578f4c9df
+      - req-58985d19-3c42-41c1-bb25-7954c387b271
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c72eb7cf-79e9-4351-b05f-14b578f4c9df
+      - req-58985d19-3c42-41c1-bb25-7954c387b271
       Date:
-      - Wed, 26 Sep 2018 18:40:49 GMT
+      - Thu, 25 Oct 2018 18:18:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2101,7 +1823,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2116,22 +1838,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2dfe8e0d60514c048b02e19f5c11b08a
+      - 2387293e47d04a44a2b29e7b10b4cac8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4127a529-a99a-4058-a246-ce1e19ce71b2
+      - req-c424bf5a-9aca-4000-8b1c-18dd67617c42
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4127a529-a99a-4058-a246-ce1e19ce71b2
+      - req-c424bf5a-9aca-4000-8b1c-18dd67617c42
       Date:
-      - Wed, 26 Sep 2018 18:40:49 GMT
+      - Thu, 25 Oct 2018 18:18:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2141,7 +1863,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2159,13 +1881,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:49 GMT
+      - Thu, 25 Oct 2018 18:18:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e9fa76d-5a7c-4ebb-955b-478267fbdeed
+      - req-24ba7a78-5bdb-453f-a5ea-78eb3ebb2c31
       Content-Length:
       - '4118'
       Connection:
@@ -2174,10 +1896,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:49.457360", "expires":
-        "2018-09-26T19:40:49Z", "id": "55238fc6461449be8e4595787aa1b68a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:57.433110", "expires":
+        "2018-10-25T19:18:57Z", "id": "b919c7177b5841619f68b9d68d9cc60b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4Ws37VPaQgus-gsWRYTMHQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["tRjbQ7lpT8Ko7KeeW-fdjQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2221,7 +1943,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2236,22 +1958,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55238fc6461449be8e4595787aa1b68a
+      - b919c7177b5841619f68b9d68d9cc60b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c68576fa-0943-4c95-a526-12995cef3617
+      - req-eb5cb851-0fc2-42a5-98d6-ae0775462080
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c68576fa-0943-4c95-a526-12995cef3617
+      - req-eb5cb851-0fc2-42a5-98d6-ae0775462080
       Date:
-      - Wed, 26 Sep 2018 18:40:49 GMT
+      - Thu, 25 Oct 2018 18:18:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2261,7 +1983,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2279,13 +2001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:49 GMT
+      - Thu, 25 Oct 2018 18:18:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b519ea5a-6d60-4648-b109-a1282823b65e
+      - req-66681052-b98d-4fdb-a2bc-82359dd77a50
       Content-Length:
       - '4117'
       Connection:
@@ -2294,10 +2016,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:50.022577", "expires":
-        "2018-09-26T19:40:50Z", "id": "bcdba4bda63048758f3507551aca9d3b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:57.943009", "expires":
+        "2018-10-25T19:18:57Z", "id": "89288df0524c42c69c60a6bfc0a2b08f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dIcivY4GQz--OUwp-TG4Mw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lFRaEEeDT7GIWrNK_-zMKQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2341,7 +2063,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2356,7 +2078,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcdba4bda63048758f3507551aca9d3b
+      - 89288df0524c42c69c60a6bfc0a2b08f
   response:
     status:
       code: 200
@@ -2367,16 +2089,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-553095da-6b5b-455a-a4e3-a8ad2f89aa41
+      - req-fc5141d6-2445-473e-98e7-a14aada82c7d
       Date:
-      - Wed, 26 Sep 2018 18:40:50 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2394,13 +2116,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:50 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-60db3fba-7123-424a-ba83-171a9c10c388
+      - req-58d25be9-d982-4b53-922c-027b859afa39
       Content-Length:
       - '4131'
       Connection:
@@ -2409,10 +2131,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:50.397948", "expires":
-        "2018-09-26T19:40:50Z", "id": "c386c7f624f941228605469bcc988573", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:58.286540", "expires":
+        "2018-10-25T19:18:58Z", "id": "305c55d30176468db6351df9a06f3d58", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CxPiNk-IQ7KfxhshA4pNQA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rJ45XlIySoK6ozI93OF1ZQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2456,7 +2178,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2471,7 +2193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c386c7f624f941228605469bcc988573
+      - 305c55d30176468db6351df9a06f3d58
   response:
     status:
       code: 200
@@ -2482,16 +2204,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-56120cb6-7840-45af-b316-839bc8381505
+      - req-d7917210-8298-435b-8e26-b4b1fcc3fd85
       Date:
-      - Wed, 26 Sep 2018 18:40:50 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2506,7 +2228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f38fc93b63fc4a90832a5f80887db9b3
+      - f64906fa09424f9684c8339b5679811b
   response:
     status:
       code: 200
@@ -2517,16 +2239,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-17afece1-1b92-409d-883d-72707ccae35d
+      - req-db482807-a6d4-46e5-82d7-c0e156de970b
       Date:
-      - Wed, 26 Sep 2018 18:40:50 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2544,13 +2266,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:50 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-78d8e599-011a-4766-988b-45d11cdf0402
+      - req-3972d38c-3d18-4617-912c-10f8063c5f2a
       Content-Length:
       - '4118'
       Connection:
@@ -2559,10 +2281,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:50.888346", "expires":
-        "2018-09-26T19:40:50Z", "id": "9483f6024aeb4a198ba5d2aaea8775e4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:58.771792", "expires":
+        "2018-10-25T19:18:58Z", "id": "dabe09b463674b8ea69d79e4a80a585b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["C6Zy-odbRnqnHr7a3nRsRg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["O-kxLbUJR7-RbHPB98Xlmw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2606,7 +2328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2621,7 +2343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9483f6024aeb4a198ba5d2aaea8775e4
+      - dabe09b463674b8ea69d79e4a80a585b
   response:
     status:
       code: 200
@@ -2632,16 +2354,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8f6479d6-904d-445c-856b-f21e53617f46
+      - req-30495f74-037d-4ab9-ae93-611baa0e5325
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2656,7 +2378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2669,9 +2391,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7277185c-e0f4-4169-8de6-cdefab22c708
+      - req-1a781dbe-c875-4487-a0d4-570575a82520
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2681,7 +2403,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2696,7 +2418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2709,9 +2431,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8e12bfdb-266d-4bed-aa4c-d3b9b855a57a
+      - req-9a67cba7-4ea6-43d6-95b5-c54f6a9d00b4
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2721,7 +2443,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2739,13 +2461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3f18dd0d-c50c-4da0-be6f-819be97ada07
+      - req-1c6aac61-d822-4ca3-9c8f-455c6bf4b7c4
       Content-Length:
       - '4117'
       Connection:
@@ -2754,10 +2476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:51.418077", "expires":
-        "2018-09-26T19:40:51Z", "id": "b8392ba12f4540e1a25b202a6af67f16", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:18:59.283699", "expires":
+        "2018-10-25T19:18:59Z", "id": "ad05b33062d14277b1b734bda51bb04c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["h8TKoQiRROW-vztMZGNc9g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["a1xfKqK9RQ2lNwbhnlbmiw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2801,7 +2523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2816,7 +2538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -2827,9 +2549,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-29be8ac4-3023-4405-9608-49e0e0311fb7
+      - req-8ca8ba70-6e7d-4c4d-9c80-cd57e33e97ad
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2863,7 +2585,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2878,7 +2600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -2889,14 +2611,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-76549e39-3dfe-4f5b-acc3-65e2d6eb8428
+      - req-e7213109-0dbc-4639-b518-f82d22dc5e57
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:18:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2914,13 +2636,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:51 GMT
+      - Thu, 25 Oct 2018 18:18:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-226dda01-6198-4c49-8dd3-013bfce7d91e
+      - req-856d0b8b-7e2b-4f67-a87a-25bdb71d7d08
       Content-Length:
       - '4131'
       Connection:
@@ -2929,10 +2651,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:51.992690", "expires":
-        "2018-09-26T19:40:51Z", "id": "8b9042a8ee9d424f86103add953999cb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:00.022642", "expires":
+        "2018-10-25T19:19:00Z", "id": "1d9dedec55c54f7b85f751d72819d9b5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3r0wVPE4RuWX-rFh4Wq7sA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dZpHJ-pYTta6n5oPWKN6yg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2976,7 +2698,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2991,7 +2713,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b9042a8ee9d424f86103add953999cb
+      - 1d9dedec55c54f7b85f751d72819d9b5
   response:
     status:
       code: 200
@@ -3002,14 +2724,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-dcfd108d-6b5c-4e01-a3e0-46cfcb9052ae
+      - req-e03f822b-6e42-462f-a3db-5f749a988c75
       Date:
-      - Wed, 26 Sep 2018 18:40:52 GMT
+      - Thu, 25 Oct 2018 18:19:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3024,7 +2746,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07dd19f93b0f4d85b490d52e90c7f8af
+      - 41cc0054e6014e34adc973534935eeed
   response:
     status:
       code: 200
@@ -3035,14 +2757,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-e0b4c575-b33e-4223-90e7-505fd8ce2af7
+      - req-bf4e84ff-f8b9-4e05-9e26-f453eeee9120
       Date:
-      - Wed, 26 Sep 2018 18:40:52 GMT
+      - Thu, 25 Oct 2018 18:19:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3060,13 +2782,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:52 GMT
+      - Thu, 25 Oct 2018 18:19:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b858a974-c7c7-4f0b-b0fd-58091265e720
+      - req-bcc1daba-85e2-4a55-85ad-6671f0ae8f2a
       Content-Length:
       - '4118'
       Connection:
@@ -3075,10 +2797,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:52.502285", "expires":
-        "2018-09-26T19:40:52Z", "id": "49c408486cce4c8f923a9b0117a445e6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:00.527083", "expires":
+        "2018-10-25T19:19:00Z", "id": "986cd1ac45764494bada48ed6d6365ce", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ZfMkTYjZSV2YfIXpmzXnBQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["s7WZ2QJkSmSbC97zRZuA0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3122,7 +2844,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3137,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c408486cce4c8f923a9b0117a445e6
+      - 986cd1ac45764494bada48ed6d6365ce
   response:
     status:
       code: 200
@@ -3148,14 +2870,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-fe8add52-1042-46ad-a807-a2dddefbeaba
+      - req-6c90ecb0-e9a8-4b98-9edf-d9ea741b8008
       Date:
-      - Wed, 26 Sep 2018 18:40:52 GMT
+      - Thu, 25 Oct 2018 18:19:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3170,7 +2892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3181,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-5a134725-e8e5-44b3-b363-b09c88ba6ab0
+      - req-aef0a694-1976-4b67-a414-ad9eef819672
       Date:
-      - Wed, 26 Sep 2018 18:40:53 GMT
+      - Thu, 25 Oct 2018 18:19:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3210,7 +2932,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3225,7 +2947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3236,9 +2958,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bc16ac33-61f4-4d7a-a027-2ac6c04c8c43
+      - req-f05448f4-f56a-4326-966f-61b1efa42d14
       Date:
-      - Wed, 26 Sep 2018 18:40:53 GMT
+      - Thu, 25 Oct 2018 18:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3265,7 +2987,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3280,7 +3002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3291,9 +3013,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-981b4ac5-f61a-4522-88fe-2751b8fa9ccd
+      - req-71d3ae1e-a486-49f1-9427-def1139d42e9
       Date:
-      - Wed, 26 Sep 2018 18:40:53 GMT
+      - Thu, 25 Oct 2018 18:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3320,7 +3042,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3335,7 +3057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3346,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e772d1c6-d22a-4d7e-bdf5-1db056917648
+      - req-c9ce327b-4750-4e96-bf82-59b4d3c7b2d2
       Date:
-      - Wed, 26 Sep 2018 18:40:53 GMT
+      - Thu, 25 Oct 2018 18:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3360,7 +3082,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3375,7 +3097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3386,9 +3108,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-8f9d7b99-0dae-4ba5-aaff-5d2227a82447
+      - req-1fa91373-8a5e-4626-aea1-4b05b60fe5c7
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3444,7 +3166,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3459,7 +3181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3470,9 +3192,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-dfd86ea4-c354-4327-a229-afd58c6f8a32
+      - req-2329554c-3993-4dab-9300-1ad1fd8567bb
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3484,7 +3206,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3499,7 +3221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3510,9 +3232,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-cd4292b4-48f7-48f4-8724-0091778f120e
+      - req-7fdf7269-726e-473a-bee4-b35e43fcbd2b
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3568,7 +3290,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3583,7 +3305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3594,9 +3316,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1c0f37df-50b7-4bf9-b4ae-1660dd5d55f3
+      - req-6a88dc32-cd6a-438a-a5f4-4b43cc02b414
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3608,7 +3330,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3623,7 +3345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8392ba12f4540e1a25b202a6af67f16
+      - ad05b33062d14277b1b734bda51bb04c
   response:
     status:
       code: 200
@@ -3634,9 +3356,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-afb11b09-998e-4136-992c-cdb406ff18b1
+      - req-ffdb289e-56c9-4bab-9890-81a828ac7818
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3692,7 +3414,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3707,7 +3429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3718,14 +3440,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-459f9ac7-5062-47e4-90e9-5561dc62d77f
+      - req-34ddfa53-5ea7-4079-8b8b-151b467d855a
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3740,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3751,9 +3473,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cce376bb-1360-4279-a890-a6382b1174cb
+      - req-d7c889f4-ad57-4a22-ac35-c9975d3bdd00
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3795,7 +3517,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3810,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3821,14 +3543,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-21478442-10cd-4151-b73e-eb5467b27bf4
+      - req-c5522874-3898-40c4-ab88-ba319179be80
       Date:
-      - Wed, 26 Sep 2018 18:40:54 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3843,7 +3565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3854,14 +3576,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-eee589bd-9056-4cfc-8e2b-4ece63a6d492
+      - req-c6450e73-fca2-4596-9bd9-d0b60d39331f
       Date:
-      - Wed, 26 Sep 2018 18:40:55 GMT
+      - Thu, 25 Oct 2018 18:19:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3876,7 +3598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3887,14 +3609,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-62e69977-926d-447c-8a13-3fcb3d7f93b3
+      - req-fb845266-a7b7-4cd5-abdd-76acf7dfe5e4
       Date:
-      - Wed, 26 Sep 2018 18:40:55 GMT
+      - Thu, 25 Oct 2018 18:19:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3909,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb4831a1574f92aaf7ca47a551260e
+      - 3e98b31fe83541bca8af8b6614b5c870
   response:
     status:
       code: 200
@@ -3920,14 +3642,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-37d367e5-b246-441b-a124-ac602ecf53c2
+      - req-74f75013-841f-4a11-b05e-af82a639fab2
       Date:
-      - Wed, 26 Sep 2018 18:40:55 GMT
+      - Thu, 25 Oct 2018 18:19:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3942,7 +3664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3955,13 +3677,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-5c037780-0202-4b23-b904-0d7b00d23789
+      - req-a3f06196-2d3b-421c-84a3-d70f2bf390c4
       Date:
-      - Wed, 26 Sep 2018 18:40:55 GMT
+      - Thu, 25 Oct 2018 18:19:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -4003,7 +3725,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -4018,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4031,9 +3753,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-fc527968-80e6-4c77-b7f1-62e57b4c0bf8
+      - req-e86a854e-82de-4135-86cb-c1bfc50935b6
       Date:
-      - Wed, 26 Sep 2018 18:40:55 GMT
+      - Thu, 25 Oct 2018 18:19:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -4057,7 +3779,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:41:33Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -4079,7 +3801,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -4094,7 +3816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4107,13 +3829,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-c67055d0-8707-456c-b8e7-f9a8cf26d025
+      - req-a8937341-973f-470d-beb4-7bf14aed684d
       Date:
-      - Wed, 26 Sep 2018 18:40:56 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:24Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -4134,7 +3856,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -4157,7 +3879,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4172,7 +3894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4185,9 +3907,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-b26cbd08-e221-42a2-b9a4-48bc777a35e4
+      - req-bdb9221b-4eb4-43a1-a47e-11de85bbf37b
       Date:
-      - Wed, 26 Sep 2018 18:40:56 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4229,7 +3951,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4244,7 +3966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4257,9 +3979,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-8271601a-b979-4739-8249-574ed1cd4183
+      - req-d07d6bf7-1ae7-434a-ae22-fb06571ddd7c
       Date:
-      - Wed, 26 Sep 2018 18:40:56 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4282,7 +4004,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4297,7 +4019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4310,14 +4032,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-79167b62-1695-4863-a005-73553e65eaa9
+      - req-49422070-a15c-447d-b42e-d41557006108
       Date:
-      - Wed, 26 Sep 2018 18:40:56 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4332,7 +4054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4345,14 +4067,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f058bb73-d8a0-4ea9-ab32-cb73edfecf09
+      - req-c24b19df-83c0-4324-bee1-2d95e00c54cd
       Date:
-      - Wed, 26 Sep 2018 18:40:56 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4367,7 +4089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4380,14 +4102,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7ea5987d-8a91-4407-a815-b8a17a8b936a
+      - req-763a0d76-584d-401b-8fc8-12ae62f60338
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4402,7 +4124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4415,14 +4137,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0919bc05-4dfb-4061-afec-e301e4e5225b
+      - req-7c1f09a6-45d8-4843-84c1-232fd7a5dac8
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4437,7 +4159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4450,14 +4172,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f38619a5-c037-4ba7-ac8b-9ebcdfcbd92f
+      - req-f4abe089-11cf-4455-823a-868991f46244
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4472,7 +4194,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4485,14 +4207,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-31bcea9d-da56-4964-bb69-54e539ebdac6
+      - req-19b83fa1-0460-4ef9-831a-cbe519a23980
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4507,7 +4229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4520,14 +4242,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c8898c42-669b-426f-a304-a5d9665a0238
+      - req-cccbd7d1-8aad-4a5e-b6e7-b193d3d2cdc3
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4542,7 +4264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4555,14 +4277,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0cdf35fc-7fe7-4513-85b2-132774f47c26
+      - req-c24a2d15-dea9-45ef-aea3-16223eb1e4c9
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4577,7 +4299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4590,14 +4312,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b099934c-d459-4ff4-8512-ac5a116b235f
+      - req-0be873cf-cace-4c80-8bb1-bd39426503dc
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4612,7 +4334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4625,26 +4347,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f2788102-b449-4ede-9e09-b6d424a5287d
+      - req-eb864402-b553-4bbc-80d3-e68de5f6af0a
       Date:
-      - Wed, 26 Sep 2018 18:40:57 GMT
+      - Thu, 25 Oct 2018 18:19:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:40:54.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:01.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:40:49.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:07.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:40:50.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:08.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:40:48.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:01.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:40:57.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:02.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:57 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4659,7 +4381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 16f9545d275e42a6b4f73abce2430314
+      - f62a708414a54311af58f113b00a65b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4672,26 +4394,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-da19009e-53a0-4486-90b7-7136d6e9f44d
+      - req-a8dbc978-0381-4e62-9adc-a0ed1493f377
       Date:
-      - Wed, 26 Sep 2018 18:40:58 GMT
+      - Thu, 25 Oct 2018 18:19:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:40:54.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:19:01.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:40:49.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:19:07.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:40:50.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:19:08.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:40:48.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:19:01.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:40:57.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:19:02.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:58 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4709,13 +4431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:59 GMT
+      - Thu, 25 Oct 2018 18:19:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5cd4a653-587a-4760-af45-b2a18a8edd4a
+      - req-6fcb6106-aa2d-42d0-ba38-228041035ded
       Content-Length:
       - '4170'
       Connection:
@@ -4724,10 +4446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:59.201994", "expires":
-        "2018-09-26T19:40:59Z", "id": "23c3df31ebef45d89f130b15f68c4961", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:13.863840", "expires":
+        "2018-10-25T19:19:13Z", "id": "8ff1417d9fae4c2b8097a444d32d6d99", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qsXblOAuQu-g-o68GrsvQw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CUfWkRYKRrq1eG0UdJrdWw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4772,7 +4494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4790,13 +4512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:40:59 GMT
+      - Thu, 25 Oct 2018 18:19:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e738d3e7-2e7a-4380-bcef-60c0d928a207
+      - req-02f8b569-d2ce-4cf4-b3c2-8793bf88fe47
       Content-Length:
       - '4170'
       Connection:
@@ -4805,10 +4527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:40:59.405981", "expires":
-        "2018-09-26T19:40:59Z", "id": "82ac9f6d700644e5b94282f8961d77ee", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:14.045538", "expires":
+        "2018-10-25T19:19:14Z", "id": "938d9094ae4848d5801b056a51988e42", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WGtoJYhIQfyLutoHrS4yzA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YIyrpdp3Q820OyIt6sxwQQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4853,7 +4575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4868,7 +4590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -4879,9 +4601,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-b8f41782-f122-494a-a238-8c634af8bb03
+      - req-a8940fe0-43e6-4ce8-a5e4-dc2c76e7b898
       Date:
-      - Wed, 26 Sep 2018 18:40:59 GMT
+      - Thu, 25 Oct 2018 18:19:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4923,7 +4645,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4938,7 +4660,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -4949,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-4455d94a-fbf2-4378-82b5-212adf72ae7d
+      - req-46bc1a84-2545-49e6-83ba-b0eb1293c37f
       Date:
-      - Wed, 26 Sep 2018 18:40:59 GMT
+      - Thu, 25 Oct 2018 18:19:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4994,7 +4716,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -5009,7 +4731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5020,9 +4742,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-ebe38f0a-670f-4dfe-8231-ef1bf479290f
+      - req-d7d416ea-016c-496c-8ac5-6665fff0645c
       Date:
-      - Wed, 26 Sep 2018 18:40:59 GMT
+      - Thu, 25 Oct 2018 18:19:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -5057,7 +4779,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:40:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5072,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5083,9 +4805,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-4aea8491-e80c-422a-b7f2-9de64d9cece2
+      - req-0844c039-1f62-47c1-a48a-c56fd8f8af2f
       Date:
-      - Wed, 26 Sep 2018 18:41:00 GMT
+      - Thu, 25 Oct 2018 18:19:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -5172,7 +4894,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5187,7 +4909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5198,17 +4920,37 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-964e2bcd-c6c9-4147-a837-8ffe775937ae
+      - req-777164df-e814-4aaa-babc-6c63c086357e
       Date:
-      - Wed, 26 Sep 2018 18:41:00 GMT
+      - Thu, 25 Oct 2018 18:19:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -5238,31 +4980,11 @@ http_interactions:
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5270,7 +4992,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5285,7 +5007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5296,28 +5018,81 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0a423111-bbfe-494c-b3fc-5c4751b0a7bb
+      - req-92e6d8c0-08b3-47d0-8f82-adc147300155
       Date:
-      - Wed, 26 Sep 2018 18:41:00 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5330,6 +5105,62 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 938d9094ae4848d5801b056a51988e42
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a9484c18-b071-4458-ad15-5c7d35f3c08d
+      Date:
+      - Thu, 25 Oct 2018 18:19:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
@@ -5337,6 +5168,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -5389,68 +5226,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-206e26a8-3bd7-4dab-a9b4-bc93bba6f5c2
-      Date:
-      - Wed, 26 Sep 2018 18:41:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -5468,73 +5243,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5549,7 +5271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5560,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9daf5c56-ba89-4749-87c2-6b334d2ff54b
+      - req-966b7d4d-ce8f-4171-87a8-cf2a859ae324
       Date:
-      - Wed, 26 Sep 2018 18:41:00 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5594,7 +5316,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5609,7 +5331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5620,9 +5342,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f485ad36-7470-4dc2-8b3a-71505bc0291a
+      - req-15d8820f-07f1-4507-a20a-aca49c814c29
       Date:
-      - Wed, 26 Sep 2018 18:41:01 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5654,7 +5376,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5669,7 +5391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -5680,9 +5402,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-09c27295-7e9a-4a8e-9fd2-a26a156a2a74
+      - req-8c97a469-1ccb-4e1a-901e-f4ac59543ce4
       Date:
-      - Wed, 26 Sep 2018 18:41:01 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6085,7 +5807,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6100,7 +5822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -6111,9 +5833,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6b229a0a-59ea-4d50-bc2e-fc54b39b16fa
+      - req-93bad4ca-722f-4ab5-94f1-84438c42b901
       Date:
-      - Wed, 26 Sep 2018 18:41:01 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6516,7 +6238,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6531,7 +6253,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -6542,9 +6264,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3aceaf86-f065-490d-bd60-933b6757717a
+      - req-bfeefd34-6550-40bd-95ba-4b92a4201320
       Date:
-      - Wed, 26 Sep 2018 18:41:01 GMT
+      - Thu, 25 Oct 2018 18:19:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6586,7 +6308,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6601,7 +6323,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82ac9f6d700644e5b94282f8961d77ee
+      - 938d9094ae4848d5801b056a51988e42
   response:
     status:
       code: 200
@@ -6612,9 +6334,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a0972d1e-7300-43f1-8282-56b0861a5e8b
+      - req-59d9b34b-964a-4629-b7a3-c917a78345f2
       Date:
-      - Wed, 26 Sep 2018 18:41:01 GMT
+      - Thu, 25 Oct 2018 18:19:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6656,7 +6378,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6674,13 +6396,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:02 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-71fe68d7-5b56-430a-a71c-7889c8f5a470
+      - req-e8eeaa7f-d904-4c0e-bc0e-073d5e70880f
       Content-Length:
       - '4170'
       Connection:
@@ -6689,10 +6411,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:02.654411", "expires":
-        "2018-09-26T19:41:02Z", "id": "2b85a96af1fb4bf79a9a254b41b73113", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.079225", "expires":
+        "2018-10-25T19:19:17Z", "id": "b16fbb774bad4b029aa89f4c1530c489", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["P2b175rDTACtAZg16Xyzog"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fsYiZouMQVCKv2oiiHvH4A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6737,7 +6459,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6755,13 +6477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:02 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f9bb9d82-8a80-4f02-b2aa-71568335232e
+      - req-888ba512-6aff-47ae-a0e8-2c3ce30eb0e3
       Content-Length:
       - '4170'
       Connection:
@@ -6770,10 +6492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:02.836727", "expires":
-        "2018-09-26T19:41:02Z", "id": "87e0328d76b94d538a42ae7aed5c52cf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.260928", "expires":
+        "2018-10-25T19:19:17Z", "id": "0c915a4c21a14c29bc0780a74cd7f333", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0qBhTekpR2yaADzBTG86CQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["BWTvDg0CSK6rZ88pTiAzUg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6818,13 +6540,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6836,13 +6558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:02 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-588cac1a-7391-48f8-a537-8d9be00e4a05
+      - req-b57c2dd0-af66-4331-b91e-daea1d18380a
       Content-Length:
       - '370'
       Connection:
@@ -6851,13 +6573,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:02.993371", "expires":
-        "2018-09-26T19:41:02Z", "id": "8a30ebdb2c2846f3a285288ac9d81bd4", "audit_ids":
-        ["tL6zMkIKTGWGvmbplvioow"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.417951", "expires":
+        "2018-10-25T19:19:17Z", "id": "f3b57032e7ca47299d1f59f5b2e0cb84", "audit_ids":
+        ["0QqT4M-tT0mvqpN7S7XCzA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6872,20 +6594,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8a30ebdb2c2846f3a285288ac9d81bd4
+      - f3b57032e7ca47299d1f59f5b2e0cb84
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28a5af4c-f388-4810-838d-f62728bfa289
+      - req-d022cf96-6def-447f-af94-aa0804b74c2f
       Content-Length:
       - '500'
       Connection:
@@ -6902,133 +6624,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"8a30ebdb2c2846f3a285288ac9d81bd4"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-51ee4214-5200-4392-9ef9-2272c36358bb
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:03.284391", "expires":
-        "2018-09-26T19:41:02Z", "id": "9a67d35a901b4ab98c79b003eb926cb8", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lzE86vRiQvyR-pP5fkIEPQ",
-        "tL6zMkIKTGWGvmbplvioow"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8a30ebdb2c2846f3a285288ac9d81bd4
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-df3963b5-435f-4347-9abf-78de59bf4f6c
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7046,13 +6642,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b74011f3-094a-41dc-9492-bd7562c249ba
+      - req-f83b9692-410d-4497-ab3b-344549a313d9
       Content-Length:
       - '4117'
       Connection:
@@ -7061,10 +6657,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:03.609369", "expires":
-        "2018-09-26T19:41:03Z", "id": "92bc5cd24177423d8e68760701057557", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.735511", "expires":
+        "2018-10-25T19:19:17Z", "id": "9fe70029b1524536843dfe618c521add", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["w7R-9IRaQHyGVHxo_RAJSQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qzmRKyRuQEOUahJvSULqwg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7108,7 +6704,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7126,13 +6722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
+      - Thu, 25 Oct 2018 18:19:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b93719bb-184e-47f0-a99b-9a04730d162d
+      - req-665f9334-d9fc-4c02-84bf-c76dc46d29d4
       Content-Length:
       - '4131'
       Connection:
@@ -7141,10 +6737,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:03.819507", "expires":
-        "2018-09-26T19:41:03Z", "id": "a2d49769b3444f2fa5e1d5c1b4b870b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:17.920433", "expires":
+        "2018-10-25T19:19:17Z", "id": "fa3b1b52050045b48209d179dd1c61d5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ikEKGswySUafn6Eaub582Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ENOLFigrT8KxNov6u3nLPQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7188,7 +6784,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7206,13 +6802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:03 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-36a8be11-69e5-40e8-9e4f-5b5baa375707
+      - req-89b5e35f-67d3-4b9d-af6e-0a7f720317ec
       Content-Length:
       - '4118'
       Connection:
@@ -7221,10 +6817,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:04.025334", "expires":
-        "2018-09-26T19:41:04Z", "id": "82cff174e6f9478191739f8dcaecab0d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:18.100457", "expires":
+        "2018-10-25T19:19:18Z", "id": "6cfa00b90dd0447d9b628a39048f628d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["x7mrQQ_7TtWDiGptRv8hZA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["pndcZSBoQ2SGGRn4ScLlnQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7268,7 +6864,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7286,13 +6882,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:04 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-93e53850-8d34-402f-a42d-fd28de46b5c0
+      - req-821d6330-51d0-410e-85b8-a6458bc4298d
       Content-Length:
       - '4117'
       Connection:
@@ -7301,10 +6897,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:04.227470", "expires":
-        "2018-09-26T19:41:04Z", "id": "8b619381baf74dca8bd4feab9592aa7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:18.281265", "expires":
+        "2018-10-25T19:19:18Z", "id": "40982ead58fa466cb1e3873689ad2d60", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kF-fHf-LSr69Le7f-j13TA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MrJvFK97SvOdX_w26cGeLw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7348,7 +6944,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -7363,22 +6959,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c36596af-b4ed-4312-8dc6-d257653d2b04
+      - req-05b11e05-d7c1-432a-a208-d5ca4918df3c
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-c36596af-b4ed-4312-8dc6-d257653d2b04
+      - req-05b11e05-d7c1-432a-a208-d5ca4918df3c
       Date:
-      - Wed, 26 Sep 2018 18:41:04 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -7411,7 +7007,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -7426,22 +7022,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a56ca93-51db-4c95-806b-dbc735c37f59
+      - req-bfd4f024-2f68-46db-8c75-8ba087832100
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-0a56ca93-51db-4c95-806b-dbc735c37f59
+      - req-bfd4f024-2f68-46db-8c75-8ba087832100
       Date:
-      - Wed, 26 Sep 2018 18:41:04 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -7482,7 +7078,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7497,22 +7093,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1ad406f-c3ab-4eb8-957a-fc2f9ff1cecc
+      - req-e3326ab7-f1d0-4492-9b49-b3cc47a4a451
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a1ad406f-c3ab-4eb8-957a-fc2f9ff1cecc
+      - req-e3326ab7-f1d0-4492-9b49-b3cc47a4a451
       Date:
-      - Wed, 26 Sep 2018 18:41:04 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7546,7 +7142,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7561,27 +7157,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce9400d9-f3fa-4d74-aa6a-a017b6ad1ede
+      - req-e4e83ac3-e5dd-4fef-9c91-576dcb62321f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ce9400d9-f3fa-4d74-aa6a-a017b6ad1ede
+      - req-e4e83ac3-e5dd-4fef-9c91-576dcb62321f
       Date:
-      - Wed, 26 Sep 2018 18:41:05 GMT
+      - Thu, 25 Oct 2018 18:19:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7599,13 +7195,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:05 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d4568c3a-b659-4b45-ac45-49e9b57d078e
+      - req-72d40d54-cea1-46cd-92f8-e7c3fcaece2b
       Content-Length:
       - '4131'
       Connection:
@@ -7614,10 +7210,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:05.199130", "expires":
-        "2018-09-26T19:41:05Z", "id": "1ce7753c15154c59b36b3fd0e146aa76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:19.112121", "expires":
+        "2018-10-25T19:19:19Z", "id": "0fea1460976545c8957e7bf03da35442", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VI_DPrIgRJ28KMtc_yKRBA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ukAvOrZ9Qkafa2VwFq3bWw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7661,7 +7257,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7676,27 +7272,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce7753c15154c59b36b3fd0e146aa76
+      - 0fea1460976545c8957e7bf03da35442
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae058211-10fa-4525-8326-bdc29c8b28ea
+      - req-e8598618-fac9-450c-b2d2-6b7e615dd307
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ae058211-10fa-4525-8326-bdc29c8b28ea
+      - req-e8598618-fac9-450c-b2d2-6b7e615dd307
       Date:
-      - Wed, 26 Sep 2018 18:41:05 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7711,27 +7307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87e0328d76b94d538a42ae7aed5c52cf
+      - 0c915a4c21a14c29bc0780a74cd7f333
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e192098e-6fff-4fa6-822b-ab648fd8be89
+      - req-b9e42986-5959-486a-8869-ee72d6755bb3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e192098e-6fff-4fa6-822b-ab648fd8be89
+      - req-b9e42986-5959-486a-8869-ee72d6755bb3
       Date:
-      - Wed, 26 Sep 2018 18:41:05 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7749,13 +7345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:05 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec8e90b2-06f5-4075-ba37-391a4c96851f
+      - req-86a526cd-a31b-4ce3-a6e9-455f98fb9f55
       Content-Length:
       - '4118'
       Connection:
@@ -7764,10 +7360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:05.849660", "expires":
-        "2018-09-26T19:41:05Z", "id": "ae8aeaccedbb42ec906241b3458919bb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:19.644888", "expires":
+        "2018-10-25T19:19:19Z", "id": "a2cfe70e692a4658954edf9b9518d4d8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hmesKYfyQluRfWjGcsg8vQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ua4uLKT8RD-9ET_BJPFmag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7811,7 +7407,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7826,27 +7422,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae8aeaccedbb42ec906241b3458919bb
+      - a2cfe70e692a4658954edf9b9518d4d8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-acd08ab8-750e-4393-9baf-f26fd3cd3177
+      - req-535d5c87-e65b-473c-b612-be815a2f473e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-acd08ab8-750e-4393-9baf-f26fd3cd3177
+      - req-535d5c87-e65b-473c-b612-be815a2f473e
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7861,22 +7457,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f151d423-aa4e-4e24-9718-af18693aca83
+      - req-3eab6cd2-1cf2-4be4-85f0-29669ce183dc
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-f151d423-aa4e-4e24-9718-af18693aca83
+      - req-3eab6cd2-1cf2-4be4-85f0-29669ce183dc
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7891,7 +7487,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7906,22 +7502,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0325b512-4430-49b8-9cae-3fc8b05b7d49
+      - req-83eeeb64-e23d-424e-a01e-46c5946b0596
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-0325b512-4430-49b8-9cae-3fc8b05b7d49
+      - req-83eeeb64-e23d-424e-a01e-46c5946b0596
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7936,7 +7532,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7951,27 +7547,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce7753c15154c59b36b3fd0e146aa76
+      - 0fea1460976545c8957e7bf03da35442
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29cf0557-90f0-4deb-a0e2-65fe4173cfe7
+      - req-2f7ed56b-282e-41e4-93c2-14dea999d5ac
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-29cf0557-90f0-4deb-a0e2-65fe4173cfe7
+      - req-2f7ed56b-282e-41e4-93c2-14dea999d5ac
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7986,27 +7582,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce7753c15154c59b36b3fd0e146aa76
+      - 0fea1460976545c8957e7bf03da35442
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1efc3ccd-e03e-4674-a602-251270f72365
+      - req-14e14a00-d3eb-414b-b962-fc1bec9dd09d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1efc3ccd-e03e-4674-a602-251270f72365
+      - req-14e14a00-d3eb-414b-b962-fc1bec9dd09d
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8021,27 +7617,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87e0328d76b94d538a42ae7aed5c52cf
+      - 0c915a4c21a14c29bc0780a74cd7f333
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fdd35c18-d351-4cd8-920d-94492acc57d0
+      - req-f42f86db-dc15-4dd2-9382-8abb938543f8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fdd35c18-d351-4cd8-920d-94492acc57d0
+      - req-f42f86db-dc15-4dd2-9382-8abb938543f8
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8056,27 +7652,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87e0328d76b94d538a42ae7aed5c52cf
+      - 0c915a4c21a14c29bc0780a74cd7f333
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bcdff0a2-9042-4ee2-ac14-44bc7b47bc64
+      - req-e8dade85-dec3-435f-9289-d921aacaa1b0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bcdff0a2-9042-4ee2-ac14-44bc7b47bc64
+      - req-e8dade85-dec3-435f-9289-d921aacaa1b0
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8091,27 +7687,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae8aeaccedbb42ec906241b3458919bb
+      - a2cfe70e692a4658954edf9b9518d4d8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bc3a1671-2b91-485a-b180-f0876ef86649
+      - req-da15657b-f7a6-4c41-b1cf-a62bf2b7f073
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bc3a1671-2b91-485a-b180-f0876ef86649
+      - req-da15657b-f7a6-4c41-b1cf-a62bf2b7f073
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8126,27 +7722,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae8aeaccedbb42ec906241b3458919bb
+      - a2cfe70e692a4658954edf9b9518d4d8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd64a4a1-8c11-4f8d-b1eb-3f992ced1825
+      - req-5f41a061-9695-4af4-87ff-de762a36db31
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dd64a4a1-8c11-4f8d-b1eb-3f992ced1825
+      - req-5f41a061-9695-4af4-87ff-de762a36db31
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8161,27 +7757,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6176632-1844-4810-91ae-ddfd88de5d91
+      - req-2820c25e-b469-444c-a914-45e2a379b70a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f6176632-1844-4810-91ae-ddfd88de5d91
+      - req-2820c25e-b469-444c-a914-45e2a379b70a
       Date:
-      - Wed, 26 Sep 2018 18:41:06 GMT
+      - Thu, 25 Oct 2018 18:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8196,27 +7792,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b619381baf74dca8bd4feab9592aa7e
+      - 40982ead58fa466cb1e3873689ad2d60
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-081e7fb5-743b-4cb7-8f6f-f453c7331799
+      - req-d4d3513b-f772-432e-bf2a-ed34c5865443
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-081e7fb5-743b-4cb7-8f6f-f453c7331799
+      - req-d4d3513b-f772-432e-bf2a-ed34c5865443
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8231,27 +7827,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce7753c15154c59b36b3fd0e146aa76
+      - 0fea1460976545c8957e7bf03da35442
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d1fac6b4-7405-48d8-9f38-e4d3f484dec4
+      - req-e479b527-fa98-4a50-8f48-fdc2affe94b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d1fac6b4-7405-48d8-9f38-e4d3f484dec4
+      - req-e479b527-fa98-4a50-8f48-fdc2affe94b5
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -8266,27 +7862,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce7753c15154c59b36b3fd0e146aa76
+      - 0fea1460976545c8957e7bf03da35442
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be8fb392-18b6-49da-9c30-768d45d547f4
+      - req-90f2f740-ad89-400b-8cbb-9ef353dd2933
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-be8fb392-18b6-49da-9c30-768d45d547f4
+      - req-90f2f740-ad89-400b-8cbb-9ef353dd2933
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -8301,27 +7897,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87e0328d76b94d538a42ae7aed5c52cf
+      - 0c915a4c21a14c29bc0780a74cd7f333
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-92c57ff9-cded-413d-a4d0-5e78332946cd
+      - req-8e536adb-08ea-4e5d-86ca-5a25bafe6343
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-92c57ff9-cded-413d-a4d0-5e78332946cd
+      - req-8e536adb-08ea-4e5d-86ca-5a25bafe6343
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -8336,27 +7932,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 87e0328d76b94d538a42ae7aed5c52cf
+      - 0c915a4c21a14c29bc0780a74cd7f333
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60ee4cd6-2762-4cca-b491-91405edf1761
+      - req-fafe6c49-39f6-4e19-814d-51cd98221ce2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-60ee4cd6-2762-4cca-b491-91405edf1761
+      - req-fafe6c49-39f6-4e19-814d-51cd98221ce2
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -8371,27 +7967,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae8aeaccedbb42ec906241b3458919bb
+      - a2cfe70e692a4658954edf9b9518d4d8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-def53565-2f2c-4e8b-9515-ad086eab1b62
+      - req-87ae6054-2edc-4c01-8ac9-cdccecf6ffec
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-def53565-2f2c-4e8b-9515-ad086eab1b62
+      - req-87ae6054-2edc-4c01-8ac9-cdccecf6ffec
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -8406,27 +8002,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ae8aeaccedbb42ec906241b3458919bb
+      - a2cfe70e692a4658954edf9b9518d4d8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cae2c459-ae1d-43f8-b3a5-b41da23264b5
+      - req-ffc062cf-c61b-4c0c-88e1-0b2d9d24a5f1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cae2c459-ae1d-43f8-b3a5-b41da23264b5
+      - req-ffc062cf-c61b-4c0c-88e1-0b2d9d24a5f1
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8444,13 +8040,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6af90738-9674-430f-b9da-3a87d170fc2d
+      - req-d202bf0d-6cc1-405b-8665-5c45f1fd3930
       Content-Length:
       - '4170'
       Connection:
@@ -8459,10 +8055,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:07.860841", "expires":
-        "2018-09-26T19:41:07Z", "id": "2adb0b101dd446c5884296739f5e1b5b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:21.948797", "expires":
+        "2018-10-25T19:19:21Z", "id": "ace88c09b901442d8a238c9e1da8fbd5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["aPRf2Un7SQqVF0eBpnmXJg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YA19BazjTsyLhYXdjjlp4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8507,7 +8103,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8525,13 +8121,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:07 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0f224074-1f86-4f94-8d6e-4cb5052cc070
+      - req-f92d91dd-76c4-4a0a-af37-ab05eaa50130
       Content-Length:
       - '4170'
       Connection:
@@ -8540,10 +8136,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:08.040713", "expires":
-        "2018-09-26T19:41:08Z", "id": "5346f45325e2427faf3942de65d218ab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.138687", "expires":
+        "2018-10-25T19:19:22Z", "id": "f9c5ec6c049d40ad95fc640ccef28458", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HYSEvMcCRampPoJL8nCAtg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["BnksuwcURbKAO24JHfwZmg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8588,13 +8184,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8606,13 +8202,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d1783471-9354-460e-b87d-6398e779566e
+      - req-9ddb1065-0762-4515-820f-2aed338b8453
       Content-Length:
       - '370'
       Connection:
@@ -8621,13 +8217,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:08.193897", "expires":
-        "2018-09-26T19:41:08Z", "id": "a2107ea0e6e44dc29d4e5963468aebaa", "audit_ids":
-        ["5-erOU_gS-mII5ra7FPlsw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.287739", "expires":
+        "2018-10-25T19:19:22Z", "id": "9ab89ff04c4b4e439d0d45b6f48fd559", "audit_ids":
+        ["y0ZFo5Q7R2SxYgNnh5nLGw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8642,20 +8238,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2107ea0e6e44dc29d4e5963468aebaa
+      - 9ab89ff04c4b4e439d0d45b6f48fd559
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-049974e8-1ed5-4798-af5d-2bad5930f129
+      - req-4838ca62-cc4a-4bc1-b9d8-76d5b5541252
       Content-Length:
       - '500'
       Connection:
@@ -8672,133 +8268,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"a2107ea0e6e44dc29d4e5963468aebaa"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-532f08cc-71bf-4926-9a58-874f907fab86
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:08.495697", "expires":
-        "2018-09-26T19:41:08Z", "id": "cc5e55adad57462b84878cbc264d7399", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JUNxcNGaTj6mLZPs3IGa7Q",
-        "5-erOU_gS-mII5ra7FPlsw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a2107ea0e6e44dc29d4e5963468aebaa
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-aa5dc7f5-5627-4ab2-ab6b-3774080350bb
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8816,13 +8286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fcdeb2d9-3ccb-4b6b-b0b4-1d9d357e9a13
+      - req-5d6d2b30-f46e-471a-97e5-65d26c84afec
       Content-Length:
       - '4117'
       Connection:
@@ -8831,10 +8301,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:08.848699", "expires":
-        "2018-09-26T19:41:08Z", "id": "7625abe12a0d4292978ea776e5edfa88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.595187", "expires":
+        "2018-10-25T19:19:22Z", "id": "2f9f79962d44427aa9fff55a46f9d96c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tJXJpu4TTLuC_T_bsYxehg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rVzzixL7TJSCt_s7VK-2uA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8878,7 +8348,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8896,13 +8366,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:08 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a615441b-f3e9-41c1-91a6-a387d326da9d
+      - req-a3258868-a05d-4229-8f24-3b91ed1e8048
       Content-Length:
       - '4131'
       Connection:
@@ -8911,10 +8381,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:09.021970", "expires":
-        "2018-09-26T19:41:09Z", "id": "a76cad6e1bdc4671986d8332922737c1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.779243", "expires":
+        "2018-10-25T19:19:22Z", "id": "6401f1e7ba614c0da37ec39cb11baa32", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["h9MXkch3RIO8pUBVZT_0SA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5sfi2Y5FSUOJTlPE9DZY2A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8958,7 +8428,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8976,13 +8446,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:09 GMT
+      - Thu, 25 Oct 2018 18:19:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b908af4f-1b30-4bd7-a416-93a127674a35
+      - req-a0872ec6-a7e5-4965-8318-8e4068ff3b9a
       Content-Length:
       - '4118'
       Connection:
@@ -8991,10 +8461,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:09.195953", "expires":
-        "2018-09-26T19:41:09Z", "id": "becb53c631934acd8df814ee10daa114", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:22.953333", "expires":
+        "2018-10-25T19:19:22Z", "id": "70c23ed6878d4130b272591941fa3c33", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["E1JKTZJPRTmO4wThErpHWw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e8QlBwPVT8SjI-UlVqgctQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9038,7 +8508,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9056,13 +8526,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:09 GMT
+      - Thu, 25 Oct 2018 18:19:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-472fe87b-2e58-4321-a105-f4efe9214cf4
+      - req-a5e6be66-212c-4e99-9acf-ed161b1a4d6f
       Content-Length:
       - '4117'
       Connection:
@@ -9071,10 +8541,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:09.384833", "expires":
-        "2018-09-26T19:41:09Z", "id": "794b1cfc96f9472894e540beda808197", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:23.171437", "expires":
+        "2018-10-25T19:19:23Z", "id": "24adb3bc0061469883245308ebcbf0c4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["veUM-o73S4ChpZTycbLKnA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VN8ZnGCrRqa2N0n0o2syDg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9118,7 +8588,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9133,7 +8603,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 794b1cfc96f9472894e540beda808197
+      - 24adb3bc0061469883245308ebcbf0c4
   response:
     status:
       code: 200
@@ -9162,15 +8632,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx37ef4caa6eb34651ac179-005babd2c5
+      - txcdac7f81b4d94733a02f0-005bd2092b
       Date:
-      - Wed, 26 Sep 2018 18:41:09 GMT
+      - Thu, 25 Oct 2018 18:19:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -9185,7 +8655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 794b1cfc96f9472894e540beda808197
+      - 24adb3bc0061469883245308ebcbf0c4
   response:
     status:
       code: 200
@@ -9214,14 +8684,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txa5e1cd6fcc7d4c8c80f0f-005babd2c5
+      - tx0b9d9a05ed464d7cb6ace-005bd2092b
       Date:
-      - Wed, 26 Sep 2018 18:41:09 GMT
+      - Thu, 25 Oct 2018 18:19:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9239,13 +8709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:09 GMT
+      - Thu, 25 Oct 2018 18:19:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a6ce7e9-b7ab-461a-96da-6deedaa1e922
+      - req-419bda9a-999b-4bca-a384-fda74b8fa78f
       Content-Length:
       - '4131'
       Connection:
@@ -9254,10 +8724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:09.864712", "expires":
-        "2018-09-26T19:41:09Z", "id": "15d6f1b5ea0349caa4a05e619324dfdf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:23.926507", "expires":
+        "2018-10-25T19:19:23Z", "id": "1eeb09515c31474a878fe6809df507bf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Z3QrdsfQQqK3asnmltyWgw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["A_kcVhjlTXage4RS5bpiKg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9301,7 +8771,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -9316,7 +8786,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15d6f1b5ea0349caa4a05e619324dfdf
+      - 1eeb09515c31474a878fe6809df507bf
   response:
     status:
       code: 200
@@ -9329,22 +8799,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987270.02400'
+      - '1540491564.08763'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987270.02400'
+      - '1540491564.08763'
       X-Trans-Id:
-      - txa18febe2aa69404498306-005babd2c5
+      - tx69fda55216fa463c89a5e-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -9359,7 +8829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5346f45325e2427faf3942de65d218ab
+      - f9c5ec6c049d40ad95fc640ccef28458
   response:
     status:
       code: 200
@@ -9372,22 +8842,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987270.17254'
+      - '1540491564.27775'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987270.17254'
+      - '1540491564.27775'
       X-Trans-Id:
-      - tx0d6b0e13a9ec4ce7ba961-005babd2c6
+      - txfe8842f01c8c4817b4079-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9405,13 +8875,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6e5350a3-3c99-403e-a9fc-6893f8def475
+      - req-647f8bd7-d61f-4e78-a965-e22661dec14f
       Content-Length:
       - '4118'
       Connection:
@@ -9420,10 +8890,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:41:10.345436", "expires":
-        "2018-09-26T19:41:10Z", "id": "d855ee730aa24c33908d9aa982a0ae93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:19:24.459812", "expires":
+        "2018-10-25T19:19:24Z", "id": "bd00dfa075d2452fae454d05792b6086", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["V5QPwuPoQOSzId0VQrSvVw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ktQO7WIJQPanWgmJ_0e2rg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9467,7 +8937,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -9482,7 +8952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d855ee730aa24c33908d9aa982a0ae93
+      - bd00dfa075d2452fae454d05792b6086
   response:
     status:
       code: 200
@@ -9495,22 +8965,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987270.50090'
+      - '1540491564.62641'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987270.50090'
+      - '1540491564.62641'
       X-Trans-Id:
-      - txe1ae8a2bc1024958aa8e8-005babd2c6
+      - txa86fa8ab376a40c7a3358-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -9525,7 +8995,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 794b1cfc96f9472894e540beda808197
+      - 24adb3bc0061469883245308ebcbf0c4
   response:
     status:
       code: 200
@@ -9546,9 +9016,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2b756b3be96944f68af71-005babd2c6
+      - tx7490ff941a9d4560a3b56-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -9558,7 +9028,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -9573,7 +9043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 794b1cfc96f9472894e540beda808197
+      - 24adb3bc0061469883245308ebcbf0c4
   response:
     status:
       code: 200
@@ -9594,14 +9064,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txcf189d7d91794f6e9ea39-005babd2c6
+      - txd0d167e56c6f4fe9b1285-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -9616,7 +9086,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 794b1cfc96f9472894e540beda808197
+      - 24adb3bc0061469883245308ebcbf0c4
   response:
     status:
       code: 200
@@ -9637,12 +9107,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txa9b86502aee24d1aa2327-005babd2c6
+      - tx1d806a65bb404520954a3-005bd2092c
       Date:
-      - Wed, 26 Sep 2018 18:41:10 GMT
+      - Thu, 25 Oct 2018 18:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:41:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:19:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:05 GMT
+      - Thu, 25 Oct 2018 18:20:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c86291ba-0eab-4061-9ad7-890a9e103d64
+      - req-a6078d24-f23b-4f3a-a832-cd73fb92de30
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:05.362212", "expires":
-        "2018-09-26T19:42:05Z", "id": "e83d7c78d4a4416b9419a7c483f14139", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:39.616815", "expires":
+        "2018-10-25T19:20:39Z", "id": "4c1551e76ebe4d2ebb68a4467c6a441e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2pqtY3UwTG6lb4AoOa5W3A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["c_RCjpQhQe22Cii6yHF0ZQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:05 GMT
+      - Thu, 25 Oct 2018 18:20:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-968426b2-c466-4443-88fe-ceac590463e5
+      - req-dc92a463-843b-4005-9e78-3027f87722ca
       Date:
-      - Wed, 26 Sep 2018 18:42:05 GMT
+      - Thu, 25 Oct 2018 18:20:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:05 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-268047d0-d424-460f-8207-42ea0bca86f7
+      - req-fc80f17b-2b8b-4ba8-ba97-682b282b83a4
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:05.851574", "expires":
-        "2018-09-26T19:42:05Z", "id": "6f4695330cb6490a93109f626861e072", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.060285", "expires":
+        "2018-10-25T19:20:40Z", "id": "e6d583ace24c48059fa12175ffd8d4a3", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6JudpaeYRmOB--3L1iHwig"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jJyhkdeqS8mve3EOmgyewQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,34 +247,34 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6db722a2-5f65-4cb7-a9c3-8897d028fae6
+      - req-086819de-0848-40bd-8a12-c93e495a2dda
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-6db722a2-5f65-4cb7-a9c3-8897d028fae6
+      - req-086819de-0848-40bd-8a12-c93e495a2dda
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-696721e4-95aa-4b37-a887-06ec79f6e981
+      - req-ebdde89b-7d31-44c8-8609-3fe840085dd0
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:06.172597", "expires":
-        "2018-09-26T19:42:06Z", "id": "387ed602209d4cada7bca03e5c0fc583", "audit_ids":
-        ["q8HxH69jS-GOwE7MsG6KLQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.379965", "expires":
+        "2018-10-25T19:20:40Z", "id": "f4e24959442b4c4580e2b1404c6f6d7d", "audit_ids":
+        ["5w-FSRAeQMK5GzSiqQ4bVQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 387ed602209d4cada7bca03e5c0fc583
+      - f4e24959442b4c4580e2b1404c6f6d7d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28c1feac-1dd2-4942-ae0c-2a307877efef
+      - req-d1546fa6-cf49-4517-a8ba-e37f77bef341
       Content-Length:
       - '500'
       Connection:
@@ -352,133 +352,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"387ed602209d4cada7bca03e5c0fc583"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-07a20291-37cc-4ce6-a9cd-eb3c5b1df7c0
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:06.474068", "expires":
-        "2018-09-26T19:42:06Z", "id": "c6750e2fccbc4a11b1c0bb993f1117ca", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mzQRTy6PTLuGWNFJjztiRQ",
-        "q8HxH69jS-GOwE7MsG6KLQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 387ed602209d4cada7bca03e5c0fc583
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-12962c02-ee8c-4746-828b-de0b25ebd02d
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-de496016-cc3c-4e95-8c1d-f14ee6f40028
+      - req-a5f0c89c-970d-4eed-929e-0524d1197c60
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:06.786706", "expires":
-        "2018-09-26T19:42:06Z", "id": "8ce36bb6f2d34af292cc1a7bc600108d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.693545", "expires":
+        "2018-10-25T19:20:40Z", "id": "38e245157a014262a3571406f0b30599", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1zeKzGMzRUi7-LcLJMSWsQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zt3Y8JpBR9u8TlNmc4vrKA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
   response:
     status:
       code: 200
@@ -584,7 +458,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +467,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +485,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:06 GMT
+      - Thu, 25 Oct 2018 18:20:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9e79a935-0b10-4ba9-ba6b-9677b15dc216
+      - req-bdadb8e8-2894-4553-afb4-8b448ee7d14c
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +500,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:07.049571", "expires":
-        "2018-09-26T19:42:07Z", "id": "533069a8e9aa43759a924cd3ae11e922", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:40.961571", "expires":
+        "2018-10-25T19:20:40Z", "id": "d0617893a7d8498ca571b7000e867f85", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UAHjnSfqRjuGQt6PypIPMA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3iz_mngVQJ260OP4zAK5Cg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +547,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
   response:
     status:
       code: 200
@@ -699,7 +573,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +582,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a24f20cb-296a-4b80-911d-8fa24d7668b5
+      - req-5a5f60ee-632c-4541-a716-de59745833ee
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:07.308036", "expires":
-        "2018-09-26T19:42:07Z", "id": "82d823b480e44b3abc1b0b0c3655c345", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:41.258783", "expires":
+        "2018-10-25T19:20:41Z", "id": "e2862124e07c4ce98c3440bfb1f0310d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5lrMt_SCQseCKuYQy98GJg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4JNZcvu4TPikgloEpvMyMQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
   response:
     status:
       code: 200
@@ -814,7 +688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +725,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-08b734e6-18e2-4daf-9a1e-791bec51c945
+      - req-a405b654-0224-4cbd-96be-a9b719f3d939
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:58.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +772,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-647bc016-6d25-4def-a7ac-0565e106f9ca
+      - req-1f6fdc18-6603-4e00-806c-17ab5f87a7b3
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:58.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +819,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9360a44b-db9a-44b2-8542-f8d7c8675940
+      - req-9a3a2d8c-66f0-47ae-a8b1-f506d8472b70
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:58.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +866,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-308f53fe-468d-490e-81e6-bbb5e3f15e46
+      - req-ec2670d2-72ef-4840-8c6f-199bc40ad181
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:58.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +913,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-bfd8a489-5194-4c4c-9509-a08a5ef84129
+      - req-b5534d2f-7078-4535-ae06-c5ddf4ab4123
       Date:
-      - Wed, 26 Sep 2018 18:42:07 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:41:58.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:32.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +960,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-bc8d501b-fe96-4472-ba05-3e01f3415459
+      - req-33bd0115-95c9-43ff-b0d7-97f5d7205e59
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:42:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1007,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-baa128cc-04b0-4f98-92b1-d5cb37efb709
+      - req-716468e1-4bf6-45f2-909c-bf3f0f10be95
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:42:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1054,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d6f63d15-d93d-4eb0-996b-5e40d70d79dc
+      - req-800d7a0e-cffc-4a12-980c-30389f5ba0fc
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-26T18:42:04.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-10-25T18:20:41.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-09-26T18:41:59.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-10-25T18:20:37.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-26T18:42:00.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-10-25T18:20:38.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-09-26T18:42:08.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-10-25T18:20:41.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-26T18:42:07.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-10-25T18:20:42.000000"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1101,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-9d628eb2-1b93-4e8e-8c60-3ce05c551936
+      - req-751f4761-82fd-4ec3-980a-af6df293b8d7
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1117,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1145,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-b0baff73-afc0-434f-a7a9-d292f3448404
+      - req-6f8d69a8-8abb-41c1-937b-f0dc89ba9f86
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1161,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1189,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-a7ba38d2-e093-44b1-a8d7-d794bb0b1250
+      - req-f0c6b070-8183-4265-bbfb-ee5b7393ca5a
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1206,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1234,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-1323ff3f-f384-48fd-a778-43172e8691e0
+      - req-3195ded1-3348-4b2b-8ff9-13f7bef25c81
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1246,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1274,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-771895b3-d3df-4d47-a90b-36c29cb4a4d3
+      - req-0a00bf85-9bde-47fc-b41b-8ff05e775a94
       Date:
-      - Wed, 26 Sep 2018 18:42:08 GMT
+      - Thu, 25 Oct 2018 18:20:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1300,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
+      - Thu, 25 Oct 2018 18:20:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-adf9d099-db5b-4502-b604-5221da2ee678
+      - req-8320ecb3-e5f7-4d40-ad17-be17f40e9431
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1315,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:09.079997", "expires":
-        "2018-09-26T19:42:09Z", "id": "51265294312748d094cec9d3a7c285b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.166487", "expires":
+        "2018-10-25T19:20:43Z", "id": "761970b1e1b94bd382b3b9d4f305c48c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zqL-pLjDRBq9RSn3LY4wGg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YgswmtIIRIWS_CwI2C25Vg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,46 +1363,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 51265294312748d094cec9d3a7c285b9
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.233:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.233:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1381,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
+      - Thu, 25 Oct 2018 18:20:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9c718ef2-e454-41ec-969b-81e0b1968066
+      - req-70d52f5b-f6b5-435c-9ca3-a7232ed0ae75
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1396,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:09.332123", "expires":
-        "2018-09-26T19:42:09Z", "id": "c29f2deb2e4c42f9bc557e78c81d6909", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.346553", "expires":
+        "2018-10-25T19:20:43Z", "id": "a482c14795714eb6b1348bb17337bdd3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["45i8pLGZRT-cI-zEOUZymQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tes9EfGWSUSsY3e_x_iHAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1443,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c29f2deb2e4c42f9bc557e78c81d6909
+      - a482c14795714eb6b1348bb17337bdd3
   response:
     status:
       code: 200
@@ -1634,9 +1469,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-79b10725-64ff-4213-910d-364f2daba014
+      - req-5f0a63b2-17ca-415f-8946-99c92d52edcf
       Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
+      - Thu, 25 Oct 2018 18:20:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1513,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c29f2deb2e4c42f9bc557e78c81d6909
+      - a482c14795714eb6b1348bb17337bdd3
   response:
     status:
       code: 200
@@ -1704,14 +1539,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-523dee33-f843-43b1-92d4-96a4bfb0637f
+      - req-29d6742a-cd31-4f67-a447-1227c8d2155a
       Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
+      - Thu, 25 Oct 2018 18:20:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1564,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:09 GMT
+      - Thu, 25 Oct 2018 18:20:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d7badc32-5896-415e-9f6a-808ead0842df
+      - req-71f8225b-5c97-4538-b923-abeceaa1ca60
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1579,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:09.783482", "expires":
-        "2018-09-26T19:42:09Z", "id": "e72e84359e9e4a96aa1d799b357ddb88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:43.869528", "expires":
+        "2018-10-25T19:20:43Z", "id": "8b59bb3fd3074bb08cab3be212575494", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FlJKOZVRQNug9ccr1nNZJg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dlYa4D-NQmSqEcUgQJ3Yhw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1626,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1641,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72e84359e9e4a96aa1d799b357ddb88
+      - 8b59bb3fd3074bb08cab3be212575494
   response:
     status:
       code: 200
@@ -1817,9 +1652,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-75925ce0-97cd-419f-8e0d-c7f93678c57d
+      - req-964467ec-04e3-447c-b85c-1875fe76e546
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1696,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72e84359e9e4a96aa1d799b357ddb88
+      - 8b59bb3fd3074bb08cab3be212575494
   response:
     status:
       code: 200
@@ -1887,14 +1722,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0224dafe-71b0-41c3-929d-3d43585a2d93
+      - req-78c36271-0a96-4408-9e67-1dd4314ff205
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51265294312748d094cec9d3a7c285b9
+      - 761970b1e1b94bd382b3b9d4f305c48c
   response:
     status:
       code: 200
@@ -1920,9 +1755,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-33011d5d-244e-448e-9aa0-d24877472478
+      - req-ada0814e-8922-4267-991a-51efa46d5558
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1799,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51265294312748d094cec9d3a7c285b9
+      - 761970b1e1b94bd382b3b9d4f305c48c
   response:
     status:
       code: 200
@@ -1990,14 +1825,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b5616cbb-f921-4141-b860-e97030408a82
+      - req-9f083946-a615-4e90-b641-6e74b17a7823
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +1850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3236baf1-9dd8-496e-9d73-92b7f116fc82
+      - req-d093f3b4-a061-4a8d-9c8f-195822b45ec5
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +1865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:10.693317", "expires":
-        "2018-09-26T19:42:10Z", "id": "b1855704aed140ce981895481594bd86", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:44.689804", "expires":
+        "2018-10-25T19:20:44Z", "id": "836448ddfc794d1f85e4ccae2a599b58", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QjbckrW2S6agNLDu461dZg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Zt5Xk3GZQGSXBs0T4vJUrg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +1912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +1927,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1855704aed140ce981895481594bd86
+      - 836448ddfc794d1f85e4ccae2a599b58
   response:
     status:
       code: 200
@@ -2103,9 +1938,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0f4e2238-e5da-42fb-a738-eaee5dcb1522
+      - req-76b7a141-40f2-49b5-a24f-08860de76c10
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +1982,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +1997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1855704aed140ce981895481594bd86
+      - 836448ddfc794d1f85e4ccae2a599b58
   response:
     status:
       code: 200
@@ -2173,14 +2008,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-951d4651-9dc4-469e-9dc5-dd0b338e0afa
+      - req-d019ae49-8157-4c22-b8f8-6bffd3d341a1
       Date:
-      - Wed, 26 Sep 2018 18:42:10 GMT
+      - Thu, 25 Oct 2018 18:20:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2043,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-f80b96b6-cdf0-4609-813e-442f9d8089ab
+      - req-3942c581-c4a3-4142-b49a-93749ce0d08c
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2055,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2083,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e1aff908-4842-4fc9-8f20-c7caec01d0d4
+      - req-a1d0620f-a9b7-4a0e-85e4-342f1cbac66a
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2095,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2123,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1d6a3ba6-041a-441f-8794-5237edbca6a2
+      - req-bb0f8366-983c-45aa-ac71-7eb0413e06a6
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2135,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2150,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2163,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-774036b4-9ecc-4700-8a91-1f42018cdb21
+      - req-1c56d56d-8c53-455f-bd36-8d90c4832572
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2175,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2203,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-360b168e-882b-45eb-9f7d-9c5926034d80
+      - req-38e5bd5b-b1ed-42ad-9e74-fe46252becd4
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2215,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2243,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-3ae16939-32af-4767-81b8-46d47630d6c3
+      - req-23f50c78-9f26-47a5-905c-ee313f59b712
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2255,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2283,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a47c59b5-5027-4257-b2f5-982a26259661
+      - req-56dc769a-232c-4a18-a174-95cf7ed8ffe8
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2295,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2323,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-cabea218-f73e-43bf-9ec2-bcf19263fedc
+      - req-33859d00-94e8-4a9b-94cf-4b4e156f4630
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2335,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:11 GMT
+      - Thu, 25 Oct 2018 18:20:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-39231ca7-e67d-4256-9daa-a5330670decd
+      - req-4023cf04-937b-4e0f-a438-7445f325940e
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2368,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:11.960407", "expires":
-        "2018-09-26T19:42:11Z", "id": "3a14c3360d784920859f1cd0974f330d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:45.944623", "expires":
+        "2018-10-25T19:20:45Z", "id": "68e224b3cf4c4579a0d95c373fabab5b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2gkZdIqYQ5-ZTDjR_tMUDA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Yc_2hGRNRaOhMSoVc56tEg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2416,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2434,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c895675a-3c18-4439-a71e-dc7424c41001
+      - req-2a25e6b0-bac2-48b0-a2ce-3cb1d0d619d0
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2449,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:12.137062", "expires":
-        "2018-09-26T19:42:12Z", "id": "6828005cc3a44811b0dff05b8ccb9f7b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:46.127739", "expires":
+        "2018-10-25T19:20:46Z", "id": "14b86404e1d5474d8aad1f054ba61dfd", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["hmZXvbmJQwu6oEArShDZ2g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["f_7VV6DvTOuEnj1fKUjDIA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2496,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2511,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -2687,9 +2522,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-72a51c00-ed9b-4a69-9ba9-1e4e51f8fb52
+      - req-2f9394cb-a937-48db-95a7-33addb04ed78
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2558,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -2749,14 +2584,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-506e4463-f544-4b8e-ae90-50812bf3a48f
+      - req-4c56dbbb-88c6-4404-b418-5e4f4375a419
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-174c05c4-9315-419a-a9a9-037a8709ca24
+      - req-d7a54c3c-7d6b-4084-8f8b-ee84c48df763
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:12.615646", "expires":
-        "2018-09-26T19:42:12Z", "id": "42eb89d2ed9d4d6cbebb224f090ee34a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:46.615933", "expires":
+        "2018-10-25T19:20:46Z", "id": "084c8c5b651e47b38a9a81d4f1234784", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kq0cHA3dQ_yloorpm_9QQA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["t24shibaSI2K1dOQ3ESnew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2671,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42eb89d2ed9d4d6cbebb224f090ee34a
+      - '084c8c5b651e47b38a9a81d4f1234784'
   response:
     status:
       code: 200
@@ -2862,14 +2697,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6dec6e3e-beed-4db7-9832-b15473598fdd
+      - req-b7fbe078-abc8-4389-ae4b-45616327dd5e
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3a14c3360d784920859f1cd0974f330d
+      - 68e224b3cf4c4579a0d95c373fabab5b
   response:
     status:
       code: 200
@@ -2895,14 +2730,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cc8c5ea9-6e88-44cf-a315-92a28855fa4f
+      - req-1aa9b693-d0b5-4859-8765-36cc9396c55f
       Date:
-      - Wed, 26 Sep 2018 18:42:12 GMT
+      - Thu, 25 Oct 2018 18:20:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2755,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:13 GMT
+      - Thu, 25 Oct 2018 18:20:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c7745de3-d38f-460c-8361-c2c4f1bd0b1b
+      - req-eda47782-974f-4030-9c3d-2387f65ac215
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2770,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:13.120901", "expires":
-        "2018-09-26T19:42:13Z", "id": "0db7a640d6644e52b2f0ef3bd330b1a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:47.145404", "expires":
+        "2018-10-25T19:20:47Z", "id": "0803a104f96b48e195e7bc575f0edfe8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mYsbNulzRE2ir3FJ6ytZlQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["089H9Og3QqCD_8goh8actg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2817,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0db7a640d6644e52b2f0ef3bd330b1a3
+      - '0803a104f96b48e195e7bc575f0edfe8'
   response:
     status:
       code: 200
@@ -3008,14 +2843,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5c75ea13-bc13-44a4-97bf-14478747862b
+      - req-3719f207-9a43-432e-9b11-8fa07664b0ab
       Date:
-      - Wed, 26 Sep 2018 18:42:13 GMT
+      - Thu, 25 Oct 2018 18:20:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +2865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3041,9 +2876,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c9d39efe-dc01-4052-b799-e6eec4f0dbbc
+      - req-bc0ddddb-d0b9-48a2-a709-84f1091670b9
       Date:
-      - Wed, 26 Sep 2018 18:42:13 GMT
+      - Thu, 25 Oct 2018 18:20:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +2905,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +2920,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3096,9 +2931,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-adb7435c-2d11-491f-818a-7a4619d751dc
+      - req-d907a2bf-5026-46db-8654-ea6bf42968a8
       Date:
-      - Wed, 26 Sep 2018 18:42:14 GMT
+      - Thu, 25 Oct 2018 18:20:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +2960,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +2975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3151,9 +2986,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fbb72b68-37b8-4592-9a9f-fece711c842b
+      - req-a7f5cb2e-7184-4b07-b557-fb85b6bc3338
       Date:
-      - Wed, 26 Sep 2018 18:42:14 GMT
+      - Thu, 25 Oct 2018 18:20:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3015,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3206,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4d9768b0-397a-4d6a-89cd-7c4988c06036
+      - req-893b4957-1d75-4a0e-9689-831cc30fa1e3
       Date:
-      - Wed, 26 Sep 2018 18:42:14 GMT
+      - Thu, 25 Oct 2018 18:20:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3099,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3290,9 +3125,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2d80ae99-064d-4ca0-a609-fffbd34e0e4f
+      - req-9b843e66-16c2-4947-a74d-e32dbd3840ad
       Date:
-      - Wed, 26 Sep 2018 18:42:14 GMT
+      - Thu, 25 Oct 2018 18:20:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3139,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,13 +3167,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-23e463ab-fc25-425a-a000-e7bd70233cb5
+      - req-98bd6cb5-f0c9-4e35-aae4-d8cb7db3371c
       Date:
-      - Wed, 26 Sep 2018 18:42:15 GMT
+      - Thu, 25 Oct 2018 18:20:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -3380,7 +3215,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3243,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-c0a17d25-ed61-4d7f-9741-4a34c5b16dba
+      - req-a76e47ee-accc-4957-a4e0-bedd5b56db9a
       Date:
-      - Wed, 26 Sep 2018 18:42:15 GMT
+      - Thu, 25 Oct 2018 18:20:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3434,7 +3269,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-10-09T18:41:33Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -3456,7 +3291,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,13 +3319,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-b9a18c89-7513-4603-842d-55db8e1aa54d
+      - req-cebef3f8-62fc-4e48-95d8-91796653e454
       Date:
-      - Wed, 26 Sep 2018 18:42:15 GMT
+      - Thu, 25 Oct 2018 18:20:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-10-09T18:40:24Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -3511,7 +3346,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -3534,7 +3369,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3397,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-642276ab-271b-461f-a5af-56759e27c005
+      - req-dbeac794-f5fb-4e57-badb-3ace99063e0d
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3441,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3469,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-252d9ef7-d8c1-4445-856d-18aa4cbcc9b0
+      - req-829723aa-5ac5-4e87-ac2d-274489e2a07d
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3494,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3522,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-893ff0be-5bda-4439-8ab4-0a9da6e60f2b
+      - req-89f1c284-1eb8-49c4-ae61-7202a7b21c49
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3557,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-52f5b87a-346d-43d0-b176-3610ce729a24
+      - req-7457678c-962a-4e38-8b70-a7840a09a083
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3592,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-bfbf3f0b-0ea3-4589-a196-044242e7c65f
+      - req-4dd8c614-5821-42a3-8bd3-ff545b428773
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3790,9 +3625,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fb68d564-dbac-49ca-a8b8-8495722c64d7
+      - req-ef2bdb2b-c584-4321-aab2-cdcce8cdf0ee
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3683,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3874,9 +3709,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7dee2464-89c3-4348-a035-d72b99dc1e05
+      - req-45480488-8dfc-44f8-9a74-814c84b467ae
       Date:
-      - Wed, 26 Sep 2018 18:42:16 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3723,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3914,9 +3749,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2c5bc9bb-8045-43cf-a4ce-29b67dba6d22
+      - req-40614a3f-873a-45f0-8062-06a519fdd0ce
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3807,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6828005cc3a44811b0dff05b8ccb9f7b
+      - 14b86404e1d5474d8aad1f054ba61dfd
   response:
     status:
       code: 200
@@ -3998,9 +3833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-35b13e12-277b-47d9-a512-97ca88714c42
+      - req-7ad6a91d-9280-4854-9267-522f4e67b4cd
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +3847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-cc5b6520-a379-4575-8050-f7818384cdcd
+      - req-942a07eb-a506-41d9-9215-94466a07b449
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +3886,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 533069a8e9aa43759a924cd3ae11e922
+      - d0617893a7d8498ca571b7000e867f85
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-dcbde47e-cc81-4f0a-8b61-bac76fa78421
+      - req-cbc24310-035e-4ba4-887b-355ed854ba7a
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +3925,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +3940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +3953,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-164aa3de-3533-48d8-8aef-925443709166
+      - req-fa2dee29-da8b-45fe-a703-1d88cf235743
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +3964,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +3979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82d823b480e44b3abc1b0b0c3655c345
+      - e2862124e07c4ce98c3440bfb1f0310d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +3992,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3a23f435-8652-409b-a4e3-8378dbd542a8
+      - req-c77a4b44-4113-48c9-b3ac-29878d79966d
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4003,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4021,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:17 GMT
+      - Thu, 25 Oct 2018 18:20:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cf98052-f0a0-4de2-a8c8-577d6764ceac
+      - req-c1fa9909-3b72-4ced-83dc-395798b7162e
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4036,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:17.761653", "expires":
-        "2018-09-26T19:42:17Z", "id": "3dbb010f61c44bbc8aff371db37863c6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:51.926966", "expires":
+        "2018-10-25T19:20:51Z", "id": "6c97ee060d61417eaeffaac7986bfdaa", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["eO_buT8GRPuIVESF8gy0rA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v2ll89LBR4WNw0OTw-i0gg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4083,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4098,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f66edebb-1d68-4776-816c-5aec1586b9c9
+      - req-38a1cc38-24bd-4e9d-8387-a91fe875c17a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f66edebb-1d68-4776-816c-5aec1586b9c9
+      - req-38a1cc38-24bd-4e9d-8387-a91fe875c17a
       Date:
-      - Wed, 26 Sep 2018 18:42:18 GMT
+      - Thu, 25 Oct 2018 18:20:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4123,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4141,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:18 GMT
+      - Thu, 25 Oct 2018 18:20:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec9dd92d-9458-463b-b073-06c17cd60ba0
+      - req-06b3e9da-5b09-4e81-b143-d90942a45abc
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4156,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:18.245822", "expires":
-        "2018-09-26T19:42:18Z", "id": "104564f1723b407d800c7004651179d6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:52.472851", "expires":
+        "2018-10-25T19:20:52Z", "id": "0461dcd5f0b34aa997bbcda22fbb5a80", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["srsqf4s0RnqBVQZSvzduqA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gqULNIuBRg-TAHeoNYspVA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4203,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4218,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 104564f1723b407d800c7004651179d6
+      - 0461dcd5f0b34aa997bbcda22fbb5a80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c29d026-a898-4a92-9ca7-d1201935badb
+      - req-b770eaca-867b-4e8a-8336-52a62926f75d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3c29d026-a898-4a92-9ca7-d1201935badb
+      - req-b770eaca-867b-4e8a-8336-52a62926f75d
       Date:
-      - Wed, 26 Sep 2018 18:42:18 GMT
+      - Thu, 25 Oct 2018 18:20:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4243,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4258,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae212f8d-ca68-4202-9119-8b2e4fe2eb87
+      - req-4cfb2bf3-fce6-4724-b166-280c94b93584
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ae212f8d-ca68-4202-9119-8b2e4fe2eb87
+      - req-4cfb2bf3-fce6-4724-b166-280c94b93584
       Date:
-      - Wed, 26 Sep 2018 18:42:18 GMT
+      - Thu, 25 Oct 2018 18:20:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4283,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4301,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:18 GMT
+      - Thu, 25 Oct 2018 18:20:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-668e4192-71e5-49eb-9690-f4904980247d
+      - req-0c6a0de9-7cf9-4530-9f64-ee43ca09b39b
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4316,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:19.041946", "expires":
-        "2018-09-26T19:42:19Z", "id": "9681b99ad2214fd3a7cbbe3b70e2bd3d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.276740", "expires":
+        "2018-10-25T19:20:53Z", "id": "a89aa27f3db74247af98b4664ce2b7a3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["34aKS2X7RiaF1OpYqX67Ug"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ny3xvqQcQI2m7XnsOQD8qg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4363,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9681b99ad2214fd3a7cbbe3b70e2bd3d
+      - a89aa27f3db74247af98b4664ce2b7a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-78054352-e7b9-417d-a17a-65998a444d91
+      - req-61ba532b-652c-4a6e-957e-256777bcbee6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-78054352-e7b9-417d-a17a-65998a444d91
+      - req-61ba532b-652c-4a6e-957e-256777bcbee6
       Date:
-      - Wed, 26 Sep 2018 18:42:19 GMT
+      - Thu, 25 Oct 2018 18:20:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4403,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:19 GMT
+      - Thu, 25 Oct 2018 18:20:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2fb33082-4608-41de-ba72-2fc484525a0d
+      - req-1d35d3f5-e014-4699-8cad-85c4fd4f0391
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:19.538761", "expires":
-        "2018-09-26T19:42:19Z", "id": "5b9cea20d2ef4226b5ea96f2518a0a05", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.765450", "expires":
+        "2018-10-25T19:20:53Z", "id": "1cd59edbcf224e6db6ef06e72bc7d90f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["OfEgVtOURda_4DgDV6sKxw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EkyKkqshTXy1ZKQ303eUjw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,39 +4484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:42:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:19 GMT
+      - Thu, 25 Oct 2018 18:20:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbebcd81-96ec-436b-8739-3032c9b22170
+      - req-dc337adf-7448-4fe1-b3e7-dc6cf1f0f85c
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4517,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:19.822519", "expires":
-        "2018-09-26T19:42:19Z", "id": "97eee193a62a4c3dacf3b444f68c44c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:53.944175", "expires":
+        "2018-10-25T19:20:53Z", "id": "aef0c103e73b4b7e8e3cb8fefcfb3b94", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["57MGYW_qQ0mtlS8z-a8YYw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["oT2ZON5ZRjeXoEEwGaY47A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4564,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97eee193a62a4c3dacf3b444f68c44c5
+      - aef0c103e73b4b7e8e3cb8fefcfb3b94
   response:
     status:
       code: 200
@@ -4787,16 +4590,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-20dfd8a5-740d-42df-80ef-518b57b872ef
+      - req-0554a250-852d-4c9a-a3e9-0d1404cf7195
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4617,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28affbc4-3848-46db-af8c-991ca5bbf9e8
+      - req-34a2b2c7-9b08-4988-aa2b-4907e59a29b5
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4632,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:20.197250", "expires":
-        "2018-09-26T19:42:20Z", "id": "53c01147a58b49acb1d55beed30cda55", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:54.275660", "expires":
+        "2018-10-25T19:20:54Z", "id": "fe0510d9d93f4ffdb2389d1acb3f1325", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zi4ID113SMOxe36KGVazNg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Oojl4J5bSXGu1ZWZ8Huugw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4679,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53c01147a58b49acb1d55beed30cda55
+      - fe0510d9d93f4ffdb2389d1acb3f1325
   response:
     status:
       code: 200
@@ -4902,16 +4705,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-83023d40-4c0f-4873-a863-6cc03155648b
+      - req-542a7c32-763b-4dd8-9277-43a40883ab4b
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
+      - 1cd59edbcf224e6db6ef06e72bc7d90f
   response:
     status:
       code: 200
@@ -4937,16 +4740,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9ee85970-b30e-49f1-b7c6-bd5d0883699f
+      - req-4a4805f0-912d-4904-b535-8938cb8c1317
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4767,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e906a1a0-ef10-4fb9-ba89-d4e34ea99bb3
+      - req-f35baea6-569e-400c-ab8f-2f215c55c63c
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4782,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:20.689944", "expires":
-        "2018-09-26T19:42:20Z", "id": "bd66b2d21a304d6cb0728da2bf254faf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:54.737450", "expires":
+        "2018-10-25T19:20:54Z", "id": "43c0d89129c1435a914bf45c29d2710d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["fnvfZxvfSfmB7raqVodyxw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0Ko_xVT_QCSQ3m1YHFNKRQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +4829,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +4844,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd66b2d21a304d6cb0728da2bf254faf
+      - 43c0d89129c1435a914bf45c29d2710d
   response:
     status:
       code: 200
@@ -5052,16 +4855,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-97e62226-f802-41c0-b9a0-79dfe2504c3c
+      - req-c2f04c80-9a2a-45b9-9b56-729c3d96d81a
       Date:
-      - Wed, 26 Sep 2018 18:42:20 GMT
+      - Thu, 25 Oct 2018 18:20:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +4892,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3c63e0b5-6037-494c-b4a6-b9c676b5a9db
+      - req-a61dfaec-9cfe-4e95-8530-4443446685d7
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +4917,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +4932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +4945,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-719c57c9-0b3e-488a-8b5e-166c8f486009
+      - req-2eb3c777-27cb-484d-8ef3-03a7eaedf59c
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +4970,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +4998,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0b697d48-a0b9-40c5-98c7-c0bfc43c1977
+      - req-4912a67a-ce50-4512-ab06-23aaa1cfc073
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5023,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5038,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5051,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d6edf494-4fb7-402e-998a-58f33891e1fa
+      - req-cdda5475-52a5-4dbe-ac79-4dd09f9e9424
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5076,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5104,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a77d98b1-eb88-472c-b5fe-96d0cabc8adc
+      - req-51d81f0a-5b3f-4f4f-94fd-7387d2cf6277
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5129,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5157,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-29a63925-10e5-4554-b33b-a47ff6e478bc
+      - req-8c179ab4-d403-4c8c-9ca1-cd561d8f8021
       Date:
-      - Wed, 26 Sep 2018 18:42:21 GMT
+      - Thu, 25 Oct 2018 18:20:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5180,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5193,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-7adc38e5-9405-445c-9cca-bce7c15d5599
+      - req-057d283c-0781-4ae2-be04-f5358b966a91
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5218,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5246,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-6806909d-0942-4d0a-9144-674c5f3a8661
+      - req-2f1dce31-e998-44ab-bab6-2711f5709bb4
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-628d4708-a57d-4c78-a177-bbad5edfdf75
+      - req-803d6b85-509a-49fa-b679-39bf5a1f8e82
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5307,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5335,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-14f39b6e-379f-4d20-831b-fd7aa47a2e6a
+      - req-3f70b5e7-d8ea-42c8-a595-e8aefbbd447f
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5360,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ce36bb6f2d34af292cc1a7bc600108d
+      - 38e245157a014262a3571406f0b30599
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5388,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-a8ee511b-9078-4fb5-87cd-37b8b7bfac8b
+      - req-ee371727-1782-4a55-9dce-f169da9ac894
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5413,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:22 GMT
+      - Thu, 25 Oct 2018 18:20:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e447914e-8657-4051-b488-058eb2d68a10
+      - req-b3ded2d0-65b9-41d3-b292-454a8c6577cf
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:22.989854", "expires":
-        "2018-09-26T19:42:22Z", "id": "cbc29e8556e54d718a9bd0f68624ec9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:57.004762", "expires":
+        "2018-10-25T19:20:56Z", "id": "24367b3416f048c3af1d2ce7993f2925", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CuYciy_vRceXzYhVm_nBEg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Z_C-5laSRKSOa_fpeKFdmA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,88 +5494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"cbc29e8556e54d718a9bd0f68624ec9a"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-849a973e-f174-4f66-9ea1-c8e4f8d32851
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:23.170779", "expires":
-        "2018-09-26T19:42:22Z", "id": "ad09c1cb2575473f915d9296d9b51ecc", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CTMrs9lFRle3tTog9t2ufA", "CuYciy_vRceXzYhVm_nBEg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1dc5178f-a791-411a-b743-589ff9a2b368
+      - req-ba117b66-ae11-46c9-96b0-409bd09c6a94
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:23.361243", "expires":
-        "2018-09-26T19:42:23Z", "id": "7eb1bb9ca8d74368bc11d3da3dbe3a7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:57.190575", "expires":
+        "2018-10-25T19:20:57Z", "id": "602fe3a88f1743a5a77e883eaa2a88ad", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Fj67U5p8R7mAk6IMBWKu5Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["oBj8Mje_TQ-jg_6pV0dIAA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,88 +5575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7eb1bb9ca8d74368bc11d3da3dbe3a7e"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-db9c7db4-c3e8-4cf1-a884-050cc5791f39
-      Content-Length:
-      - '4196'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:23.545041", "expires":
-        "2018-09-26T19:42:23Z", "id": "4b5942b7059e43738eae67079e4f3e9b", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["G-8dzKx9Tsqte8Ydv-13Fg", "Fj67U5p8R7mAk6IMBWKu5Q"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e83d7c78d4a4416b9419a7c483f14139
+      - 4c1551e76ebe4d2ebb68a4467c6a441e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5603,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-d3bfaafa-8280-4574-8380-5394495295f4
+      - req-2c80cc52-8f09-4cc5-96c1-7bcfea6c4a83
       Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5625,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cde668b0-bac4-46a8-9407-35de32d8c66d
+      - req-1119ad52-a5ba-41e9-a117-dccfa6b990d0
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-cde668b0-bac4-46a8-9407-35de32d8c66d
+      - req-1119ad52-a5ba-41e9-a117-dccfa6b990d0
       Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +5673,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +5688,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-15d45187-5a8e-4d04-bf11-0db1d1d6eee9
+      - req-e5357eac-fc3c-4759-a61f-653b6217e3d9
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-15d45187-5a8e-4d04-bf11-0db1d1d6eee9
+      - req-e5357eac-fc3c-4759-a61f-653b6217e3d9
       Date:
-      - Wed, 26 Sep 2018 18:42:23 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +5720,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +5735,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 104564f1723b407d800c7004651179d6
+      - 0461dcd5f0b34aa997bbcda22fbb5a80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-394d3818-6808-4411-825e-f479092a9727
+      - req-7d4b53eb-3ba3-4a27-b68c-5691d580ac7a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-394d3818-6808-4411-825e-f479092a9727
+      - req-7d4b53eb-3ba3-4a27-b68c-5691d580ac7a
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +5770,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-151bd9b9-b777-4ec0-a32e-1e2e18ce1167
+      - req-7b8f7376-0c7a-4574-9c82-85d6d09f6b21
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-151bd9b9-b777-4ec0-a32e-1e2e18ce1167
+      - req-7b8f7376-0c7a-4574-9c82-85d6d09f6b21
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +5805,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9681b99ad2214fd3a7cbbe3b70e2bd3d
+      - a89aa27f3db74247af98b4664ce2b7a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2186cf3a-663e-44f0-b375-5500d287528c
+      - req-195b270e-8c9b-47a4-b552-730ef2c83f37
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2186cf3a-663e-44f0-b375-5500d287528c
+      - req-195b270e-8c9b-47a4-b552-730ef2c83f37
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +5840,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2bcf1dd-37ca-4ca9-87cc-543d4c4b5fae
+      - req-8adb1d8e-5693-4c56-97fe-1c302c4db1a9
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-e2bcf1dd-37ca-4ca9-87cc-543d4c4b5fae
+      - req-8adb1d8e-5693-4c56-97fe-1c302c4db1a9
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +5870,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +5885,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a091df1a-cbd3-42b1-a0d4-a0e4627bee51
+      - req-e8e03fec-0a0c-4a43-afca-235d09cc2faa
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-a091df1a-cbd3-42b1-a0d4-a0e4627bee51
+      - req-e8e03fec-0a0c-4a43-afca-235d09cc2faa
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +5915,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 104564f1723b407d800c7004651179d6
+      - 0461dcd5f0b34aa997bbcda22fbb5a80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-872e8fd2-b3e6-4138-ab44-c6292d97765b
+      - req-0517c64b-5ba4-4f2e-a065-604cc0b69abd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-872e8fd2-b3e6-4138-ab44-c6292d97765b
+      - req-0517c64b-5ba4-4f2e-a065-604cc0b69abd
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +5965,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 104564f1723b407d800c7004651179d6
+      - 0461dcd5f0b34aa997bbcda22fbb5a80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5cf3853-e299-4c48-a55b-dc55f9e7b5bf
+      - req-93423ba5-bac2-4633-803f-ea982fd88920
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b5cf3853-e299-4c48-a55b-dc55f9e7b5bf
+      - req-93423ba5-bac2-4633-803f-ea982fd88920
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6000,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-444b9549-c44c-475d-8594-1b49150795bf
+      - req-7fd65027-3084-4b9b-9091-95d82a619b8b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-444b9549-c44c-475d-8594-1b49150795bf
+      - req-7fd65027-3084-4b9b-9091-95d82a619b8b
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6035,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ba98b896-cd85-4cff-a189-71c5a0fd8443
+      - req-033f4be7-6a80-47de-8fb4-57187475d60c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ba98b896-cd85-4cff-a189-71c5a0fd8443
+      - req-033f4be7-6a80-47de-8fb4-57187475d60c
       Date:
-      - Wed, 26 Sep 2018 18:42:24 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6070,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9681b99ad2214fd3a7cbbe3b70e2bd3d
+      - a89aa27f3db74247af98b4664ce2b7a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ca42ed4-2988-4280-8d1b-f6a5e2827ee4
+      - req-9a02b611-460c-405b-9cc3-8e9a509667cb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4ca42ed4-2988-4280-8d1b-f6a5e2827ee4
+      - req-9a02b611-460c-405b-9cc3-8e9a509667cb
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6105,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9681b99ad2214fd3a7cbbe3b70e2bd3d
+      - a89aa27f3db74247af98b4664ce2b7a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-835d9b56-e3dd-407c-84e0-bb5604a4a46f
+      - req-b2f3afa3-50f3-44f1-abcc-e823cb13495a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-835d9b56-e3dd-407c-84e0-bb5604a4a46f
+      - req-b2f3afa3-50f3-44f1-abcc-e823cb13495a
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6140,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9bebda01-27e2-4c19-9c8d-fe42caa6231b
+      - req-092a92ad-dcf4-447e-91b4-aff4442ada77
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-9bebda01-27e2-4c19-9c8d-fe42caa6231b
+      - req-092a92ad-dcf4-447e-91b4-aff4442ada77
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:20:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6188,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6203,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6c968cfc-efdb-4bed-9d45-7ac4a6df5daa
+      - req-420fc9c2-ed95-43c0-b687-7cad7f182db8
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-6c968cfc-efdb-4bed-9d45-7ac4a6df5daa
+      - req-420fc9c2-ed95-43c0-b687-7cad7f182db8
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6259,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6274,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00f6aecf-4e53-4eee-94ea-a757a448bc1f
+      - req-0f74ca1e-b7cf-4d04-8bd7-b0da0b46a58e
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-00f6aecf-4e53-4eee-94ea-a757a448bc1f
+      - req-0f74ca1e-b7cf-4d04-8bd7-b0da0b46a58e
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6323,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6338,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3dbb010f61c44bbc8aff371db37863c6
+      - 6c97ee060d61417eaeffaac7986bfdaa
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d104f35e-e983-4ce6-b846-832ce59f97df
+      - req-556b7e33-9471-44a9-a8b6-05dc2c99948e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d104f35e-e983-4ce6-b846-832ce59f97df
+      - req-556b7e33-9471-44a9-a8b6-05dc2c99948e
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6373,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 104564f1723b407d800c7004651179d6
+      - 0461dcd5f0b34aa997bbcda22fbb5a80
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de2c1244-518d-4edb-958d-15ba16484692
+      - req-5e3cbefe-a147-4326-af88-a4f124c51ebd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-de2c1244-518d-4edb-958d-15ba16484692
+      - req-5e3cbefe-a147-4326-af88-a4f124c51ebd
       Date:
-      - Wed, 26 Sep 2018 18:42:25 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6408,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f4695330cb6490a93109f626861e072
+      - e6d583ace24c48059fa12175ffd8d4a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8ff97fc1-961c-4466-b44c-c77a63d38e44
+      - req-005bd2eb-7fdb-4f6e-977c-c17d7fbe81a6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8ff97fc1-961c-4466-b44c-c77a63d38e44
+      - req-005bd2eb-7fdb-4f6e-977c-c17d7fbe81a6
       Date:
-      - Wed, 26 Sep 2018 18:42:26 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6443,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9681b99ad2214fd3a7cbbe3b70e2bd3d
+      - a89aa27f3db74247af98b4664ce2b7a3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c6822e0-fcc6-49ed-a9ac-7cfcd5dc60ba
+      - req-b829ffb7-01c1-40fd-8c0e-2f384dac0b88
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7c6822e0-fcc6-49ed-a9ac-7cfcd5dc60ba
+      - req-b829ffb7-01c1-40fd-8c0e-2f384dac0b88
       Date:
-      - Wed, 26 Sep 2018 18:42:26 GMT
+      - Thu, 25 Oct 2018 18:21:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6481,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:27 GMT
+      - Thu, 25 Oct 2018 18:21:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5676ccac-c94d-4730-a000-a1458e4b3309
+      - req-b54db0d7-ea26-47a1-9793-1c4545ecee00
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6496,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:27.302115", "expires":
-        "2018-09-26T19:42:27Z", "id": "d102f13fcd5a4001801355bf695e752d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:01.777914", "expires":
+        "2018-10-25T19:21:01Z", "id": "aa02163d31384f00a5cfcae5b2be4e82", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DcyAolbyQ7SP_oBqzJ2MtA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mv6jh9n5S_yTAMKAzbfCrA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6544,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6562,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:27 GMT
+      - Thu, 25 Oct 2018 18:21:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-685a4be3-9500-456c-bf3e-a31ff8456999
+      - req-b203f4e5-f696-4d14-9bc9-d6a1fbd0db20
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6577,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:27.479550", "expires":
-        "2018-09-26T19:42:27Z", "id": "84873202ad2d47a1b12629ca99dcb7e7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:01.960457", "expires":
+        "2018-10-25T19:21:01Z", "id": "760b2203b4a84c07b1aed9c8c673ab9f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ar6Ww2c6Q0-zisAGDcoKtA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Kl53PP8FRgCVqm4MIzw_oQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6625,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6640,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -7010,42 +6651,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-98d7ccaa-a85f-4aa3-b8dc-72c20e448e8d
+      - req-d12da784-0dc0-41e1-8e1d-555bef9a94eb
       Date:
-      - Wed, 26 Sep 2018 18:42:27 GMT
+      - Thu, 25 Oct 2018 18:21:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -7070,19 +6681,49 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +6741,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:27 GMT
+      - Thu, 25 Oct 2018 18:21:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8c2b3acb-ee04-43e1-9252-7cbd99366452
+      - req-20cf0b49-a84a-4d3e-a34b-037cc9de08af
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +6756,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:27.858414", "expires":
-        "2018-09-26T19:42:27Z", "id": "f126037bbf13495cad423440a8cc7385", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:02.317749", "expires":
+        "2018-10-25T19:21:02Z", "id": "906152fa897540e1a577b2dec4caeb6a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ORo_4uRJRxCVwmTwiJ_w4g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4ql_v5W9RlSDFNpJcfBeIQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,13 +6804,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7181,13 +6822,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:27 GMT
+      - Thu, 25 Oct 2018 18:21:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ac05d77c-9a94-452d-a9d4-40d138d8d752
+      - req-0227d6a6-be8c-4b10-80bc-74cff0ea2174
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +6837,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:28.005735", "expires":
-        "2018-09-26T19:42:28Z", "id": "a329aa8e683e430a90f9008eb67fca36", "audit_ids":
-        ["UgUE7PINSZ60bIwYHPb_XQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:02.482782", "expires":
+        "2018-10-25T19:21:02Z", "id": "cfc25793645f4f40973c055c612ee7c7", "audit_ids":
+        ["C-1Mdb_TSgqXsOKrf51BmQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +6858,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a329aa8e683e430a90f9008eb67fca36
+      - cfc25793645f4f40973c055c612ee7c7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
+      - Thu, 25 Oct 2018 18:21:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-40275e8a-f1a9-47e9-8c50-22b1e9d3c977
+      - req-66906f65-d5a1-42e0-8659-9f424bdc1f67
       Content-Length:
       - '500'
       Connection:
@@ -7247,133 +6888,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"a329aa8e683e430a90f9008eb67fca36"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-d76ca4a6-9f23-4dc1-bbb4-a4d59bfb8cdc
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:28.299819", "expires":
-        "2018-09-26T19:42:28Z", "id": "af48d68d7b0e47d189ca9dcc73c01e5b", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rES4g7b6Qv2nITY0VU_pcg",
-        "UgUE7PINSZ60bIwYHPb_XQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a329aa8e683e430a90f9008eb67fca36
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-44b7873d-aa7b-4be5-97d8-9a4a11c229f1
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +6906,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
+      - Thu, 25 Oct 2018 18:21:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-baebf62a-663c-4499-bab5-0595043d293b
+      - req-bb9d28ff-8d71-4b70-8716-b7d28a25875c
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +6921,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:28.608238", "expires":
-        "2018-09-26T19:42:28Z", "id": "b8c4aaed117a41a7bcc00a64f0afd620", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.002361", "expires":
+        "2018-10-25T19:21:02Z", "id": "64d3e01064674a56a2ff83cc5d9a0315", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DhiQWxJBR8ONCgTbPvdu3g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yfKh8ZtlSauCticgOD1oJA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +6968,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +6986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bbf8a79e-60b6-447d-8bf3-6fac0bfc3362
+      - req-f029302e-30a4-4a2f-88f4-b60f78cec738
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:28.792570", "expires":
-        "2018-09-26T19:42:28Z", "id": "ea9f513302434c3dae512e3bb761e8c7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.197449", "expires":
+        "2018-10-25T19:21:03Z", "id": "85a54f2fa16244caa1ff2a5ee04da6f9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Jfz7x3bcT-mYOyCEjmZl6A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["EjN4kOf_Su2ZPqpPz8Y7eg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:28 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-953bfa38-0904-42ed-999a-ac53d41d848d
+      - req-dd8f41aa-8a8b-4231-a4e8-f2bf34013005
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7081,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:28.975213", "expires":
-        "2018-09-26T19:42:28Z", "id": "2dd089645a4e4af08cd869e00a79b2e0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.373012", "expires":
+        "2018-10-25T19:21:03Z", "id": "57a58fced9bf48f7be7836ecb3803b5e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jXbX-UngToqr8H5hlTaNbw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["fboWBeyOTYKHG-F48CDLHA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7128,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7146,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:29 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-232a2520-8b32-47a8-bfa6-682a6b1406b4
+      - req-2edeb47b-ea85-48d9-978b-21462ffc0df8
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7161,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:29.158485", "expires":
-        "2018-09-26T19:42:29Z", "id": "6dea2a6c52d6458e9763351cf77b8818", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:03.551855", "expires":
+        "2018-10-25T19:21:03Z", "id": "72f762964a4f48e58e61d8bde21c3461", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IHdriPo5T_iH_I9N0HCAbQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tdJXD7X7S5S5iU3_FSU4CA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7208,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -7719,9 +7234,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-a59140d4-ce70-4fe7-ac83-d25ea8603e52
+      - req-dbcc393a-a5eb-47a0-9bb6-d836aa77f8d0
       Date:
-      - Wed, 26 Sep 2018 18:42:29 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7270,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -7781,14 +7296,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9b9b610d-8fb7-4c03-9c89-1e1ae6aab402
+      - req-168c528d-d45b-4626-9e69-ba29a8e54ebe
       Date:
-      - Wed, 26 Sep 2018 18:42:29 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7321,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:29 GMT
+      - Thu, 25 Oct 2018 18:21:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3191d91a-3740-4a33-9123-71cea0fd5cf1
+      - req-27b77bcc-1e6b-4317-aa83-5e33cbc569b1
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7336,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:29.658530", "expires":
-        "2018-09-26T19:42:29Z", "id": "42435b61769e456a92aa7202e714aef5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:04.045522", "expires":
+        "2018-10-25T19:21:04Z", "id": "ebc687d2d34c412484f25ee22aca813c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dby5SQl2SQmjhfiYIFejVQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["e8pOM7VSREettFAPxmR4GA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7383,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42435b61769e456a92aa7202e714aef5
+      - ebc687d2d34c412484f25ee22aca813c
   response:
     status:
       code: 200
@@ -7894,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d198efb3-3f65-45c1-8076-4d764fa24137
+      - req-775af8d8-26cf-4631-a990-85590f9b885c
       Date:
-      - Wed, 26 Sep 2018 18:42:29 GMT
+      - Thu, 25 Oct 2018 18:21:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f126037bbf13495cad423440a8cc7385
+      - 906152fa897540e1a577b2dec4caeb6a
   response:
     status:
       code: 200
@@ -7927,14 +7442,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8d2a6d91-2ca2-4aa8-93e0-ec399efbb9e7
+      - req-58f83f79-09c3-49fa-9d83-38814235d864
       Date:
-      - Wed, 26 Sep 2018 18:42:30 GMT
+      - Thu, 25 Oct 2018 18:21:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:30 GMT
+      - Thu, 25 Oct 2018 18:21:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2064942-8815-43eb-a94c-8c0cb3c1bc31
+      - req-d354c6b4-365c-4c7d-ae12-128bb6c328f5
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7482,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:30.359137", "expires":
-        "2018-09-26T19:42:30Z", "id": "34e237def1484e23a3acc864c489bf37", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:04.542551", "expires":
+        "2018-10-25T19:21:04Z", "id": "a010a59213e74a079412c85ea8139299", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dF4uP7SIQhCIF2wcQjTsaQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["m2-cPrhlS_WmOq6pMlIB3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +7529,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +7544,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34e237def1484e23a3acc864c489bf37
+      - a010a59213e74a079412c85ea8139299
   response:
     status:
       code: 200
@@ -8040,14 +7555,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-278f5a85-dcae-457e-8eab-d56c487b7de3
+      - req-ba1f3f5d-29a8-49c0-bbf0-66a3c72410e5
       Date:
-      - Wed, 26 Sep 2018 18:42:30 GMT
+      - Thu, 25 Oct 2018 18:21:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +7577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8073,9 +7588,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fc0fd8b2-385b-43d0-8ff9-be3893d97558
+      - req-bf02f9c4-99e8-4e4c-9cae-79b730e8760a
       Date:
-      - Wed, 26 Sep 2018 18:42:30 GMT
+      - Thu, 25 Oct 2018 18:21:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +7617,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +7632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8128,9 +7643,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-82db02e6-1662-42c7-a151-33df4268625f
+      - req-57015872-eb16-44de-8884-9400de3ecbca
       Date:
-      - Wed, 26 Sep 2018 18:42:31 GMT
+      - Thu, 25 Oct 2018 18:21:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +7672,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +7687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8183,9 +7698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a4d0a75d-33b3-471f-8ce4-6c022acfbee0
+      - req-d427be5a-21b8-435e-b0bd-1719d1d73236
       Date:
-      - Wed, 26 Sep 2018 18:42:31 GMT
+      - Thu, 25 Oct 2018 18:21:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +7727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +7742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8238,9 +7753,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-572bd410-b0c9-4a08-bc32-863007c01bc0
+      - req-6733f83e-d7f9-47cd-86c2-7a73270c6b0f
       Date:
-      - Wed, 26 Sep 2018 18:42:31 GMT
+      - Thu, 25 Oct 2018 18:21:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +7767,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +7782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8278,9 +7793,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c09cdc58-240a-4722-9660-9ed70e9a5577
+      - req-5616446a-d646-49d2-b02e-2e3bbcd38688
       Date:
-      - Wed, 26 Sep 2018 18:42:31 GMT
+      - Thu, 25 Oct 2018 18:21:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +7807,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +7822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dea2a6c52d6458e9763351cf77b8818
+      - 72f762964a4f48e58e61d8bde21c3461
   response:
     status:
       code: 200
@@ -8318,9 +7833,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ccbb6ad9-f26b-47a0-8276-75bad6110c01
+      - req-d399e03c-5ff6-43cb-a946-3205410a950a
       Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
+      - Thu, 25 Oct 2018 18:21:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +7847,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +7865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
+      - Thu, 25 Oct 2018 18:21:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7da92944-af64-4e44-a943-086acc1141e9
+      - req-77420475-3fb4-41f5-80a7-063e16a7d496
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +7880,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:32.257906", "expires":
-        "2018-09-26T19:42:32Z", "id": "affe8a6c0d2549ada7aca5157c58b7dc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:06.521939", "expires":
+        "2018-10-25T19:21:06Z", "id": "9cf592f4239141e4b04496837db81aa1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sgP3XRMkSvu-Uyx1sPzIng"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KGaGScEdToGuXuGzaJurKA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +7927,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +7942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -8438,184 +7953,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-118a30e2-e90b-410b-877e-16a8282751a5
+      - req-3b2a987c-5cc0-427f-9b42-a31d1d045e4f
       Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
+      - Thu, 25 Oct 2018 18:21:06 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-597f605a-3796-40c3-a414-e1853f4819a0
-      Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8646,68 +7994,6 @@ http_interactions:
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:32 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fd23eed8-6d3a-4975-ab71-08e56c61dbac
-      Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -8754,34 +8040,90 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 9cf592f4239141e4b04496837db81aa1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-923c35ce-e33a-4919-8231-5b3c81d5c5ff
+      Date:
+      - Thu, 25 Oct 2018 18:21:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8795,20 +8137,61 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8826,13 +8209,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:32 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bde84288-ef70-4ddc-9192-eef0dc13c190
+      - req-7cd7c3c3-1738-41d1-873a-42743337a72d
       Content-Length:
       - '4131'
       Connection:
@@ -8841,10 +8224,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:33.019283", "expires":
-        "2018-09-26T19:42:33Z", "id": "1fc1bf8f6e8d4b1bab114786571dca71", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:07.121681", "expires":
+        "2018-10-25T19:21:07Z", "id": "dbfb886069a446f4b6195c8b336e80d1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hK00hbZEQM2qi12v9JDPfQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["HtWfFsqLR6C757-BOBFlBA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8888,7 +8271,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8903,7 +8286,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -8914,41 +8297,46 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bc6902b0-cab4-4391-accb-3717849c42c6
+      - req-6fc8045b-d2c1-4863-8136-ba928671fe64
       Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -8961,12 +8349,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -8979,34 +8361,35 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9020,7 +8403,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9035,7 +8418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -9046,52 +8429,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-64e2926a-63da-4e70-a7c9-da773fc49001
+      - req-0823f650-ce80-4267-9cc6-3148cd8473b1
       Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -9139,67 +8487,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e809c226-8a45-4f36-b897-cfd1e1e8d7b1
-      Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9212,79 +8516,26 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9299,7 +8550,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -9310,57 +8561,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-337ca463-585a-4d9b-a23f-8c3f1a2422b5
+      - req-a9429755-a611-49c3-9837-ba2b87fe7b0b
       Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -9369,6 +8579,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -9403,138 +8619,41 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e32af6ee-a3ac-43a7-9386-b174ab07794b
-      Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9548,7 +8667,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9563,7 +8682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -9574,12 +8693,47 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d2e7a1ed-3a1a-4ff4-a6a4-ab8cfe3064f9
+      - req-a408488a-b099-468b-b0c2-9beb524e6f93
       Date:
-      - Wed, 26 Sep 2018 18:42:33 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -9626,179 +8780,12 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-20f12fb8-04c4-40a4-9224-506585b4d4b3
-      Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9812,535 +8799,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0fedd146-8955-403d-9683-9b2674a3bbb1
-      Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-60055c11-e0f1-40b6-ac85-e6959c866954
-      Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f66b0d3a-599c-4907-8a63-09b1c6f2f4ac
-      Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6bc2630f-b149-401b-8c5d-e34b727b3107
-      Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10358,13 +8817,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:34 GMT
+      - Thu, 25 Oct 2018 18:21:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6612f4b7-16d7-47d0-b966-0e66d931cd2c
+      - req-9219bb59-b914-4021-8e8c-f2c4b8515370
       Content-Length:
       - '4118'
       Connection:
@@ -10373,10 +8832,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:35.050718", "expires":
-        "2018-09-26T19:42:35Z", "id": "22e979724b344672bb14dcf6a049c9bc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:08.034464", "expires":
+        "2018-10-25T19:21:08Z", "id": "62bde9868b734c38b919ebbf540a06f6", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hXEvnrP1TziPV04OyRfXzQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Pmn4h71VRKmgfcfC-DtfIA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -10420,7 +8879,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -10435,7 +8894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -10446,41 +8905,46 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ffed9fd8-7cc2-42a7-b6b2-3def2d4b16ab
+      - req-a0bbe52d-03e3-4c7b-9902-2515e6843f83
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -10493,12 +8957,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -10511,34 +8969,35 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -10552,7 +9011,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -10567,7 +9026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -10578,12 +9037,47 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3002b50d-2c5a-4efe-8264-39330734e658
+      - req-f5c07280-c691-4e65-9617-8b49a51beac8
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -10630,193 +9124,26 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0e99860f-b051-4622-b409-4a4e93815e44
-      Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10831,7 +9158,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -10842,9 +9169,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-d57f42df-3424-4bf8-b49e-cf39aa988839
+      - req-69496a14-8c4c-4b59-82cb-e37353c03095
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10886,7 +9213,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10901,7 +9228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -10912,9 +9239,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-60d0b4b1-e07f-4ac9-a9d8-ccf2ba3376f6
+      - req-6b66f5ff-3575-4be3-86c8-819cb299f47e
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10956,7 +9283,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10971,7 +9298,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -10982,9 +9309,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-764c6800-d207-4be7-b047-5de8e84d8989
+      - req-eb2ff672-4e06-4e15-8523-b829a8201957
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11026,7 +9353,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11041,7 +9368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -11052,9 +9379,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-24a13ea4-b154-404d-8784-1a1fc83d4545
+      - req-6ee227a9-4856-44da-a751-29340b4bcd17
       Date:
-      - Wed, 26 Sep 2018 18:42:35 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11096,7 +9423,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -11111,7 +9438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -11122,9 +9449,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-56b320ce-9526-4663-930d-2352b7375310
+      - req-f325517e-9d16-4b97-aa2a-e1dc53bc91fd
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11166,7 +9493,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11181,7 +9508,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -11192,9 +9519,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-30231512-6b39-4977-931b-6262093f129e
+      - req-e5e88dea-b217-4f09-884f-4b28d8404fd4
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11236,7 +9563,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -11251,7 +9578,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -11262,9 +9589,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-931621cc-683c-406c-8b32-bf25130d12af
+      - req-8cb7a449-15be-4c83-a85e-50e224c172a8
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11306,7 +9633,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -11321,7 +9648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -11332,9 +9659,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-dbc00657-8338-4f38-8a76-51b0311c8f14
+      - req-130f5e79-0173-42a9-86a5-04ead7cac951
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -11376,7 +9703,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11391,7 +9718,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -11402,9 +9729,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-cae5ad60-cd06-4ea4-89ff-e0e16f662987
+      - req-f13652d8-6cac-4333-9fcf-8ef9adc206e3
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11807,7 +10134,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11822,7 +10149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -11833,9 +10160,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-56b0655d-d0f5-48e6-b2e7-728136c57a25
+      - req-89e86738-fc3c-402e-9dfb-bfa850035a81
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12238,7 +10565,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12253,7 +10580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -12264,9 +10591,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-1856b20c-3b55-4c12-84ff-02a95c895ef9
+      - req-01f62995-f07e-4ad6-b303-c0cf044e01fd
       Date:
-      - Wed, 26 Sep 2018 18:42:36 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12669,7 +10996,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12684,7 +11011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -12695,9 +11022,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fb3d92ff-6b81-410d-8aa3-3da8275fb2df
+      - req-264d7f70-0555-4740-85a8-287cbe246170
       Date:
-      - Wed, 26 Sep 2018 18:42:37 GMT
+      - Thu, 25 Oct 2018 18:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13100,7 +11427,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13115,7 +11442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -13126,9 +11453,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5e9849af-5559-4846-8d17-e0d55b78cd3d
+      - req-de9ab0cf-0805-4738-8b47-f318fa458e10
       Date:
-      - Wed, 26 Sep 2018 18:42:37 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13531,7 +11858,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13546,7 +11873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -13557,9 +11884,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4567673b-c9a4-416a-949f-3cca3c08f993
+      - req-6d2ca450-c14d-4d68-af8f-91d03d81e420
       Date:
-      - Wed, 26 Sep 2018 18:42:37 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13962,7 +12289,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -13977,7 +12304,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -13988,9 +12315,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3f817937-57e0-4793-80b1-f7ded5763614
+      - req-fcf82ddf-e35a-47a4-8afe-d355a51f7090
       Date:
-      - Wed, 26 Sep 2018 18:42:37 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14393,7 +12720,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -14408,7 +12735,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -14419,9 +12746,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-fa755255-303b-49dc-9154-f0a2daa15e28
+      - req-101feee1-4574-41b3-b02e-589491ef9778
       Date:
-      - Wed, 26 Sep 2018 18:42:37 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -14824,7 +13151,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14839,7 +13166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -14850,9 +13177,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-816fd870-fa0c-4a21-afe5-30719d9bc314
+      - req-5f0cc14e-b65e-4991-983a-baba175ea8f1
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14884,7 +13211,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14899,7 +13226,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -14910,9 +13237,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-35eb353c-df3d-4d62-9e2b-bbad21f20169
+      - req-f83f3dd0-48f6-441a-bf2b-ed1590dc2a0d
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14944,7 +13271,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14959,7 +13286,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -14970,9 +13297,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3a18b038-7369-4801-8ad3-fdf3c0b39900
+      - req-deba776c-df4a-447c-91a0-a1d6d322c10b
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15004,7 +13331,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -15019,7 +13346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -15030,9 +13357,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e762820b-a2ce-4f26-8b42-5e69299bb9bf
+      - req-91d761df-e059-44c2-bca2-633cd62e9409
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15064,7 +13391,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -15079,7 +13406,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -15090,9 +13417,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-bfefd50f-8f12-4a95-a3c8-f7e4f48988e2
+      - req-b9c5c42f-cc4e-427f-8afc-50284225da60
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15124,7 +13451,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -15139,7 +13466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -15150,9 +13477,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2e40769f-0e28-4b80-84a0-7e97c56f0c5a
+      - req-ac0fa52c-66ec-4a2d-9abd-f71a30c51212
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15184,7 +13511,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -15199,7 +13526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -15210,9 +13537,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b5d3a587-fe37-4ec1-9c99-b8e158d0c318
+      - req-08840a69-707a-4a98-9b93-e67c7c15e911
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15244,7 +13571,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -15259,7 +13586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -15270,9 +13597,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-6f3835fb-fbdd-49fd-a97d-e0d52503e347
+      - req-54899449-af0c-468c-896a-c7a741175507
       Date:
-      - Wed, 26 Sep 2018 18:42:38 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -15304,7 +13631,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15319,7 +13646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -15330,9 +13657,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d53fa2ba-e1b9-4d86-a5d2-09a6a332c514
+      - req-fd1b37ab-f6a4-4566-a256-bc64de9fe22d
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15374,7 +13701,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15389,7 +13716,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -15400,9 +13727,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-ff6e3011-e473-4951-950a-f5da43c30efa
+      - req-2bc26cda-130d-4173-b343-4a248f926d7f
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15445,7 +13772,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15460,7 +13787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -15471,9 +13798,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-fce957ec-66df-4d82-b01e-58c172558fdb
+      - req-f7ac9d2a-ca36-4c2b-a3b0-0b64e0b85b27
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15508,7 +13835,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15523,7 +13850,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - affe8a6c0d2549ada7aca5157c58b7dc
+      - 9cf592f4239141e4b04496837db81aa1
   response:
     status:
       code: 200
@@ -15534,9 +13861,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-31c20523-7973-4f3f-b6a8-755c6d0127c6
+      - req-4657924b-8941-4c98-99d8-ef4b08da51f6
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15623,7 +13950,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15638,7 +13965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -15649,9 +13976,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-de72202f-a984-4609-80c2-698d97d4887a
+      - req-d54e76fd-85cd-49e6-aa76-a410ff800357
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15693,7 +14020,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15708,7 +14035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -15719,9 +14046,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a155bff8-5413-4f0b-bb87-d6500ad9b112
+      - req-d8d6d9d7-7ac1-4d76-b3e8-3c570b95d0aa
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15764,7 +14091,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15779,7 +14106,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -15790,9 +14117,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-72ef0552-8661-4adb-a046-c59c4cf2d0d6
+      - req-2a17f46c-fa81-4dd4-b477-9f4e49170551
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15827,7 +14154,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15842,7 +14169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fc1bf8f6e8d4b1bab114786571dca71
+      - dbfb886069a446f4b6195c8b336e80d1
   response:
     status:
       code: 200
@@ -15853,9 +14180,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-d7b42687-e0d3-47f3-b1c8-3dd218b2cc62
+      - req-3666e7da-fdd6-4216-94a5-9cfd1a2192b4
       Date:
-      - Wed, 26 Sep 2018 18:42:39 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15942,7 +14269,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:39 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15957,7 +14284,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -15968,9 +14295,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-65721ec3-e22e-4965-a064-d2130fe82dd6
+      - req-fcb15067-7921-452a-840f-1105a9f7984d
       Date:
-      - Wed, 26 Sep 2018 18:42:40 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -16012,7 +14339,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -16027,7 +14354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -16038,9 +14365,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-dff74596-fa0f-46bc-baeb-4630a69a3ce4
+      - req-37c9f231-8e87-4689-b2de-a42cb380cdfd
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -16083,7 +14410,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -16098,7 +14425,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -16109,9 +14436,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-ab188213-38ae-4aa2-ae83-f44e6fc18056
+      - req-2bda4f40-1674-48bc-9084-4c73c988d729
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -16146,7 +14473,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -16161,7 +14488,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84873202ad2d47a1b12629ca99dcb7e7
+      - 760b2203b4a84c07b1aed9c8c673ab9f
   response:
     status:
       code: 200
@@ -16172,9 +14499,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-39442b19-ebe6-4dfa-9dff-73aeb4f42394
+      - req-264ec232-cfb2-450b-a374-27a3b18174f0
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -16261,7 +14588,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -16276,7 +14603,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -16287,9 +14614,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f2e696b2-2887-44d7-aa3c-a5d2b046de08
+      - req-baf256bc-18d5-4255-9af3-afdbe8327599
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -16331,7 +14658,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -16346,7 +14673,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -16357,9 +14684,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-01ea6707-d5af-4291-8a65-dde0645953b3
+      - req-ede57b8f-1040-4a39-bdc5-1b44c0a72979
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -16402,7 +14729,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -16417,7 +14744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -16428,9 +14755,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-b7ff6783-d8c3-4862-84aa-56bcf2a5c444
+      - req-92d58dcb-ceed-42c4-83fb-a9240f66479e
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -16465,7 +14792,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -16480,7 +14807,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 22e979724b344672bb14dcf6a049c9bc
+      - 62bde9868b734c38b919ebbf540a06f6
   response:
     status:
       code: 200
@@ -16491,9 +14818,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-1e44bf7a-6f3a-463c-bfc4-127825d8590e
+      - req-4ed0a935-5172-42f3-9795-15fbc91439f9
       Date:
-      - Wed, 26 Sep 2018 18:42:41 GMT
+      - Thu, 25 Oct 2018 18:21:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -16580,7 +14907,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:41 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16598,13 +14925,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:42 GMT
+      - Thu, 25 Oct 2018 18:21:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b341b6f-b724-4a60-b6e3-1e2ffad418ae
+      - req-dc788efe-315a-406c-8b5b-4495f0f3b0e7
       Content-Length:
       - '4170'
       Connection:
@@ -16613,10 +14940,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:42.323776", "expires":
-        "2018-09-26T19:42:42Z", "id": "c12aa057c08345038bf88f621fd30fad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.328745", "expires":
+        "2018-10-25T19:21:14Z", "id": "89ceb1c8d66a424ebf627fbcd08db792", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ol6h13i8TzCjKUozX4D5rA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PIIuMwTqSrG7P7eL2Vmr4g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16661,7 +14988,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16679,13 +15006,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:42 GMT
+      - Thu, 25 Oct 2018 18:21:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4088dcee-5930-4fb5-9ac5-ab74a2db46d0
+      - req-33071a01-f093-41d2-a89c-2a8669fd8fbd
       Content-Length:
       - '4170'
       Connection:
@@ -16694,10 +15021,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:42.510554", "expires":
-        "2018-09-26T19:42:42Z", "id": "f769d9060839475f8b15092033fc1dd3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.529666", "expires":
+        "2018-10-25T19:21:14Z", "id": "f5457a181dda4b939d613aff7e636b27", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["SPmRHA5ST3e6VsnngdYIkQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["t-tfuec4TwKWRRraQihu0Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16742,13 +15069,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -16760,13 +15087,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:42 GMT
+      - Thu, 25 Oct 2018 18:21:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c7516ef-f846-46de-984e-3752b6881506
+      - req-02671a97-494f-4907-b53f-d61473b79d79
       Content-Length:
       - '370'
       Connection:
@@ -16775,13 +15102,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:42.664210", "expires":
-        "2018-09-26T19:42:42Z", "id": "99dff8aeb24e4fbf915e76fb251262f1", "audit_ids":
-        ["Q0c-0sLuRMWHrz3iU5HQ0Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.679665", "expires":
+        "2018-10-25T19:21:14Z", "id": "11e47e3d30084de6986a3cc1683c249f", "audit_ids":
+        ["PyqyRXPrRVCauvPlXo2K6A"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:42 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16796,20 +15123,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99dff8aeb24e4fbf915e76fb251262f1
+      - 11e47e3d30084de6986a3cc1683c249f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:42 GMT
+      - Thu, 25 Oct 2018 18:21:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-21c56176-1caa-4440-acc7-c48893142090
+      - req-dcee983e-25fb-4901-bec5-af44a18efbf1
       Content-Length:
       - '500'
       Connection:
@@ -16826,133 +15153,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:42 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"99dff8aeb24e4fbf915e76fb251262f1"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:42 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-ac596415-e4b0-4c24-abe9-d23d8920ef8c
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:42.976062", "expires":
-        "2018-09-26T19:42:42Z", "id": "677407e052b846f3aa7a416dfc0ab8ce", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qpgKOQcAQUOQeycZ6ovAFw",
-        "Q0c-0sLuRMWHrz3iU5HQ0Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 99dff8aeb24e4fbf915e76fb251262f1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:43 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-6eb892d5-97b5-407c-bf3f-b8a8e971f97a
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16970,13 +15171,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:43 GMT
+      - Thu, 25 Oct 2018 18:21:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c371f126-dc6c-474e-98ff-1895216c4932
+      - req-cd164a76-c5af-4b82-8acc-803a862a4647
       Content-Length:
       - '4117'
       Connection:
@@ -16985,10 +15186,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:43.299297", "expires":
-        "2018-09-26T19:42:43Z", "id": "69c56c8411754fb186cfefa0512441e7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:14.987911", "expires":
+        "2018-10-25T19:21:14Z", "id": "79203508f4e54c38b405c3cd82ca963d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DGTWuW0JSr2WADbjF1B6Vg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Ga8F5F-zS7KMe6QMc79KDA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17032,7 +15233,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17050,13 +15251,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:43 GMT
+      - Thu, 25 Oct 2018 18:21:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2b96893-a8d5-44cd-b9dc-4908bcce3748
+      - req-6284a4dc-628d-425f-a9f4-14c357ab2f2f
       Content-Length:
       - '4131'
       Connection:
@@ -17065,10 +15266,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:43.481448", "expires":
-        "2018-09-26T19:42:43Z", "id": "696477749e834a1a86b00cbf3744108f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.200010", "expires":
+        "2018-10-25T19:21:15Z", "id": "c4e87db96afb44a7814e7ee8c4b7d17d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Kn2SeH1bRXyR7YcOz4IUug"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9flt6kkqRdKU54g9S_RbsQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17112,7 +15313,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17130,13 +15331,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:43 GMT
+      - Thu, 25 Oct 2018 18:21:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d02c5369-4a1a-41b5-a52f-16327398b985
+      - req-09b3737f-c34d-4a29-970f-809c195a11a3
       Content-Length:
       - '4118'
       Connection:
@@ -17145,10 +15346,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:43.670612", "expires":
-        "2018-09-26T19:42:43Z", "id": "9e7ba8efbf91454fa860fd09194d2f53", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.382445", "expires":
+        "2018-10-25T19:21:15Z", "id": "57d5fa8c300f4b998ed25afca629b962", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_uDcS9dtRKmqAuzQsYbyOg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g85XElk4RTGD_aqh9CYYFg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17192,7 +15393,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17210,13 +15411,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:43 GMT
+      - Thu, 25 Oct 2018 18:21:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc3162a1-577d-499d-b473-c79245328e08
+      - req-44663002-417d-4bd6-85c0-8c58f80b40e5
       Content-Length:
       - '4117'
       Connection:
@@ -17225,10 +15426,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:43.850652", "expires":
-        "2018-09-26T19:42:43Z", "id": "41df6850ef26414ca583a055f4b84dc3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:15.558540", "expires":
+        "2018-10-25T19:21:15Z", "id": "b85769cdd65a481084dabca28af7ca2c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wwUknv3uRciGJcqhjzschg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gn8ZY8MdQMKGGm84zy-SkQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17272,7 +15473,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:43 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -17287,22 +15488,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86b58501-a3bf-4491-a5da-5ebe44fbe18c
+      - req-17614a7d-8961-49cb-8bc9-53a41dc7a00b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-86b58501-a3bf-4491-a5da-5ebe44fbe18c
+      - req-17614a7d-8961-49cb-8bc9-53a41dc7a00b
       Date:
-      - Wed, 26 Sep 2018 18:42:44 GMT
+      - Thu, 25 Oct 2018 18:21:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -17335,7 +15536,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -17350,22 +15551,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e3a9e2d2-9933-471d-ae11-5a2ec515126d
+      - req-ee8eb45e-cdf4-407d-a68d-97683f7a70ef
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-e3a9e2d2-9933-471d-ae11-5a2ec515126d
+      - req-ee8eb45e-cdf4-407d-a68d-97683f7a70ef
       Date:
-      - Wed, 26 Sep 2018 18:42:44 GMT
+      - Thu, 25 Oct 2018 18:21:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -17406,7 +15607,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -17421,22 +15622,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-955335aa-dd58-4f3d-bd3d-939ba4955cdb
+      - req-11895812-0509-4f44-9374-99494cd19a6a
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-955335aa-dd58-4f3d-bd3d-939ba4955cdb
+      - req-11895812-0509-4f44-9374-99494cd19a6a
       Date:
-      - Wed, 26 Sep 2018 18:42:44 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -17470,7 +15671,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -17485,27 +15686,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2ad14d44-8395-439f-bd56-392ad7825e2c
+      - req-42da9c2d-b297-468f-b965-d61cb9670dac
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2ad14d44-8395-439f-bd56-392ad7825e2c
+      - req-42da9c2d-b297-468f-b965-d61cb9670dac
       Date:
-      - Wed, 26 Sep 2018 18:42:44 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17523,13 +15724,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:44 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e3d71b0-f1e3-4879-81a5-38e4d302105a
+      - req-60637d60-7f23-4494-a79b-3ae9c61b71b1
       Content-Length:
       - '4131'
       Connection:
@@ -17538,10 +15739,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:44.839795", "expires":
-        "2018-09-26T19:42:44Z", "id": "4e793257eca94bc398a5572888ee23fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:16.435898", "expires":
+        "2018-10-25T19:21:16Z", "id": "1346862440464cab9413b733b6939f88", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["QbWjrnJCSCqj4D1n1hmOWw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yHs-Pu9DRuy3xqL4KxxG5g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17585,7 +15786,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:44 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -17600,27 +15801,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9649554e-8908-471e-a220-705da28242ba
+      - req-deb68cc4-006f-4bb1-88ba-30908016b759
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9649554e-8908-471e-a220-705da28242ba
+      - req-deb68cc4-006f-4bb1-88ba-30908016b759
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -17635,27 +15836,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6f1be2a5-c1f1-454c-a6c8-e0338c1cc6a4
+      - req-cbe3a09d-f026-4adf-b0a9-812c0a15c90d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6f1be2a5-c1f1-454c-a6c8-e0338c1cc6a4
+      - req-cbe3a09d-f026-4adf-b0a9-812c0a15c90d
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17673,13 +15874,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32f159c4-02e2-487c-ae6a-6c359c772dc0
+      - req-52f19094-3604-49b5-a0a4-5992ed2ca878
       Content-Length:
       - '4118'
       Connection:
@@ -17688,10 +15889,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:45.382814", "expires":
-        "2018-09-26T19:42:45Z", "id": "8733e9460fbb418abb475fbeb0c61959", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:17.038479", "expires":
+        "2018-10-25T19:21:17Z", "id": "cd218f4caea44b4cab83a6643d21d23d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FLO9rKhlRS-1OchJDF5qyQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-EV9wEKzRLu4yUM2D4kCig"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17735,7 +15936,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -17750,27 +15951,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-849f1a65-abfa-4be1-b2c1-4c7b9708402f
+      - req-a0958315-a808-49ee-807a-47f97401c4ab
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-849f1a65-abfa-4be1-b2c1-4c7b9708402f
+      - req-a0958315-a808-49ee-807a-47f97401c4ab
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -17785,22 +15986,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd170e0a-5d0f-4e19-8cc5-7518bdfcb121
+      - req-80b77b80-f5a9-4698-a541-ee3d8e4b5f70
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-dd170e0a-5d0f-4e19-8cc5-7518bdfcb121
+      - req-80b77b80-f5a9-4698-a541-ee3d8e4b5f70
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17815,7 +16016,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -17830,22 +16031,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3e382cb-818e-4b3a-8d03-697093841605
+      - req-ee0bbbed-632b-4264-bc29-01819c17ae4f
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-b3e382cb-818e-4b3a-8d03-697093841605
+      - req-ee0bbbed-632b-4264-bc29-01819c17ae4f
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -17860,7 +16061,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -17875,27 +16076,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9461fb4d-8530-49db-95dd-92f438d2524d
+      - req-24be1626-c233-4c67-a4da-5d7afdd38eec
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9461fb4d-8530-49db-95dd-92f438d2524d
+      - req-24be1626-c233-4c67-a4da-5d7afdd38eec
       Date:
-      - Wed, 26 Sep 2018 18:42:45 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:45 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -17910,27 +16111,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-77a86f7a-a209-4997-b14c-d15e09577bae
+      - req-8b87b3ed-64e1-434a-8a29-5002aa22936c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-77a86f7a-a209-4997-b14c-d15e09577bae
+      - req-8b87b3ed-64e1-434a-8a29-5002aa22936c
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -17945,27 +16146,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed49e45a-539a-4dec-b15d-fe6c042e01c4
+      - req-ff9f24bd-c7ef-4129-95cd-48eac79b6b01
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ed49e45a-539a-4dec-b15d-fe6c042e01c4
+      - req-ff9f24bd-c7ef-4129-95cd-48eac79b6b01
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -17980,27 +16181,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eb35f64f-6d54-4557-9717-5a60c237e98b
+      - req-674ad204-0fcd-4a7a-a96f-49dd76bb30ab
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-eb35f64f-6d54-4557-9717-5a60c237e98b
+      - req-674ad204-0fcd-4a7a-a96f-49dd76bb30ab
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -18015,27 +16216,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f9b876bf-4c6e-442c-bf82-d45bcb3884d9
+      - req-120d8180-0bc8-410b-8d6f-62eb03b39b35
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f9b876bf-4c6e-442c-bf82-d45bcb3884d9
+      - req-120d8180-0bc8-410b-8d6f-62eb03b39b35
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -18050,27 +16251,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-323a3401-86c5-4244-9f1b-8b1015df2ba4
+      - req-802cfc1f-ecbf-47d9-840f-71207f1885f8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-323a3401-86c5-4244-9f1b-8b1015df2ba4
+      - req-802cfc1f-ecbf-47d9-840f-71207f1885f8
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -18085,27 +16286,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-251f1fb3-c707-4b8d-9551-1854fb7d2d1e
+      - req-6b51d03e-c352-4a5b-889e-0234c314d911
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-251f1fb3-c707-4b8d-9551-1854fb7d2d1e
+      - req-6b51d03e-c352-4a5b-889e-0234c314d911
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -18120,27 +16321,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-06cb22f9-7ddb-49aa-9438-6f2cc3999ae6
+      - req-4c0271b5-f9a3-4fa2-bb61-47aa3f2c96b0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-06cb22f9-7ddb-49aa-9438-6f2cc3999ae6
+      - req-4c0271b5-f9a3-4fa2-bb61-47aa3f2c96b0
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -18155,27 +16356,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a26beb1-7dbb-40d1-ab25-ae5e00421bed
+      - req-63bebd6f-cf8f-487c-a0e1-ece783cc1e3f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8a26beb1-7dbb-40d1-ab25-ae5e00421bed
+      - req-63bebd6f-cf8f-487c-a0e1-ece783cc1e3f
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -18190,27 +16391,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-823ae754-f7cd-40ff-948a-5bbcd58ef0c7
+      - req-23af9590-1851-47a7-a28d-064e72f6cc61
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-823ae754-f7cd-40ff-948a-5bbcd58ef0c7
+      - req-23af9590-1851-47a7-a28d-064e72f6cc61
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -18225,27 +16426,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73eda27e-d460-499d-a04b-71edf833f690
+      - req-17dc64ec-ade5-4869-bfec-5e5ee47c5c3f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-73eda27e-d460-499d-a04b-71edf833f690
+      - req-17dc64ec-ade5-4869-bfec-5e5ee47c5c3f
       Date:
-      - Wed, 26 Sep 2018 18:42:46 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:46 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -18260,27 +16461,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f923f5a-c45b-4360-b004-420c0caea3da
+      - req-b570dedc-1fef-46da-89c1-a1029d7a7615
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4f923f5a-c45b-4360-b004-420c0caea3da
+      - req-b570dedc-1fef-46da-89c1-a1029d7a7615
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -18295,27 +16496,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-667342be-f2e3-4aac-8fd2-f90182fc42be
+      - req-23ff4da1-f622-4e47-8c65-9405d40f145b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-667342be-f2e3-4aac-8fd2-f90182fc42be
+      - req-23ff4da1-f622-4e47-8c65-9405d40f145b
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -18330,27 +16531,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d02ec9c6-62e3-4135-baae-08fd24a1161b
+      - req-7393fe52-5f2a-4769-8168-45f0436ccf18
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d02ec9c6-62e3-4135-baae-08fd24a1161b
+      - req-7393fe52-5f2a-4769-8168-45f0436ccf18
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -18365,22 +16566,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0758647d-b5e8-4636-a947-7cc09c3425d4
+      - req-d7a833f1-910a-4790-9103-66343928fc83
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0758647d-b5e8-4636-a947-7cc09c3425d4
+      - req-d7a833f1-910a-4790-9103-66343928fc83
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18392,7 +16593,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -18407,22 +16608,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41df6850ef26414ca583a055f4b84dc3
+      - b85769cdd65a481084dabca28af7ca2c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f0d729be-2ba1-4469-af66-8c2b39016628
+      - req-9f49b49f-8483-49d2-9801-3df45aa860de
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f0d729be-2ba1-4469-af66-8c2b39016628
+      - req-9f49b49f-8483-49d2-9801-3df45aa860de
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18434,7 +16635,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -18449,22 +16650,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bda38bad-7307-4483-9cb8-f3dc8d1c17eb
+      - req-67fccc65-4783-41fe-b0b8-f1294f9f7d59
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-bda38bad-7307-4483-9cb8-f3dc8d1c17eb
+      - req-67fccc65-4783-41fe-b0b8-f1294f9f7d59
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18476,7 +16677,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -18491,22 +16692,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e793257eca94bc398a5572888ee23fc
+      - 1346862440464cab9413b733b6939f88
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2566910-b3e4-487e-b161-4acd85f23f3e
+      - req-81ddeb9a-feab-44f2-a9b4-58b712f6ea3c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f2566910-b3e4-487e-b161-4acd85f23f3e
+      - req-81ddeb9a-feab-44f2-a9b4-58b712f6ea3c
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18518,7 +16719,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -18533,22 +16734,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-59b5b385-8303-438c-85aa-1066e9b8b9da
+      - req-e807f871-b781-4712-800d-4d9a24967d7b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-59b5b385-8303-438c-85aa-1066e9b8b9da
+      - req-e807f871-b781-4712-800d-4d9a24967d7b
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18560,7 +16761,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -18575,22 +16776,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f769d9060839475f8b15092033fc1dd3
+      - f5457a181dda4b939d613aff7e636b27
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-412938a9-eb5d-46f8-b285-0170e0e6a2b9
+      - req-1dbf1943-00cb-489a-b6c6-db0657cd8dc8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-412938a9-eb5d-46f8-b285-0170e0e6a2b9
+      - req-1dbf1943-00cb-489a-b6c6-db0657cd8dc8
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18602,7 +16803,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -18617,22 +16818,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0aebd119-306d-4577-b55e-af18153db0bc
+      - req-d418becb-9a5b-4fd0-9a3d-c24bac759318
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0aebd119-306d-4577-b55e-af18153db0bc
+      - req-d418becb-9a5b-4fd0-9a3d-c24bac759318
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18644,7 +16845,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -18659,22 +16860,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8733e9460fbb418abb475fbeb0c61959
+      - cd218f4caea44b4cab83a6643d21d23d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68e26d4f-a72b-44ff-8800-3e89ac930cdb
+      - req-0a6578d7-b124-466d-a7ff-4e18f25dd856
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-68e26d4f-a72b-44ff-8800-3e89ac930cdb
+      - req-0a6578d7-b124-466d-a7ff-4e18f25dd856
       Date:
-      - Wed, 26 Sep 2018 18:42:47 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -18686,7 +16887,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:47 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18704,13 +16905,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
+      - Thu, 25 Oct 2018 18:21:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f90adaf9-03da-41a5-836d-3cad585706d9
+      - req-d33e5c0e-c869-4595-aa77-d0900e1bcf27
       Content-Length:
       - '4170'
       Connection:
@@ -18719,10 +16920,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:48.197080", "expires":
-        "2018-09-26T19:42:48Z", "id": "c5699d0603fa4b388cb3243fe09ea1e2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.020618", "expires":
+        "2018-10-25T19:21:20Z", "id": "6ecd103974dc4346ab70d9aa403d12f6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XpPr4T0dQMyP7AAeIzqQXw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["a7iJ5eSjQm2J3nJstUk-oA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18767,7 +16968,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18785,13 +16986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86119969-bcf5-4915-ba50-26c79be56c0b
+      - req-e5b6193d-9f8d-438f-83c5-4a7274942c46
       Content-Length:
       - '4170'
       Connection:
@@ -18800,10 +17001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:48.380792", "expires":
-        "2018-09-26T19:42:48Z", "id": "4a118fec5b4641a09ddbd18ace91fcc8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.208416", "expires":
+        "2018-10-25T19:21:20Z", "id": "8973904b93774e9a93c28a718f7d32b2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MhrAlpplSZCuk8OLO8j5Wg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jsEvT4ifRjumJ-npQZmFFw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -18848,13 +17049,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -18866,13 +17067,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fe8de47d-8d9e-44fe-ac40-ec17800304b9
+      - req-b12cdd39-7af4-453c-83a3-a794032b85a3
       Content-Length:
       - '370'
       Connection:
@@ -18881,13 +17082,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:48.531735", "expires":
-        "2018-09-26T19:42:48Z", "id": "7e1f778f637047969a5e01e506e507ef", "audit_ids":
-        ["ZfgEtn0cQFuUol6xnRGXrA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.362404", "expires":
+        "2018-10-25T19:21:20Z", "id": "67fefa2f75184d658544b15708283729", "audit_ids":
+        ["JWPlqlpTT9iHDlW3wWeeew"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -18902,20 +17103,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7e1f778f637047969a5e01e506e507ef
+      - 67fefa2f75184d658544b15708283729
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f5524d6-9ee8-4e2b-b2d3-29650937529f
+      - req-15be26df-ee31-45b3-a57c-b79c10882066
       Content-Length:
       - '500'
       Connection:
@@ -18932,133 +17133,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7e1f778f637047969a5e01e506e507ef"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-95455c4e-2231-4765-a41e-ff4bfc0b77a7
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:48.826369", "expires":
-        "2018-09-26T19:42:48Z", "id": "e6279129ccb741279dde0eb31c04e894", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MnNILHP4SvufB9LoBbOSAw",
-        "ZfgEtn0cQFuUol6xnRGXrA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7e1f778f637047969a5e01e506e507ef
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:48 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-fb57bf58-ac20-4b6a-ac8e-65d79a4fc9bb
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:48 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19076,13 +17151,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-36d15da8-d991-4201-8639-34ac0390103e
+      - req-f6804615-ce33-4045-9dea-3756e51e5cd9
       Content-Length:
       - '4117'
       Connection:
@@ -19091,10 +17166,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:49.145930", "expires":
-        "2018-09-26T19:42:49Z", "id": "7318cfff85134cf0911b0ac501bc2529", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.666144", "expires":
+        "2018-10-25T19:21:20Z", "id": "bcb8078777554cd7a54d65367304c3fe", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TrD7QtjMQ4GD-MQnsGeK_A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RvWWutrZQA-pD3rmm5auMg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -19138,7 +17213,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19156,13 +17231,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-62edaaf1-f66e-4601-b3ee-60910dfb6a6e
+      - req-d8cd641c-ed7e-4a74-9a30-cbe8a309ca73
       Content-Length:
       - '4131'
       Connection:
@@ -19171,10 +17246,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:49.327534", "expires":
-        "2018-09-26T19:42:49Z", "id": "058fcf81c7d8449cbd6dc6c27c350ac9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:20.847017", "expires":
+        "2018-10-25T19:21:20Z", "id": "43305d2c02cc466f842471736326af86", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Iv8J5QblRqmN_2vUiHV9Qg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MtJsTRsfRXWHJj5tVUHt8A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -19218,7 +17293,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19236,13 +17311,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-03b23314-0054-4c72-b066-42fb97d45d0b
+      - req-61bfbe89-a883-4cdd-990c-621ba5654f5c
       Content-Length:
       - '4118'
       Connection:
@@ -19251,10 +17326,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:49.508630", "expires":
-        "2018-09-26T19:42:49Z", "id": "e9608fba5257435c8aadab376d5e89fa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.032452", "expires":
+        "2018-10-25T19:21:21Z", "id": "6b8753aab5a148d69026ceabe73c4dd1", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WpHDJIhTQd-c6yUPOgqvLw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kBMrsH4IQnOgFPyrA-XATA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -19298,7 +17373,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19316,13 +17391,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6c66f186-81db-4346-8b9e-f13fe43bc2e2
+      - req-45126859-cdcf-444d-bca0-065be568485c
       Content-Length:
       - '4117'
       Connection:
@@ -19331,10 +17406,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:49.689553", "expires":
-        "2018-09-26T19:42:49Z", "id": "2daa62b0a8b24bfe9d5dcd5ed658bbfd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.216453", "expires":
+        "2018-10-25T19:21:21Z", "id": "7669184884184863b094d71cf7ee2b49", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ze11d_Z3TpyqDQ3O08ib2w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sSBI_6HjQ0-zL4mevH3kYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -19378,7 +17453,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -19393,7 +17468,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2daa62b0a8b24bfe9d5dcd5ed658bbfd
+      - 7669184884184863b094d71cf7ee2b49
   response:
     status:
       code: 200
@@ -19422,15 +17497,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb0b5760e6de24abda8a2a-005babd329
+      - txf35748f09ffa4551b8e32-005bd209a1
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -19445,7 +17520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2daa62b0a8b24bfe9d5dcd5ed658bbfd
+      - 7669184884184863b094d71cf7ee2b49
   response:
     status:
       code: 200
@@ -19474,14 +17549,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txc93ab85435ba458daff77-005babd329
+      - tx680e9a2554ba4d3aad091-005bd209a1
       Date:
-      - Wed, 26 Sep 2018 18:42:49 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:49 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19499,13 +17574,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-07b7a59e-723e-483f-933e-18a7cbdf4c3f
+      - req-fccf97f5-0de0-4217-bf56-5c9402093da7
       Content-Length:
       - '4131'
       Connection:
@@ -19514,10 +17589,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:50.089744", "expires":
-        "2018-09-26T19:42:50Z", "id": "33fe146179b9494fa7b072d676f799fa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:21.652846", "expires":
+        "2018-10-25T19:21:21Z", "id": "97ae1d29ff4240d39f7d22ca885a8421", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1YvxWrUiQIml0Yq_U6FYZQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7TYmioPGSfqqU0hsU1gs7A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -19561,7 +17636,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -19576,7 +17651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33fe146179b9494fa7b072d676f799fa
+      - 97ae1d29ff4240d39f7d22ca885a8421
   response:
     status:
       code: 200
@@ -19589,22 +17664,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987370.28248'
+      - '1540491681.81852'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987370.28248'
+      - '1540491681.81852'
       X-Trans-Id:
-      - tx962313f39230478ca05e8-005babd32a
+      - txbcbdaa303c104042a6a2a-005bd209a1
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -19619,7 +17694,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4a118fec5b4641a09ddbd18ace91fcc8
+      - 8973904b93774e9a93c28a718f7d32b2
   response:
     status:
       code: 200
@@ -19632,22 +17707,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987370.42748'
+      - '1540491681.96666'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987370.42748'
+      - '1540491681.96666'
       X-Trans-Id:
-      - tx2420957105eb4058a3c3e-005babd32a
+      - txcd7fd240686c40cd8644f-005bd209a1
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -19665,13 +17740,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1af4de80-b698-41cf-a43f-4895758dff26
+      - req-ec3cd258-90d6-4c58-9dec-7ca7d0fa8451
       Content-Length:
       - '4118'
       Connection:
@@ -19680,10 +17755,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:50.595000", "expires":
-        "2018-09-26T19:42:50Z", "id": "143a99f1c74e4e419cabd0ccdd6c45ba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:22.145889", "expires":
+        "2018-10-25T19:21:22Z", "id": "691b20f1c95d42c4a8a1485ba69fbd20", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hYuLei3wR1O-n9FQheQwew"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["S7JWWsTYQ6iqITvLWY7MNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -19727,7 +17802,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -19742,7 +17817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 143a99f1c74e4e419cabd0ccdd6c45ba
+      - 691b20f1c95d42c4a8a1485ba69fbd20
   response:
     status:
       code: 200
@@ -19755,22 +17830,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1537987370.74399'
+      - '1540491682.30539'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1537987370.74399'
+      - '1540491682.30539'
       X-Trans-Id:
-      - tx4344981547ce446984dd3-005babd32a
+      - tx16b16ea1c03f489a8bf1a-005bd209a2
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -19785,7 +17860,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2daa62b0a8b24bfe9d5dcd5ed658bbfd
+      - 7669184884184863b094d71cf7ee2b49
   response:
     status:
       code: 200
@@ -19806,9 +17881,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx85a793301c2a4e01bf3e5-005babd32a
+      - tx4def278ec8a3432b87975-005bd209a2
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -19818,7 +17893,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -19833,7 +17908,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2daa62b0a8b24bfe9d5dcd5ed658bbfd
+      - 7669184884184863b094d71cf7ee2b49
   response:
     status:
       code: 200
@@ -19854,14 +17929,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txddd942556af7451a99e56-005babd32a
+      - tx13677c73b4084bdcbea51-005bd209a2
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:50 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -19876,7 +17951,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2daa62b0a8b24bfe9d5dcd5ed658bbfd
+      - 7669184884184863b094d71cf7ee2b49
   response:
     status:
       code: 200
@@ -19897,14 +17972,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx148db179a5c74665bf6da-005babd32a
+      - txced2c36fd078497e9ffb0-005bd209a2
       Date:
-      - Wed, 26 Sep 2018 18:42:50 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -19919,7 +17994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
+      - 1cd59edbcf224e6db6ef06e72bc7d90f
   response:
     status:
       code: 200
@@ -19930,9 +18005,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-9c129381-b66a-4148-bc2e-97b855e38990
+      - req-65cf698f-1fdd-40d1-9956-1a81db6a1265
       Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -19942,7 +18017,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19957,7 +18032,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97eee193a62a4c3dacf3b444f68c44c5
+      - aef0c103e73b4b7e8e3cb8fefcfb3b94
   response:
     status:
       code: 200
@@ -19968,52 +18043,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-317cbc24-996a-42fa-87b6-e17ab926a87a
+      - req-3aafb83e-49a7-4d00-ae47-75feb88cc46e
       Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
+      - Thu, 25 Oct 2018 18:21:22 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -20061,23 +18101,58 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -20089,7 +18164,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97eee193a62a4c3dacf3b444f68c44c5
+      - aef0c103e73b4b7e8e3cb8fefcfb3b94
   response:
     status:
       code: 200
@@ -20100,23 +18175,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b9c39576-98cf-4e4d-a86a-f56d7a5d1125
+      - req-20f4e979-7027-4f73-8ca3-4e5d66837b82
       Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
+      - Thu, 25 Oct 2018 18:21:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -20193,20 +18257,31 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -20221,7 +18296,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53c01147a58b49acb1d55beed30cda55
+      - fe0510d9d93f4ffdb2389d1acb3f1325
   response:
     status:
       code: 200
@@ -20232,144 +18307,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ef2dc761-413b-43d6-adf4-a857be72cf9d
+      - req-f5049700-f3f6-44a9-b8dc-808d09d66567
       Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
+      - Thu, 25 Oct 2018 18:21:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 53c01147a58b49acb1d55beed30cda55
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b7a2c5ee-a4e0-41ab-8c75-2d8dbaa37832
-      Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -20451,26 +18400,152 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fe0510d9d93f4ffdb2389d1acb3f1325
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-de86f432-9824-43d9-9b42-2207c89ff884
+      Date:
+      - Thu, 25 Oct 2018 18:21:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:51 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -20485,7 +18560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
+      - 1cd59edbcf224e6db6ef06e72bc7d90f
   response:
     status:
       code: 200
@@ -20496,52 +18571,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-26858a1a-ed33-482f-b1f3-a7b32cb8c21f
+      - req-3950406b-2b76-44e2-a91e-3c97e3b993fe
       Date:
-      - Wed, 26 Sep 2018 18:42:51 GMT
+      - Thu, 25 Oct 2018 18:21:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -20589,138 +18629,41 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3f852638-08a7-4694-b327-dd7b7c13a65d
-      Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -20734,7 +18677,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -20749,7 +18692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
+      - 1cd59edbcf224e6db6ef06e72bc7d90f
   response:
     status:
       code: 200
@@ -20760,12 +18703,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dac3d4a4-236e-48fc-a49e-b5ff0e5e2fbf
+      - req-abcbece9-fec7-43bb-8573-ecc318ed10cc
       Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
+      - Thu, 25 Oct 2018 18:21:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -20847,144 +18796,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4da4a337-6c10-41ba-a5a5-ff5cfc8ac110
-      Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -20998,799 +18809,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bcf1be22-2672-42ed-af3b-afcafa6521f0
-      Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-221df33c-5646-4a36-9063-2cefc023cdae
-      Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-dd81595e-c4fd-4744-b385-798841fa4fe8
-      Date:
-      - Wed, 26 Sep 2018 18:42:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7d25003c-05d3-4f16-a8cf-3fdfbaabfc8f
-      Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8a3715f2-36af-4caa-a47f-9cd3c06646cd
-      Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b9cea20d2ef4226b5ea96f2518a0a05
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ac8abbfa-e517-4945-b7fb-297a4cd9ae19
-      Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -21805,7 +18824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd66b2d21a304d6cb0728da2bf254faf
+      - 43c0d89129c1435a914bf45c29d2710d
   response:
     status:
       code: 200
@@ -21816,200 +18835,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-88d73ba5-b4f8-468c-a226-588cfa762b83
+      - req-473f05ec-34a4-4aa0-86ac-eb5548f29821
       Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
+      - Thu, 25 Oct 2018 18:21:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - bd66b2d21a304d6cb0728da2bf254faf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-213bec8d-06e6-4702-ae77-7eb617ff2f0f
-      Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -22041,23 +18905,46 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:23 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -22069,7 +18956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd66b2d21a304d6cb0728da2bf254faf
+      - 43c0d89129c1435a914bf45c29d2710d
   response:
     status:
       code: 200
@@ -22080,12 +18967,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d14aa659-2495-4e67-aa08-b205a899c6b1
+      - req-37575096-6d80-4e63-9c7f-f41f619a82be
       Date:
-      - Wed, 26 Sep 2018 18:42:53 GMT
+      - Thu, 25 Oct 2018 18:21:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -22167,24 +19060,18 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:53 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:54 GMT
+      - Thu, 25 Oct 2018 18:21:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e7b0371c-dd89-4931-a5c5-4b53a0e4cf8a
+      - req-3c917584-f066-435f-99b1-1be4452a5f75
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:54.819563", "expires":
-        "2018-09-26T19:42:54Z", "id": "56987d9493d7464ba775e55778285e50", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.446459", "expires":
+        "2018-10-25T19:21:35Z", "id": "543db57a65e44b0fa7821c7948666f9a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["V55FoZcPRM-vMUIeBEY4Qw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["avfnouqUTzujyiLK2Fpitw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56987d9493d7464ba775e55778285e50
+      - 543db57a65e44b0fa7821c7948666f9a
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:54 GMT
+      - Thu, 25 Oct 2018 18:21:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:54 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
+      - Thu, 25 Oct 2018 18:21:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-453f2741-0e53-4135-af02-b69b9274cee7
+      - req-93a8040e-1795-497e-8fc3-c6a55d0ec43a
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:55.087342", "expires":
-        "2018-09-26T19:42:55Z", "id": "14d22c55de764078b19587877df7f31d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.706780", "expires":
+        "2018-10-25T19:21:35Z", "id": "28daed0598044840bca27d756dd13dc2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pu-YCbxzQ9-aIQwpl9EyuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ovh9GvZOTE-onbmEF-KSyw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,45 +196,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 14d22c55de764078b19587877df7f31d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -246,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
+      - Thu, 25 Oct 2018 18:21:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-155277b5-f8ce-408b-ba3e-f46d9bacfd71
+      - req-c2041df4-c012-489c-bd77-6f9dd5c903c9
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:55.334409", "expires":
-        "2018-09-26T19:42:55Z", "id": "5a98ffdfcd8f4e2e9f787664b5237945", "audit_ids":
-        ["bIRlDknuQT2dphM0joco-A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:35.865556", "expires":
+        "2018-10-25T19:21:35Z", "id": "477cc52733d045ae9b73e6dea13a5829", "audit_ids":
+        ["P0kbfbXlR82KDfqgolkpVw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a98ffdfcd8f4e2e9f787664b5237945
+      - 477cc52733d045ae9b73e6dea13a5829
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
+      - Thu, 25 Oct 2018 18:21:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f87c00be-7b7b-4555-8564-6dfdf6f0dba4
+      - req-b0185b53-08f5-4517-8281-f86b9d0dbf66
       Content-Length:
       - '500'
       Connection:
@@ -312,133 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"5a98ffdfcd8f4e2e9f787664b5237945"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-b9317cd8-4561-4f5b-a53c-71889fc206a9
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:55.652886", "expires":
-        "2018-09-26T19:42:55Z", "id": "655a3081d9c54dca8848fef972730575", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mGjwVmCiRmirvvIv4cJqnQ",
-        "bIRlDknuQT2dphM0joco-A"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5a98ffdfcd8f4e2e9f787664b5237945
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-08487db7-8887-4cec-8a71-b61a1d20b787
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:55 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87446f46-f391-46e4-bb7a-ea3846489bfe
+      - req-74dc1158-328c-47a9-8dc3-6eb30112ed5a
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:55.967633", "expires":
-        "2018-09-26T19:42:55Z", "id": "f5fc6240bfc74385abdeca72562e697b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.171413", "expires":
+        "2018-10-25T19:21:36Z", "id": "e9dca4dca12d447e85fa2b511b90dac0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3f01CWz9SKO0MqRiMmgwdw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["X7HvSYbKRZiB6cnPDkaBVQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:55 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5fc6240bfc74385abdeca72562e697b
+      - e9dca4dca12d447e85fa2b511b90dac0
   response:
     status:
       code: 200
@@ -544,7 +386,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +395,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-895d4f2d-9ada-4e88-835a-55e99ff2a36c
+      - req-0e76bb77-d36b-4196-ba62-8e9d6e97063d
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +428,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:56.235387", "expires":
-        "2018-09-26T19:42:56Z", "id": "489dccd3a2da4030b6984962f3bea781", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.442279", "expires":
+        "2018-10-25T19:21:36Z", "id": "5eafda06977544e8b95f7105ffbe0643", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rqkREOrVSQCYEDXzdiUNnw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["xld8jTNWTKCn68Z0RAIEJA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +475,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 489dccd3a2da4030b6984962f3bea781
+      - 5eafda06977544e8b95f7105ffbe0643
   response:
     status:
       code: 200
@@ -659,7 +501,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +510,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f3ad5909-6cb0-4cd3-bc48-ea435b5c4086
+      - req-55afd107-f271-419b-9d7e-0bc1db3679e9
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:56.524247", "expires":
-        "2018-09-26T19:42:56Z", "id": "e84d561025024c6fa89e30bb3f5f94d9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.701153", "expires":
+        "2018-10-25T19:21:36Z", "id": "7af767ef40e949abae57b8e564968d36", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oQ-jOU53RXGAQHTrUnr_DQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wq5sDPybRwap4dVXk0H64g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +590,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e84d561025024c6fa89e30bb3f5f94d9
+      - 7af767ef40e949abae57b8e564968d36
   response:
     status:
       code: 200
@@ -774,7 +616,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +625,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +643,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f242c09-6e27-44c8-9e5b-9c6046b206c7
+      - req-69ed5e78-43b8-408d-825d-822460b30fd2
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +658,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:56.790458", "expires":
-        "2018-09-26T19:42:56Z", "id": "64bd097187b640258e30b35410f39178", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:36.959608", "expires":
+        "2018-10-25T19:21:36Z", "id": "7f4b1049f7484cedb463bb29d3ad2473", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A6qK9OejTJaIlKMllBvR8w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CL1zRdecQ--zHyoXXX3SXQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +705,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:56 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
+      - 7f4b1049f7484cedb463bb29d3ad2473
   response:
     status:
       code: 200
@@ -889,2003 +731,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0a4bdd99-7070-4c5e-948c-f1522476b8d7
+      - req-bbc275bd-8466-46c9-a77f-99fb688fde10
       Date:
-      - Wed, 26 Sep 2018 18:42:56 GMT
+      - Thu, 25 Oct 2018 18:21:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d2417a16-849f-40a4-b51f-9e9c156ae9db
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-734d6890-ee84-4ad8-85ad-d4d3db4797d3
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-82fff1ae-5e28-46a9-8f3f-b296d74a93a2
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1ef2301b-c751-48c6-bedf-eb82829a2393
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5703b8ad-8ff4-41c7-80ee-480577517e74
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8cb70ee9-0dbc-4eca-8145-3778365c786b
-      Date:
-      - Wed, 26 Sep 2018 18:42:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-205d7331-d3eb-425e-afe9-4ff24a3f001b
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-73b7c51c-ddad-46ae-9bde-2415ebbe76a3
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ddff81d1-a194-4c25-9b30-9f58b0862753
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bc8e49cc-7877-4623-9b62-5cb016f895df
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e21d2abe-e65d-4e6c-b2b3-4a65ef43088b
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f3dd187a-1911-435b-96ac-d00d4c05e304
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5bf53284-8743-4485-82bb-2f1f3c5bd528
-      Date:
-      - Wed, 26 Sep 2018 18:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-32df2dc3-66da-420b-983c-b6bdd37e51ef
-      Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-12d77cf3-8f5e-42ee-a51b-d38d35beb9f7
-      Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -2962,23 +813,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -2990,7 +852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 64bd097187b640258e30b35410f39178
+      - 7f4b1049f7484cedb463bb29d3ad2473
   response:
     status:
       code: 200
@@ -3001,52 +863,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-82a3d779-a68f-494e-b843-82c0f9d1f2ac
+      - req-4e68ce13-451e-498d-8946-72cd26f45e48
       Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
+      - Thu, 25 Oct 2018 18:21:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -3094,20 +921,55 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3125,13 +987,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
+      - Thu, 25 Oct 2018 18:21:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-162b1e5d-e984-4808-afa6-03587a78b659
+      - req-0217f29a-17f1-43af-9494-fb289b2626b6
       Content-Length:
       - '4131'
       Connection:
@@ -3140,10 +1002,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:42:59.640452", "expires":
-        "2018-09-26T19:42:59Z", "id": "0a448a628144448187dafac84796a2b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:37.520305", "expires":
+        "2018-10-25T19:21:37Z", "id": "0a761362be3c41c3b1ada73ccb56fa75", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ugVHYRFiT0SFjBZsMS-ZOw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MdPScXXNTlSWtwxcqLIbpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3187,7 +1049,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3202,7 +1064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a448a628144448187dafac84796a2b6
+      - 0a761362be3c41c3b1ada73ccb56fa75
   response:
     status:
       code: 200
@@ -3213,23 +1075,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-11392960-d0b6-45fa-8f27-9bdb0fa186aa
+      - req-e0a30e3e-3fdb-4ce7-8bb6-18b93c73fa2b
       Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
+      - Thu, 25 Oct 2018 18:21:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -3306,23 +1157,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:42:59 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -3334,7 +1196,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a448a628144448187dafac84796a2b6
+      - 0a761362be3c41c3b1ada73ccb56fa75
   response:
     status:
       code: 200
@@ -3345,68 +1207,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-085822e9-8222-46c2-8a55-0e3d4f89ad44
+      - req-06a3c0f0-4152-480e-b770-e5d0aca952a5
       Date:
-      - Wed, 26 Sep 2018 18:42:59 GMT
+      - Thu, 25 Oct 2018 18:21:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -3438,364 +1277,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 14d22c55de764078b19587877df7f31d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e89b581f-3cfa-4807-b9c5-90601646c396
-      Date:
-      - Wed, 26 Sep 2018 18:43:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 14d22c55de764078b19587877df7f31d
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-61e98889-7181-4cae-8076-c42c99469bbe
-      Date:
-      - Wed, 26 Sep 2018 18:43:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:00 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-9b0c149a-9939-4397-88cd-8cccc33ae9c9
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:00.526937", "expires":
-        "2018-09-26T19:43:00Z", "id": "c910fdfb02614060b281ce04d065ee36", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LOp_nrYcSdWctseUA0bfrg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3810,7 +1328,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c910fdfb02614060b281ce04d065ee36
+      - 28daed0598044840bca27d756dd13dc2
   response:
     status:
       code: 200
@@ -3821,52 +1339,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c3ab2597-155a-4b0d-87ec-53d7f482a255
+      - req-26fa68fb-e41b-4188-96a7-c3cd62b367db
       Date:
-      - Wed, 26 Sep 2018 18:43:00 GMT
+      - Thu, 25 Oct 2018 18:21:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -3897,68 +1380,6 @@ http_interactions:
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c910fdfb02614060b281ce04d065ee36
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a5499419-740f-43ad-8fe3-f3a39540874e
-      Date:
-      - Wed, 26 Sep 2018 18:43:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -4005,6 +1426,74 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 28daed0598044840bca27d756dd13dc2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ca3f356e-3608-4d7b-8985-f8565cce8451
+      Date:
+      - Thu, 25 Oct 2018 18:21:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
@@ -4046,20 +1535,393 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:00 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Oct 2018 18:21:38 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-16c6d7f8-424f-4395-94e3-cbbd881272eb
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:38.499123", "expires":
+        "2018-10-25T19:21:38Z", "id": "b43b26a984054fa6ac033b76a3ed8ba4", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["QXqBseMQRRya9j67A_BjWg"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b43b26a984054fa6ac033b76a3ed8ba4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-081fc975-a293-4aaa-85ab-3dd88bebf788
+      Date:
+      - Thu, 25 Oct 2018 18:21:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b43b26a984054fa6ac033b76a3ed8ba4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e51458b6-2dbf-4d37-8562-c2b10d6a0a0d
+      Date:
+      - Thu, 25 Oct 2018 18:21:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -4074,7 +1936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14d22c55de764078b19587877df7f31d
+      - 28daed0598044840bca27d756dd13dc2
   response:
     status:
       code: 200
@@ -4085,9 +1947,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-a610afe4-d5b2-4d44-8933-4ecb5abd6603
+      - req-f043f7a4-ae52-432b-b34e-fc615944e3ab
       Date:
-      - Wed, 26 Sep 2018 18:43:01 GMT
+      - Thu, 25 Oct 2018 18:21:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4102,5 +1964,5 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:01 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:38 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:14 GMT
+      - Thu, 25 Oct 2018 18:21:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2bae1b01-3d2c-44c7-a0af-1cad7b2b2d47
+      - req-8222ae9f-7714-49dc-aebb-ba4c8e9cfd40
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:14.962250", "expires":
-        "2018-09-26T19:43:14Z", "id": "2d153201ce6e4c2894c1c965b4137faf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:24.797838", "expires":
+        "2018-10-25T19:21:24Z", "id": "14592e11da78491ea971c5863dda267a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gMg7d1YvSliVVcAjM49-aQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PhISzFd7Q2aJHVhVZKnV3A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:14 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2d153201ce6e4c2894c1c965b4137faf
+      - 14592e11da78491ea971c5863dda267a
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
+      - Thu, 25 Oct 2018 18:21:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-20612f3e-febd-44e4-9894-300d6ff5448b
+      - req-cfd19ce5-74b4-4f1d-89ea-d54ca4ec5c91
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:15.225897", "expires":
-        "2018-09-26T19:43:15Z", "id": "9c7add457d9641d8ab0340267131d675", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.063213", "expires":
+        "2018-10-25T19:21:25Z", "id": "15344f26774f4ce6a4d85f6252b9aeba", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qYhCCi5WRma5NQscz2jKCA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XI9XPsbyRGOzMtzesDMxag"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,45 +196,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9c7add457d9641d8ab0340267131d675
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -246,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5430d95-fc42-4d33-9968-2ab1fd835633
+      - req-041aad6c-cad9-46ed-9c36-7bd48c8a7228
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +229,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:15.454245", "expires":
-        "2018-09-26T19:43:15Z", "id": "7edb90b7b16e4fa682c50e91d47748da", "audit_ids":
-        ["mXE1PVrGT56UgSdG1CZ60Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.216823", "expires":
+        "2018-10-25T19:21:25Z", "id": "20fcf4d2c3db49179336a60df0beae17", "audit_ids":
+        ["1eeVdJMHQVqbqsPLJF-_8A"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7edb90b7b16e4fa682c50e91d47748da
+      - 20fcf4d2c3db49179336a60df0beae17
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6745e137-bd19-4a4c-9a06-39c0a1a59615
+      - req-629ff670-c4b7-4e02-b66d-dc333c8ea4c3
       Content-Length:
       - '500'
       Connection:
@@ -312,133 +280,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"7edb90b7b16e4fa682c50e91d47748da"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-88e6808c-23b9-4d83-b8e5-b9830d12b407
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:15.751344", "expires":
-        "2018-09-26T19:43:15Z", "id": "096c0fcaafc14487a600e3150f5157f2", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["diaxoD1uSOq_kNIMjbMTjQ",
-        "mXE1PVrGT56UgSdG1CZ60Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7edb90b7b16e4fa682c50e91d47748da
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:15 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-e1cee029-0ecf-42a3-acca-601ba036b036
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:15 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +298,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-38929ac4-c452-4cbf-aacc-c0bf3b42e4bf
+      - req-ab5248bc-1b60-4c24-9eb5-09772c812993
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +313,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:16.064550", "expires":
-        "2018-09-26T19:43:16Z", "id": "d6a44296b9714c82b7c29b3a407842b7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.533834", "expires":
+        "2018-10-25T19:21:25Z", "id": "660b400ea9ce49c1b570949c02c8b6b7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["h78f9S1NR2yUg4JBav-jqw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["85GSgTqMTvu-FwIU4vxKIQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +360,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6a44296b9714c82b7c29b3a407842b7
+      - 660b400ea9ce49c1b570949c02c8b6b7
   response:
     status:
       code: 200
@@ -544,7 +386,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +395,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45bcff67-b28d-40dd-b498-12dc85716381
+      - req-31bece75-a461-4562-a464-6a7ca218c50f
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +428,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:16.321554", "expires":
-        "2018-09-26T19:43:16Z", "id": "812ac30afc2949b69a7af5e5fc0fc965", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:25.788287", "expires":
+        "2018-10-25T19:21:25Z", "id": "375cdc618b264a838a341f4efce0db31", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qnbRIkdrQnyJagOwyhUkYw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["tFqom_TcRL2XNDK_cgGYUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +475,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 812ac30afc2949b69a7af5e5fc0fc965
+      - 375cdc618b264a838a341f4efce0db31
   response:
     status:
       code: 200
@@ -659,7 +501,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +510,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0a209da-301e-417e-beb2-c6d9694c9378
+      - req-3cad0a25-a16b-4adc-951a-d28b27c865e2
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:16.572012", "expires":
-        "2018-09-26T19:43:16Z", "id": "f82a7a71234a401c9543efb19a1a2e48", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:26.339556", "expires":
+        "2018-10-25T19:21:26Z", "id": "87a2be87b2b74ee186d3ff6f497d4b8a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jHI1K59oT5egDhhMmOYL2Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4TYoMgk8RN62u5oPxeaftA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +590,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f82a7a71234a401c9543efb19a1a2e48
+      - 87a2be87b2b74ee186d3ff6f497d4b8a
   response:
     status:
       code: 200
@@ -774,7 +616,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +625,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +643,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:16 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f9ac2a8-a2de-4820-8e41-bea4af0a0524
+      - req-d33436e4-db6c-462a-aef7-827ae344fa4f
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +658,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:16.825446", "expires":
-        "2018-09-26T19:43:16Z", "id": "bbf6c37eee264ffd8ad8f402f1f635fd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:26.592725", "expires":
+        "2018-10-25T19:21:26Z", "id": "dca28787678c4687bef547289218e998", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gAlp1Ty7TJ2SXZGqCS4K7w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ioU1xqowRpOAaUk4mmcRNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +705,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:16 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bbf6c37eee264ffd8ad8f402f1f635fd
+      - dca28787678c4687bef547289218e998
   response:
     status:
       code: 200
@@ -889,68 +731,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3a0cf06c-17c3-4347-9d9e-cb005abd978b
+      - req-f0c41635-f888-4e6a-bc61-9c13e8cebc1a
       Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -982,23 +801,46 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -1010,7 +852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bbf6c37eee264ffd8ad8f402f1f635fd
+      - dca28787678c4687bef547289218e998
   response:
     status:
       code: 200
@@ -1021,12 +863,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d24efed3-cc88-4a28-97ca-d29dd5152d38
+      - req-ecdc8324-962c-4e56-ae5e-d28251e6be0a
       Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
+      - Thu, 25 Oct 2018 18:21:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1108,26 +956,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1145,13 +987,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
+      - Thu, 25 Oct 2018 18:21:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94233d12-b6bd-42ed-bc8c-c6905f775e1e
+      - req-553e5159-6143-4606-a1a6-4cc3397d1206
       Content-Length:
       - '4131'
       Connection:
@@ -1160,10 +1002,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:17.491495", "expires":
-        "2018-09-26T19:43:17Z", "id": "f2fa15ecab044093a43d33606f76a236", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:27.143753", "expires":
+        "2018-10-25T19:21:27Z", "id": "5f990704a90440cd91ee736e6d789f87", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2lYvpg4ST9yU2Ck3MsJFTw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XNESICAkQbu8GglvhCM-jA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1207,7 +1049,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1222,7 +1064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2fa15ecab044093a43d33606f76a236
+      - 5f990704a90440cd91ee736e6d789f87
   response:
     status:
       code: 200
@@ -1233,41 +1075,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8f1e7f4f-0882-44aa-94a5-fd75aa8f4ed6
+      - req-6d9ad09a-ad94-45eb-a5dd-b47e9f16d159
       Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
+      - Thu, 25 Oct 2018 18:21:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
@@ -1280,12 +1133,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -1298,34 +1145,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1339,7 +1181,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:17 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1354,7 +1196,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2fa15ecab044093a43d33606f76a236
+      - 5f990704a90440cd91ee736e6d789f87
   response:
     status:
       code: 200
@@ -1365,12 +1207,150 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d2d859ef-9255-4948-bfe5-56de28e06b3a
+      - req-5d7b14df-a6b4-42a6-8a00-d5e3805fe7f2
       Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
+      - Thu, 25 Oct 2018 18:21:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 15344f26774f4ce6a4d85f6252b9aeba
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-226ec008-1da1-4ef4-a496-2df3121559aa
+      Date:
+      - Thu, 25 Oct 2018 18:21:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1452,144 +1432,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f2fa15ecab044093a43d33606f76a236
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-28218fcc-311f-46f3-83a0-62581e2a80ed
-      Date:
-      - Wed, 26 Sep 2018 18:43:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1603,7 +1445,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1618,7 +1460,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2fa15ecab044093a43d33606f76a236
+      - 15344f26774f4ce6a4d85f6252b9aeba
   response:
     status:
       code: 200
@@ -1629,68 +1471,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7cd24ee9-c6f7-4134-889a-ee25ae7ebcf8
+      - req-5e45265b-d880-4fcf-8027-2bc38ae8eaf7
       Date:
-      - Wed, 26 Sep 2018 18:43:18 GMT
+      - Thu, 25 Oct 2018 18:21:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1705,332 +1524,6 @@ http_interactions:
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f2fa15ecab044093a43d33606f76a236
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d31ca27a-a0b8-4998-9551-94002ec52db9
-      Date:
-      - Wed, 26 Sep 2018 18:43:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9c7add457d9641d8ab0340267131d675
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ca80816d-32b2-4590-b7c3-47cca035be74
-      Date:
-      - Wed, 26 Sep 2018 18:43:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9c7add457d9641d8ab0340267131d675
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-cefc0fd1-57cc-480b-970c-190e52073bf9
-      Date:
-      - Wed, 26 Sep 2018 18:43:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2065,73 +1558,26 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2149,13 +1595,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:18 GMT
+      - Thu, 25 Oct 2018 18:21:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-05f3d6ab-5587-47ba-ac64-1847c872c724
+      - req-ea205466-76e2-47e3-8d27-62392ad4b390
       Content-Length:
       - '4118'
       Connection:
@@ -2164,10 +1610,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:18.954345", "expires":
-        "2018-09-26T19:43:18Z", "id": "e72e41a01dde4e8db1aa2de5b1ba1ce9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:28.124021", "expires":
+        "2018-10-25T19:21:28Z", "id": "ec9ee57533d44285a37329fb80bb5fc9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["c4avUDIeRiudTLCsIl6paQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["v2HFT3JbSj2weZstOqL9LQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2211,7 +1657,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:18 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2226,7 +1672,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72e41a01dde4e8db1aa2de5b1ba1ce9
+      - ec9ee57533d44285a37329fb80bb5fc9
   response:
     status:
       code: 200
@@ -2237,68 +1683,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-85deb24f-eb24-4758-99e6-2a1133d71802
+      - req-79584516-babb-42cb-9bf6-f9f25d5269dd
       Date:
-      - Wed, 26 Sep 2018 18:43:19 GMT
+      - Thu, 25 Oct 2018 18:21:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2330,23 +1753,46 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -2358,7 +1804,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e72e41a01dde4e8db1aa2de5b1ba1ce9
+      - ec9ee57533d44285a37329fb80bb5fc9
   response:
     status:
       code: 200
@@ -2369,52 +1815,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ae559cc4-b690-4479-875e-8fd5c13e50fc
+      - req-2cca2a12-f004-45d7-9c4c-2e7b3f1d57ad
       Date:
-      - Wed, 26 Sep 2018 18:43:19 GMT
+      - Thu, 25 Oct 2018 18:21:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -2462,20 +1873,55 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -2490,7 +1936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c7add457d9641d8ab0340267131d675
+      - 15344f26774f4ce6a4d85f6252b9aeba
   response:
     status:
       code: 200
@@ -2501,9 +1947,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-d1a290f5-c8de-4b53-b9cf-91a11392fd73
+      - req-41f878a2-809e-49f0-9f46-dd37250566ec
       Date:
-      - Wed, 26 Sep 2018 18:43:19 GMT
+      - Thu, 25 Oct 2018 18:21:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -2512,5 +1958,5 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:19 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:02 GMT
+      - Thu, 25 Oct 2018 18:21:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a423259-79a6-4304-b224-0cdf630217ae
+      - req-3258ad4d-a18b-4bdc-b702-94ab8876dfae
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:02.337680", "expires":
-        "2018-09-26T19:43:02Z", "id": "9dade939cf1e4f5091544ed7dd06ea4d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:29.841087", "expires":
+        "2018-10-25T19:21:29Z", "id": "0a33ada03e82475caef5008e73d97057", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_nyu5fLcSUKZc_1vKlYtSw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4702LN3LR62-WSX2UXX6VQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dade939cf1e4f5091544ed7dd06ea4d
+      - 0a33ada03e82475caef5008e73d97057
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:02 GMT
+      - Thu, 25 Oct 2018 18:21:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:02 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-434a4b85-f19f-486b-a387-5333c66a03f3
+      - req-23fa849b-a71e-4f6b-9b7e-ef06166929d4
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:02.606689", "expires":
-        "2018-09-26T19:43:02Z", "id": "efc4aff4a7784a21b49ebe61857e3820", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:30.100394", "expires":
+        "2018-10-25T19:21:30Z", "id": "d9602f4b48cc487ebf9f5ccfb08c5c44", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["LryV3GzLTkqWy5JyN2Jg3A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MeWUwucKSiqEyeTzr8gC_Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - efc4aff4a7784a21b49ebe61857e3820
+      - d9602f4b48cc487ebf9f5ccfb08c5c44
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:02 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8da0921f-6e2e-49ea-944f-4e1d41c5e27c
+      - req-9dc7a2dd-144a-4f53-826b-3bdbf984b187
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:02 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5cd1b1db-c796-41de-955e-eab78e021ea7
+      - req-8a2e7f62-5559-457f-8007-306f583c8825
       Content-Length:
       - '4117'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:02.915775", "expires":
-        "2018-09-26T19:43:02Z", "id": "90eb44333a1748d79163368fb28043f5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:30.467564", "expires":
+        "2018-10-25T19:21:30Z", "id": "c36cfb8c1eb143dea2bc3d1537a63b90", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8Bs3Gpe0RJGM4JAXcrsZ9g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1yAntcFDQ7emgJnzLgF0rw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -321,7 +321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:02 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -336,7 +336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90eb44333a1748d79163368fb28043f5
+      - c36cfb8c1eb143dea2bc3d1537a63b90
   response:
     status:
       code: 200
@@ -347,9 +347,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-1ef8d612-a895-4378-8679-98b78f1905e1
+      - req-6add53a1-520e-4ffc-9ddc-4feebb373957
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -383,7 +383,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -398,7 +398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90eb44333a1748d79163368fb28043f5
+      - c36cfb8c1eb143dea2bc3d1537a63b90
   response:
     status:
       code: 200
@@ -409,9 +409,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f4e5dfbe-fe29-4a7e-85c6-5ea572c6b365
+      - req-37924ea7-5e36-4872-8644-ed7bfa081dd0
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -467,7 +467,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -482,7 +482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90eb44333a1748d79163368fb28043f5
+      - c36cfb8c1eb143dea2bc3d1537a63b90
   response:
     status:
       code: 200
@@ -493,9 +493,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ec192422-3e05-45ae-8229-23b0221e9924
+      - req-343e0d72-edf2-430a-812e-b99d325ac0cb
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -507,7 +507,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-500465d2-dd2c-4f82-a73b-900f55035532
+      - req-3bb4119c-0720-4478-88ed-ad23498004a3
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:03.611804", "expires":
-        "2018-09-26T19:43:03Z", "id": "d2bb678d30ef4904940faaec6129bf01", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:31.189908", "expires":
+        "2018-10-25T19:21:31Z", "id": "5f44a75f9104413fb793905fe6dabfbe", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["bJgf6sLySTCLSydJ0UE5Ew"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9ad4bBFGSrG00Hk_qgQECA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,45 +588,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2bb678d30ef4904940faaec6129bf01
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -638,13 +606,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0ae5ad74-3dcd-49ba-88d1-8cb96ae5d5f0
+      - req-0a2dae8e-676c-497d-9738-6fe925b64d80
       Content-Length:
       - '370'
       Connection:
@@ -653,13 +621,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:03.852928", "expires":
-        "2018-09-26T19:43:03Z", "id": "c7a565fe6a4941a4b4d541f812075e86", "audit_ids":
-        ["qxcQCQJ5Q_iBa9DKtoBkEw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:31.346017", "expires":
+        "2018-10-25T19:21:31Z", "id": "f5ea9e8be4984ba9ac372b1d5b8408d5", "audit_ids":
+        ["IOdYbahDQ7OwLNCMUUvZcw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:03 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -674,20 +642,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7a565fe6a4941a4b4d541f812075e86
+      - f5ea9e8be4984ba9ac372b1d5b8408d5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:03 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a4707ead-f04b-4ffa-a8c7-59a12dbd6f34
+      - req-35a70871-4f49-49e1-b445-7d9cb3ae6b80
       Content-Length:
       - '500'
       Connection:
@@ -704,133 +672,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c7a565fe6a4941a4b4d541f812075e86"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-d6750d12-fc11-4e75-ac56-0e412e252c43
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:04.144135", "expires":
-        "2018-09-26T19:43:03Z", "id": "d3322926685d43639cbf3b564075c1e8", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YvyybaeNR-G5FPCfdQjEaQ",
-        "qxcQCQJ5Q_iBa9DKtoBkEw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c7a565fe6a4941a4b4d541f812075e86
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-dfd3c898-e1ab-4b23-8e48-5833e043d145
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -848,13 +690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8dbe932b-a044-4319-9c77-16829b40c95d
+      - req-d4146d64-29ec-4bfd-b563-43c9307ea49c
       Content-Length:
       - '4117'
       Connection:
@@ -863,10 +705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:04.454320", "expires":
-        "2018-09-26T19:43:04Z", "id": "b8ee8479485b4b7db43f754307481aca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:31.663740", "expires":
+        "2018-10-25T19:21:31Z", "id": "909416fd82ec41f68704780ef657ab0d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["qyAhdro9TRyzIMjvCBFz3w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1AifsIaNQFuRxoViAeNaBA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -910,7 +752,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -925,7 +767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8ee8479485b4b7db43f754307481aca
+      - 909416fd82ec41f68704780ef657ab0d
   response:
     status:
       code: 200
@@ -936,7 +778,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -945,7 +787,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -963,13 +805,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
+      - Thu, 25 Oct 2018 18:21:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d588dcb-1244-4183-8159-225f19e242a8
+      - req-9d90e5b7-0d45-4edc-b43c-02ba0d77d9c0
       Content-Length:
       - '4131'
       Connection:
@@ -978,10 +820,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:04.726688", "expires":
-        "2018-09-26T19:43:04Z", "id": "f756ee5201944652ba3292049b77fb68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:31.927980", "expires":
+        "2018-10-25T19:21:31Z", "id": "9ab724c3dc6e4169a78c0997ce1c6999", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VWpmHrMYQpeNAhxhcgO9Bw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CsZoijBFQySJy9DUwwjXTw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1025,7 +867,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1040,7 +882,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f756ee5201944652ba3292049b77fb68
+      - 9ab724c3dc6e4169a78c0997ce1c6999
   response:
     status:
       code: 200
@@ -1051,7 +893,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1060,7 +902,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:04 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1078,13 +920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:04 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-faf6e3d8-ffab-4e26-b62c-d967af783f8c
+      - req-e357dfb9-c34e-4c19-8dbd-ba68ba4a1ea6
       Content-Length:
       - '4118'
       Connection:
@@ -1093,10 +935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:05.034272", "expires":
-        "2018-09-26T19:43:04Z", "id": "710192207ad746a687eef86a9f67069a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:32.194130", "expires":
+        "2018-10-25T19:21:32Z", "id": "3df73d208d424b61ae36121f0ca88c31", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ajDQgxF-SA2Pr6fJaAUlgQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EsrqX2LmR9WaouG6-zQlfw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1140,7 +982,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1155,7 +997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 710192207ad746a687eef86a9f67069a
+      - 3df73d208d424b61ae36121f0ca88c31
   response:
     status:
       code: 200
@@ -1166,7 +1008,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:05 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1175,7 +1017,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1193,13 +1035,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:05 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-835af3be-3503-43da-a26f-c43d211dc73e
+      - req-9fc4b356-5d7a-4e5a-8adf-785a8e8e17f5
       Content-Length:
       - '4117'
       Connection:
@@ -1208,10 +1050,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:05.293303", "expires":
-        "2018-09-26T19:43:05Z", "id": "4f1e94dea8dc4a02ab87f152d2ce4baf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:32.454486", "expires":
+        "2018-10-25T19:21:32Z", "id": "4fb6fdfe285b40ee8ec548d55f9a7f28", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["oxppt09_Q8uNnwgUlcEDpA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["W9ee3X3uR0q7OLA3VoOC0A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1255,7 +1097,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1270,7 +1112,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f1e94dea8dc4a02ab87f152d2ce4baf
+      - 4fb6fdfe285b40ee8ec548d55f9a7f28
   response:
     status:
       code: 200
@@ -1281,68 +1123,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e14dfecd-e275-455a-90fe-526c46325144
+      - req-47a2c2ef-8a62-4b0f-86d9-ee976a322991
       Date:
-      - Wed, 26 Sep 2018 18:43:05 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1374,23 +1193,46 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -1402,7 +1244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f1e94dea8dc4a02ab87f152d2ce4baf
+      - 4fb6fdfe285b40ee8ec548d55f9a7f28
   response:
     status:
       code: 200
@@ -1413,12 +1255,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-618d64c3-5c92-4b12-880a-4303089d7987
+      - req-3012a79b-138d-4d88-868c-d0106bf814ef
       Date:
-      - Wed, 26 Sep 2018 18:43:05 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1500,26 +1348,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1537,13 +1379,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:05 GMT
+      - Thu, 25 Oct 2018 18:21:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1393b31b-4013-431b-895c-065b9b543143
+      - req-6c486da2-6122-4eda-92a1-00148cd102ec
       Content-Length:
       - '4131'
       Connection:
@@ -1552,10 +1394,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:05.895188", "expires":
-        "2018-09-26T19:43:05Z", "id": "7a77e951b131468e80e88905323930f2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:32.999134", "expires":
+        "2018-10-25T19:21:32Z", "id": "39d92e10e3634eedbe4da9efa6b8c7a3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MtlcVO01TZ2KVodogwRJ_A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5LLynQcyQtKvras3s7JKbw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1599,7 +1441,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:05 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1614,7 +1456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a77e951b131468e80e88905323930f2
+      - 39d92e10e3634eedbe4da9efa6b8c7a3
   response:
     status:
       code: 200
@@ -1625,155 +1467,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5c049a8b-4f17-4be4-8e2e-e2f238217c8b
+      - req-db50c4c2-9588-40e9-9b8f-36c9549fd7b0
       Date:
-      - Wed, 26 Sep 2018 18:43:06 GMT
+      - Thu, 25 Oct 2018 18:21:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7a77e951b131468e80e88905323930f2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d67b1fa4-dc18-4efe-82ab-f65b7fce411b
-      Date:
-      - Wed, 26 Sep 2018 18:43:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -1850,23 +1549,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:06 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:33 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -1878,7 +1588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a77e951b131468e80e88905323930f2
+      - 39d92e10e3634eedbe4da9efa6b8c7a3
   response:
     status:
       code: 200
@@ -1889,12 +1599,282 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7d3b9d68-736e-4dc2-a7f6-32658b6ecbe4
+      - req-bcb8d48a-73a2-4d69-bda7-f78674bffb0d
       Date:
-      - Wed, 26 Sep 2018 18:43:06 GMT
+      - Thu, 25 Oct 2018 18:21:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:33 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5f44a75f9104413fb793905fe6dabfbe
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5746f693-b0bd-47fd-ac3d-e9823f62912e
+      Date:
+      - Thu, 25 Oct 2018 18:21:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:33 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5f44a75f9104413fb793905fe6dabfbe
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ee6c4479-f870-454a-be8c-8183d73152e6
+      Date:
+      - Thu, 25 Oct 2018 18:21:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1976,276 +1956,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2bb678d30ef4904940faaec6129bf01
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8750275c-48cc-4d95-9d5e-c7d329ff9f1a
-      Date:
-      - Wed, 26 Sep 2018 18:43:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2bb678d30ef4904940faaec6129bf01
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5a9c98b2-07db-4d62-93c6-8c981a44b631
-      Date:
-      - Wed, 26 Sep 2018 18:43:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2259,271 +1969,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2bb678d30ef4904940faaec6129bf01
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f9654ca7-275d-4ef1-9342-e854a9e02939
-      Date:
-      - Wed, 26 Sep 2018 18:43:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d2bb678d30ef4904940faaec6129bf01
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a0a172cb-753a-4f41-a111-4adc554565a0
-      Date:
-      - Wed, 26 Sep 2018 18:43:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2541,13 +1987,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:07 GMT
+      - Thu, 25 Oct 2018 18:21:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-80a70f99-1eeb-494a-bc53-dee645f024d8
+      - req-e81a76f4-fbfe-4a5c-85a6-ffed49b83dec
       Content-Length:
       - '4118'
       Connection:
@@ -2556,10 +2002,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:07.735853", "expires":
-        "2018-09-26T19:43:07Z", "id": "5c3bf0f69ae240b5946d14916c7eadeb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:34.085594", "expires":
+        "2018-10-25T19:21:34Z", "id": "9c95fa0f957749ce855fe9eddec860be", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["XCm6go2hRke3eS5PMAUcmw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["pXGclrUZS8-ec0RMFsbZ5w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2603,7 +2049,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2618,7 +2064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c3bf0f69ae240b5946d14916c7eadeb
+      - 9c95fa0f957749ce855fe9eddec860be
   response:
     status:
       code: 200
@@ -2629,68 +2075,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d6bf81fa-fe37-4f77-8f2c-6cac1383240b
+      - req-aaf2948b-9cf9-4265-b39c-08835935210a
       Date:
-      - Wed, 26 Sep 2018 18:43:07 GMT
+      - Thu, 25 Oct 2018 18:21:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2722,23 +2145,46 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:07 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:34 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -2750,7 +2196,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c3bf0f69ae240b5946d14916c7eadeb
+      - 9c95fa0f957749ce855fe9eddec860be
   response:
     status:
       code: 200
@@ -2761,28 +2207,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c267ac9c-0da7-4884-88ba-381dc69e5a21
+      - req-ba319d3f-5b06-4f9b-8cd5-e2763d062803
       Date:
-      - Wed, 26 Sep 2018 18:43:08 GMT
+      - Thu, 25 Oct 2018 18:21:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2830,42 +2300,18 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:08 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
+      - Thu, 25 Oct 2018 18:21:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-510832b7-0137-4d7a-863f-3a83e7cf3893
+      - req-2e12cb75-e789-481e-a8be-d5ceda6695a4
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:09.145748", "expires":
-        "2018-09-26T19:43:09Z", "id": "7df9d962186c4befab143853e86eb8f1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:39.784139", "expires":
+        "2018-10-25T19:21:39Z", "id": "eccf233bd29648f380affc03bf64f202", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["M688UoNZQLOCkTQGpWdWWw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["3gveuSgET86OtAo7gHK_Cw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7df9d962186c4befab143853e86eb8f1
+      - eccf233bd29648f380affc03bf64f202
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
+      - Thu, 25 Oct 2018 18:21:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
+      - Thu, 25 Oct 2018 18:21:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e7cdacff-cb29-417c-a011-1fb2d0d0f565
+      - req-53f47458-d52d-4db5-a677-6e553f9d52ff
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:09.409205", "expires":
-        "2018-09-26T19:43:09Z", "id": "1bd57e3afbd44fcd8508288d27516e1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.056464", "expires":
+        "2018-10-25T19:21:40Z", "id": "500e06f2017b407fb39f0dd6d18485b8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tXqxZ8HeRFqpAmY5u9TJeQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["r-8p210rQoCt-TOdz3ptbQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bd57e3afbd44fcd8508288d27516e1c
+      - 500e06f2017b407fb39f0dd6d18485b8
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
+      - Thu, 25 Oct 2018 18:21:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-78c8ae08-cd1e-491e-9699-168733de5948
+      - req-dd0b8ae3-7e34-469f-bb7c-32c0b1904cf7
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
+      - Thu, 25 Oct 2018 18:21:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8442a3c0-29cb-4831-8f89-51c8fcf43214
+      - req-804fd885-62ef-445d-b731-e50a83b3b9e2
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:09.799190", "expires":
-        "2018-09-26T19:43:09Z", "id": "e47faa8de0f44555924ccea0c1315484", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.464981", "expires":
+        "2018-10-25T19:21:40Z", "id": "7ba0b1feee0b414082dbb318b8e80388", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["X93dhq3PTAGPGmRhU-jz2A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Tac5fzEMQyODqr_DRdZUiw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,45 +322,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e47faa8de0f44555924ccea0c1315484
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:43:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:09 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -372,13 +340,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
+      - Thu, 25 Oct 2018 18:21:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-db795ce1-9888-4603-8614-3b5029262cf0
+      - req-a299ddd6-9117-4422-b9fe-291a3cad4cdf
       Content-Length:
       - '370'
       Connection:
@@ -387,13 +355,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:10.030483", "expires":
-        "2018-09-26T19:43:10Z", "id": "61d0eb8e8c7442a1995641a9495db97a", "audit_ids":
-        ["tUT1-XjTQGmZtL3Lyms4LQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.616750", "expires":
+        "2018-10-25T19:21:40Z", "id": "81d7c232c71c4356b6b09d93920fba1f", "audit_ids":
+        ["Of_XNewATmqGoBaKq4QedQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +376,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61d0eb8e8c7442a1995641a9495db97a
+      - 81d7c232c71c4356b6b09d93920fba1f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
+      - Thu, 25 Oct 2018 18:21:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f93c4c49-042a-429d-99ed-56a90c394712
+      - req-c9650c0b-4d0e-4ebd-8524-2b44b75ec073
       Content-Length:
       - '500'
       Connection:
@@ -438,133 +406,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"61d0eb8e8c7442a1995641a9495db97a"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-6bdf21cc-efab-478a-b2a1-3fb013e32a4f
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:10.322051", "expires":
-        "2018-09-26T19:43:10Z", "id": "35fd86073c764ae089f6f3295644d319", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mbROPjosTmGWHHoK1KN3lg",
-        "tUT1-XjTQGmZtL3Lyms4LQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 61d0eb8e8c7442a1995641a9495db97a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-f4900bb0-a498-4dfb-8310-42baa6fe2463
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -582,13 +424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
+      - Thu, 25 Oct 2018 18:21:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a980c06-8687-4d4a-9230-505f4de838c6
+      - req-7121633e-3f26-453f-bc24-c9d7fae4beb3
       Content-Length:
       - '4117'
       Connection:
@@ -597,10 +439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:10.673317", "expires":
-        "2018-09-26T19:43:10Z", "id": "e6768cb8b46f4defa99a414866701842", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:40.924622", "expires":
+        "2018-10-25T19:21:40Z", "id": "80400ff4122a470db640faaa57ea0f68", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RACr7GksRmqJI4O3-b9dog"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["PtN1MDcVToe7s2ky61D4wg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -644,7 +486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -659,7 +501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6768cb8b46f4defa99a414866701842
+      - 80400ff4122a470db640faaa57ea0f68
   response:
     status:
       code: 200
@@ -670,7 +512,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -679,7 +521,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -697,13 +539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:10 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d046b5e6-34b4-47d7-894e-4b331eb0e2bb
+      - req-e02af5bd-a8e8-448b-9e55-24b13fd769bf
       Content-Length:
       - '4131'
       Connection:
@@ -712,10 +554,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:10.932472", "expires":
-        "2018-09-26T19:43:10Z", "id": "42152113f2c74bdea1b2e9223fbddd17", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.220843", "expires":
+        "2018-10-25T19:21:41Z", "id": "3c884d5a49384bedbf07018d8d31b2f4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9WZYeDlsRhmSRf4VJ5KSlA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vd7FS91dRzeIYLAmAN_TYA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -759,7 +601,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:10 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -774,7 +616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42152113f2c74bdea1b2e9223fbddd17
+      - 3c884d5a49384bedbf07018d8d31b2f4
   response:
     status:
       code: 200
@@ -785,7 +627,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -794,7 +636,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -812,13 +654,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-18b9e2d5-088f-43f0-92eb-72120996d92d
+      - req-f0f2d8e3-86b4-4766-80b4-1bcae556e112
       Content-Length:
       - '4118'
       Connection:
@@ -827,10 +669,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:11.180749", "expires":
-        "2018-09-26T19:43:11Z", "id": "f41a02113db548c3a68b7a1296efc39c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.488889", "expires":
+        "2018-10-25T19:21:41Z", "id": "15b46970b8e142089c1195a3b2410975", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EiBleGN0RFiCROhz7vwTig"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7NVtFmqvRjOihFG_Rtu0HA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -874,7 +716,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -889,7 +731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f41a02113db548c3a68b7a1296efc39c
+      - 15b46970b8e142089c1195a3b2410975
   response:
     status:
       code: 200
@@ -900,7 +742,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -909,7 +751,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -927,13 +769,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94811366-999b-4456-a4e8-0cf631b41154
+      - req-213d49f1-32f9-4dda-919f-5551de76d4b7
       Content-Length:
       - '4117'
       Connection:
@@ -942,10 +784,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:11.429255", "expires":
-        "2018-09-26T19:43:11Z", "id": "1703694d3d434379b11f8e134331915e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:41.756598", "expires":
+        "2018-10-25T19:21:41Z", "id": "b1f194f3adde4624af002baf282cbcaf", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RvON7nTSQomZWahsGIT2VQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["e6YCQ1gkRJeuLBhWpwdn8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -989,7 +831,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1004,7 +846,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1703694d3d434379b11f8e134331915e
+      - b1f194f3adde4624af002baf282cbcaf
   response:
     status:
       code: 200
@@ -1015,23 +857,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9a861856-c093-4593-8a33-fe9fda18bca1
+      - req-0249391d-e45f-4942-a52b-4e97145828a3
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -1108,23 +939,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:41 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -1136,7 +978,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1703694d3d434379b11f8e134331915e
+      - b1f194f3adde4624af002baf282cbcaf
   response:
     status:
       code: 200
@@ -1147,52 +989,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c6107122-f93d-4ee3-bfac-035417e9336f
+      - req-5f3da23e-c03d-4b6f-88d3-08a450a8debb
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -1240,20 +1047,55 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1271,13 +1113,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:11 GMT
+      - Thu, 25 Oct 2018 18:21:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c0286538-abc8-4c4e-b342-ce93120a6511
+      - req-d1520020-47cd-4bcd-ac62-4706bb4e0c9c
       Content-Length:
       - '4131'
       Connection:
@@ -1286,10 +1128,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:11.971643", "expires":
-        "2018-09-26T19:43:11Z", "id": "8d91b1f855ca45758047b8abd41ce909", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:42.300596", "expires":
+        "2018-10-25T19:21:42Z", "id": "0e4574895ddf4ee4bb20452f04954ddd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["wsdutzDVRx-EsmiRxoL09w"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zRzQ5empTD6Y1xA4lwqw5Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1333,7 +1175,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:11 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1348,7 +1190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d91b1f855ca45758047b8abd41ce909
+      - 0e4574895ddf4ee4bb20452f04954ddd
   response:
     status:
       code: 200
@@ -1359,155 +1201,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9d09946f-b05c-438f-afe8-241108056e2d
+      - req-b03ee33b-1756-4b57-ad09-3c66fab52fc1
       Date:
-      - Wed, 26 Sep 2018 18:43:12 GMT
+      - Thu, 25 Oct 2018 18:21:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8d91b1f855ca45758047b8abd41ce909
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ed8bfde6-3bab-4d50-97df-5eb05eba4d12
-      Date:
-      - Wed, 26 Sep 2018 18:43:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -1584,23 +1283,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:12 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -1612,7 +1322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d91b1f855ca45758047b8abd41ce909
+      - 0e4574895ddf4ee4bb20452f04954ddd
   response:
     status:
       code: 200
@@ -1623,12 +1333,494 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-957b2814-0e9b-4d13-bd0a-c5aec0cdc273
+      - req-4433031f-2db1-43c7-abbf-b31b41fa80c3
       Date:
-      - Wed, 26 Sep 2018 18:43:12 GMT
+      - Thu, 25 Oct 2018 18:21:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7ba0b1feee0b414082dbb318b8e80388
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-49a3b36e-5442-46b1-bad1-c6d1f5611012
+      Date:
+      - Thu, 25 Oct 2018 18:21:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 7ba0b1feee0b414082dbb318b8e80388
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-284a0aec-da9b-4887-8bee-89ec388c9f47
+      Date:
+      - Thu, 25 Oct 2018 18:21:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Oct 2018 18:21:43 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-ec8dceb4-193b-4d31-8965-eff800cce8d3
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:21:43.228976", "expires":
+        "2018-10-25T19:21:43Z", "id": "de1f44ea44f44ce4bbbc76d0071e7916", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dEP5vAVfTxSCSIfSk9ct2g"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - de1f44ea44f44ce4bbbc76d0071e7916
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-556ba2c6-a30a-4d68-838c-b1037811d335
+      Date:
+      - Thu, 25 Oct 2018 18:21:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1710,620 +1902,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e47faa8de0f44555924ccea0c1315484
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6fc1e4ee-65e7-4ca6-becd-d16f9412fc87
-      Date:
-      - Wed, 26 Sep 2018 18:43:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e47faa8de0f44555924ccea0c1315484
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-78bd7aff-d4d4-4841-852d-a0d931a227a7
-      Date:
-      - Wed, 26 Sep 2018 18:43:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:13 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-45e1aeea-0e46-4ad5-ab3e-a1987cd35923
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:13.165414", "expires":
-        "2018-09-26T19:43:13Z", "id": "2099e7f37d494d1ea0739e6bbee6ba90", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Aq1m-OFoRj6AGDuPthpXjQ"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2099e7f37d494d1ea0739e6bbee6ba90
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-757f467d-f51c-4115-b8a8-30cb9aa89a63
-      Date:
-      - Wed, 26 Sep 2018 18:43:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2099e7f37d494d1ea0739e6bbee6ba90
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c95351bf-7a5f-4852-855e-6c00a8678a16
-      Date:
-      - Wed, 26 Sep 2018 18:43:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2337,7 +1915,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2352,7 +1930,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2099e7f37d494d1ea0739e6bbee6ba90
+      - de1f44ea44f44ce4bbbc76d0071e7916
   response:
     status:
       code: 200
@@ -2363,155 +1941,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f5923a7a-1cda-458d-ab05-18b3967e516c
+      - req-86751095-f2ff-46fd-b146-049288c84e95
       Date:
-      - Wed, 26 Sep 2018 18:43:13 GMT
+      - Thu, 25 Oct 2018 18:21:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2099e7f37d494d1ea0739e6bbee6ba90
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-11662087-8a97-4876-8933-c5f125846915
-      Date:
-      - Wed, 26 Sep 2018 18:43:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
         true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
@@ -2588,18 +2023,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:13 GMT
+  recorded_at: Thu, 25 Oct 2018 18:21:43 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:20 GMT
+      - Thu, 25 Oct 2018 18:20:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aee1f4ac-7a2e-4691-bea3-4a99ee9375f5
+      - req-d977eefd-30d3-441e-acb4-e0e00d4f9ce2
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:20.431471", "expires":
-        "2018-09-26T19:43:20Z", "id": "09d2ddbc5c6147649bd8c0fd1547bbbb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:19.839001", "expires":
+        "2018-10-25T19:20:19Z", "id": "0564c5e3558741d9a30288fe73a41418", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["UwEP1fvtRN-15hnK54dVQQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fDDjJstvQVK6Kzc-uYajXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:20 GMT
+      - Thu, 25 Oct 2018 18:20:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:20 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,12 +143,12 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-5d26daf9-c164-4c6e-8b55-94bc1d65d790
+      - req-d0857a27-f32c-41f2-8a5b-a4552e43c657
       Date:
-      - Wed, 26 Sep 2018 18:43:20 GMT
+      - Thu, 25 Oct 2018 18:20:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"server": {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z",
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-b745dd8f-c143-4265-93b3-c0c620dc4f21
+      - req-d807ca4f-8115-4dc0-a627-1aef927d7964
       Date:
-      - Wed, 26 Sep 2018 18:43:21 GMT
+      - Thu, 25 Oct 2018 18:20:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-3f3bcde2-8f63-4f33-aa60-55d69eb02905
+      - req-031d2b7d-93f6-4ccf-a6f6-1cef3ca452c1
       Date:
-      - Wed, 26 Sep 2018 18:43:21 GMT
+      - Thu, 25 Oct 2018 18:20:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-34a34146-0a4d-4dbe-a531-21e7c0451d55
+      - req-6c538e8d-3aed-4ec2-92b9-5a0cb3c685f0
       Date:
-      - Wed, 26 Sep 2018 18:43:21 GMT
+      - Thu, 25 Oct 2018 18:20:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:21 GMT
+      - Thu, 25 Oct 2018 18:20:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e226cc69-2e07-4768-916c-3914abeab9e8
+      - req-f56ec43b-38d4-44e9-bcdb-e53078f8f1a1
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:21.878060", "expires":
-        "2018-09-26T19:43:21Z", "id": "4780c3e22e6c4098bcc271b969cfd041", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:21.175327", "expires":
+        "2018-10-25T19:20:21Z", "id": "63fa622f04674ed4a4a6bd2df37f8f56", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gZyeTOMgRKalKSxK2b4QEQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["haSaVWWjSE6x9hI8w3fX4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,39 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '119'
-      Date:
-      - Wed, 26 Sep 2018 18:43:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:21 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -455,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -466,9 +434,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-c7d71bc0-154a-4a4b-8962-8cb26c1eb7ff
+      - req-873042cb-c31e-437a-b216-421696d8937c
       Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
+      - Thu, 25 Oct 2018 18:20:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -477,7 +445,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -495,13 +463,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
+      - Thu, 25 Oct 2018 18:20:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e2581a6e-4ccf-4422-845e-4559559016d0
+      - req-35a2ffc1-ac3f-4701-833a-961052a33724
       Content-Length:
       - '4170'
       Connection:
@@ -510,10 +478,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:22.283312", "expires":
-        "2018-09-26T19:43:22Z", "id": "0189a67f20a2490698dd9c373f38f71f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:21.562371", "expires":
+        "2018-10-25T19:20:21Z", "id": "63af1f8154ad41e6a0862aa1e413369e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["BQwLhTwiQ9G4wXw_Az4yyQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XfsAQGUKQaapY0MMD929hg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -558,7 +526,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -573,20 +541,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0189a67f20a2490698dd9c373f38f71f'
+      - 63af1f8154ad41e6a0862aa1e413369e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
+      - Thu, 25 Oct 2018 18:20:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87a76018-2359-4899-818b-67aa59d43c4e
+      - req-4ee39689-2ae1-4c9d-ac30-50feb262ead2
       Content-Length:
       - '500'
       Connection:
@@ -603,7 +571,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -618,7 +586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -631,9 +599,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-d7ff4c9f-ae44-4f46-b360-009361b66766
+      - req-98078ca5-787f-4e26-a1d9-3e606c60d8ae
       Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
+      - Thu, 25 Oct 2018 18:20:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -642,7 +610,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -660,13 +628,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d7fbc5a0-ab2e-46f7-888a-f517e944bec4
+      - req-532ce73f-79c5-410e-8240-5814f33405fe
       Content-Length:
       - '4170'
       Connection:
@@ -675,10 +643,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:22.759778", "expires":
-        "2018-09-26T19:43:22Z", "id": "a76407a279084dccbb7591a269ee0152", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.057420", "expires":
+        "2018-10-25T19:20:22Z", "id": "566a56322f6343068a6c5b9f9adcd20c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yz8JRFeTTliXG38VXcd2yA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4G1rGQQuQBKHcZ4ZArV-1A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -723,46 +691,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9292/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a76407a279084dccbb7591a269ee0152
-  response:
-    status:
-      code: 300
-      message: Multiple Choices
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '648'
-      Date:
-      - Wed, 26 Sep 2018 18:43:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v2.2", "links": [{"href": "http://10.8.99.233:9292/v2/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v2.1", "links": [{"href": "http://10.8.99.233:9292/v2/",
-        "rel": "self"}]}, {"status": "SUPPORTED", "id": "v2.0", "links": [{"href":
-        "http://10.8.99.233:9292/v2/", "rel": "self"}]}, {"status": "SUPPORTED", "id":
-        "v1.1", "links": [{"href": "http://10.8.99.233:9292/v1/", "rel": "self"}]},
-        {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
-        "rel": "self"}]}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:22 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -777,7 +706,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a76407a279084dccbb7591a269ee0152
+      - 566a56322f6343068a6c5b9f9adcd20c
   response:
     status:
       code: 200
@@ -788,9 +717,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-00648e25-df61-42b8-8140-feb0618f51c0
+      - req-6c9cea6a-4661-44c7-9f04-715c3e76f7c1
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -801,13 +730,13 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":""}}'
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -819,13 +748,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bcf4cbf7-093d-4bbe-bd66-da48e5516c8a
+      - req-b47855e0-4f72-470f-a0f2-1677bbd04cd6
       Content-Length:
       - '370'
       Connection:
@@ -834,13 +763,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:23.151181", "expires":
-        "2018-09-26T19:43:23Z", "id": "333b483a206643ffb92644d013a24de5", "audit_ids":
-        ["QZm9VRHAQZWzmbZmLzMj1Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.413437", "expires":
+        "2018-10-25T19:20:22Z", "id": "25111928c8ef493b98d32d137de79528", "audit_ids":
+        ["2hubWOM0R5W6pSLod9GScA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -855,20 +784,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 333b483a206643ffb92644d013a24de5
+      - 25111928c8ef493b98d32d137de79528
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-34726b58-2b50-48fe-b9ab-b995cc2451de
+      - req-927dfb0d-2c97-45f2-88b1-5a557f8c3d89
       Content-Length:
       - '500'
       Connection:
@@ -885,133 +814,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"token":{"id":"333b483a206643ffb92644d013a24de5"},"tenantName":"EmsRefreshSpec-Project"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-6fc437a1-6893-4524-8266-fa20ca02a3ef
-      Content-Length:
-      - '4143'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:23.460183", "expires":
-        "2018-09-26T19:43:23Z", "id": "12db4904b6be496b9a48401a37f6daa8", "tenant":
-        {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MJzfDYF9TzKEHuhwxD0wTA",
-        "QZm9VRHAQZWzmbZmLzMj1Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
-        "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
-- request:
-    method: get
-    uri: http://11.22.33.44:5000/v2.0/tenants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 333b483a206643ffb92644d013a24de5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-aa09a78c-685a-4d89-ad1d-cf5d98e83d4a
-      Content-Length:
-      - '500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"tenants_links": [], "tenants": [{"description": "", "enabled": true,
-        "id": "69f8f7205ade4aa59084c32c83e60b5a", "name": "EmsRefreshSpec-Project"},
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, {"description": "admin tenant",
-        "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a", "name": "admin"},
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1029,13 +832,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1c18c0e2-d767-421c-a712-c9318ebfffc5
+      - req-6142b91d-faae-46c4-a691-ae1cc599ed2c
       Content-Length:
       - '4117'
       Connection:
@@ -1044,10 +847,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:23.777266", "expires":
-        "2018-09-26T19:43:23Z", "id": "a1a58d222e1349439c6bf0ccac0ef4a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:22.761694", "expires":
+        "2018-10-25T19:20:22Z", "id": "9a5e4d7a8d234d56b6d0186a36d142a2", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rQSEM5TPR-CMrkuBmI79Hw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zSxcH-DETLSKZbNbBgMhvA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1091,7 +894,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1106,7 +909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1a58d222e1349439c6bf0ccac0ef4a1
+      - 9a5e4d7a8d234d56b6d0186a36d142a2
   response:
     status:
       code: 200
@@ -1117,7 +920,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1126,7 +929,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:23 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1144,13 +947,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:23 GMT
+      - Thu, 25 Oct 2018 18:20:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-205fdba5-cab7-41b6-88b5-f0244ea531bf
+      - req-37691ff4-bb5d-4374-892d-03f0d01928d7
       Content-Length:
       - '4131'
       Connection:
@@ -1159,10 +962,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:24.027829", "expires":
-        "2018-09-26T19:43:24Z", "id": "ecb6f82ad9fa4d6ba0ac10eb5a87641b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:23.031383", "expires":
+        "2018-10-25T19:20:23Z", "id": "18fd93bee33e48709b93255d6bab9550", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["97Cxk3CwS4abMhyH-VYsDQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pcx88lvHT9SLYTGq5EYBLA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1206,7 +1009,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1221,7 +1024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecb6f82ad9fa4d6ba0ac10eb5a87641b
+      - 18fd93bee33e48709b93255d6bab9550
   response:
     status:
       code: 200
@@ -1232,7 +1035,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1241,7 +1044,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1259,13 +1062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f49be90-c300-4fdc-9ab1-a6e402507ec3
+      - req-9ddeb3a6-d3b8-48a4-b5b1-82e62cf19680
       Content-Length:
       - '4118'
       Connection:
@@ -1274,10 +1077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:24.275746", "expires":
-        "2018-09-26T19:43:24Z", "id": "9480f578090146ddadf7c4470a0513e8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:23.379732", "expires":
+        "2018-10-25T19:20:23Z", "id": "40b2a4c92b4e4ca3bba30613156bded9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WVyGZLSZSx2yd1EAw_K7xA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5eUUGNDXQ92SeMAF1-Qbxg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1321,7 +1124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1336,7 +1139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9480f578090146ddadf7c4470a0513e8
+      - 40b2a4c92b4e4ca3bba30613156bded9
   response:
     status:
       code: 200
@@ -1347,7 +1150,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1356,7 +1159,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -1371,7 +1174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1a58d222e1349439c6bf0ccac0ef4a1
+      - 9a5e4d7a8d234d56b6d0186a36d142a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1384,9 +1187,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-35f99e57-b196-43dc-917d-f3993407c389
+      - req-558bf934-ef64-40b4-a102-f6045d000912
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1396,7 +1199,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1411,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1a58d222e1349439c6bf0ccac0ef4a1
+      - 9a5e4d7a8d234d56b6d0186a36d142a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1424,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-f16277f3-4ced-40db-bfc3-e9d683616f0e
+      - req-c87d98c6-4f23-4a8e-b116-73c18667ee95
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1436,7 +1239,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -1451,7 +1254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecb6f82ad9fa4d6ba0ac10eb5a87641b
+      - 18fd93bee33e48709b93255d6bab9550
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1464,9 +1267,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-de74dd88-bd8d-43bf-9831-3be1434794c0
+      - req-c3ba2dcb-6eb5-492f-a7c2-4eeb3158e4a0
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1476,7 +1279,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1491,7 +1294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecb6f82ad9fa4d6ba0ac10eb5a87641b
+      - 18fd93bee33e48709b93255d6bab9550
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1504,9 +1307,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5b31bf93-40ff-45d4-8103-04b7a8f4a611
+      - req-8cfe277f-6544-4509-9b56-6e85441fed08
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1516,7 +1319,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -1531,7 +1334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1544,9 +1347,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-134e71b9-3d0a-418e-b7dc-c4097b7a6cca
+      - req-d884e3be-dd9b-4617-9b26-e1b5d47db35e
       Date:
-      - Wed, 26 Sep 2018 18:43:24 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1556,7 +1359,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:24 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1571,7 +1374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1584,9 +1387,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5bd9465b-6c94-4a39-be5f-194390ebcf7b
+      - req-1b65c711-60e9-426f-8a51-a8d2d69c6909
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1596,7 +1399,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -1611,7 +1414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9480f578090146ddadf7c4470a0513e8
+      - 40b2a4c92b4e4ca3bba30613156bded9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1624,9 +1427,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5e4d3304-e5cd-4973-ace2-24fc5098e23f
+      - req-acf7fb1c-02c1-4f35-addb-620d8b574063
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1636,7 +1439,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1651,7 +1454,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9480f578090146ddadf7c4470a0513e8
+      - 40b2a4c92b4e4ca3bba30613156bded9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1664,9 +1467,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-60c5889f-a3ae-446e-a025-d119ac0c35fd
+      - req-e941cd20-6a4b-4bb4-8139-d41a131c26cc
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1676,7 +1479,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -1691,7 +1494,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1704,9 +1507,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-5bce407e-fa1c-4ccf-a9cd-30e0b770aa23
+      - req-3e448106-1f25-466d-b8f8-3dbfb4345230
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -1715,7 +1518,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -1730,7 +1533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1743,15 +1546,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-33ef99fc-28ff-40c0-9004-b24d23a7cee8
+      - req-1efb0297-ffd2-4961-b88c-5a4b4fb419e1
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -1766,7 +1569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -1777,19 +1580,19 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-2ab31e78-a71e-45d4-b946-d784f6350e77
+      - req-34951384-0c35-4c7e-b48b-e5816cd436a0
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -1804,7 +1607,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -1815,9 +1618,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-f3dcbe91-1949-4aed-9a62-fa9c00a4d450
+      - req-da8c4b7a-62df-4d13-92db-b172970b53d2
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -1827,7 +1630,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1845,13 +1648,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:25 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a138e751-a525-4f4b-aedc-482bc1e21b31
+      - req-eaa7a5ab-4294-4728-9be8-cc401d74e631
       Content-Length:
       - '4117'
       Connection:
@@ -1860,10 +1663,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:25.955177", "expires":
-        "2018-09-26T19:43:25Z", "id": "be39f6f50d2a48bd8419347c884b309a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:25.435797", "expires":
+        "2018-10-25T19:20:25Z", "id": "243def16d5da4d85bc7fc5d469a751d5", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MbVW3qA1Ss-cXBxm8xNngw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Gw9yY1z7TeeaNaNKg0emLA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1907,7 +1710,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:25 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1922,7 +1725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -1933,12 +1736,47 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-12b927fe-f1be-4326-a22a-a080e50467bd
+      - req-1fd27076-9d48-434d-b1d5-2f53ed7c15a1
       Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1985,179 +1823,12 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bb56d053-c419-4127-a8d3-7948de070857
-      Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2171,7 +1842,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:26 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2186,7 +1857,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -2197,57 +1868,16 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8b4e8781-da13-465e-a3d1-32b5c6316ac9
+      - req-c14bcf0f-949b-406d-892a-924ad38fb374
       Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -2256,6 +1886,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -2290,138 +1926,41 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1eebec9b-c95b-4626-81e4-7eef01c63ccc
-      Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2435,271 +1974,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a2a59fda-eaeb-4161-922a-73c8a0af3dbf
-      Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3c30c511-c149-4086-be70-fff9612793a0
-      Date:
-      - Wed, 26 Sep 2018 18:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2717,13 +1992,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:27 GMT
+      - Thu, 25 Oct 2018 18:20:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2b8d2182-bfd4-4158-9369-203130e6959b
+      - req-2fde00e7-9688-4304-a831-f9f5c4b3f9c0
       Content-Length:
       - '4131'
       Connection:
@@ -2732,10 +2007,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:27.170475", "expires":
-        "2018-09-26T19:43:27Z", "id": "24aa559c93004fd4bf9fe1dc23f1a590", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:25.955455", "expires":
+        "2018-10-25T19:20:25Z", "id": "371865eb4ce842ea983d259a8c5daae2", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qrF_eqKCSiamkTeyx8viqg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["poa6LNoAS_CNiqoDjHPfdg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2779,7 +2054,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2794,7 +2069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -2805,52 +2080,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a5335a8e-1af9-44e6-b497-de1b428c52ef
+      - req-488cb4a2-5f0f-44de-97bb-725220e607be
       Date:
-      - Wed, 26 Sep 2018 18:43:27 GMT
+      - Thu, 25 Oct 2018 18:20:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -2881,200 +2121,6 @@ http_interactions:
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9bca7372-bf44-4071-a084-fdd5fdfa999f
-      Date:
-      - Wed, 26 Sep 2018 18:43:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-69e6b850-29c6-45a0-be43-3a79fa0cdefa
-      Date:
-      - Wed, 26 Sep 2018 18:43:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -3121,6 +2167,62 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 371865eb4ce842ea983d259a8c5daae2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-617bf20c-532e-4c1e-b83c-eb9313da2433
+      Date:
+      - Thu, 25 Oct 2018 18:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
@@ -3128,6 +2230,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -3162,183 +2270,7 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-10ca1d00-39ba-49bc-955e-25bfe2ba7839
-      Date:
-      - Wed, 26 Sep 2018 18:43:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a51a6f3b-27f7-4a94-a1ee-32b036a61871
-      Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -3373,191 +2305,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-905cd9b0-b1aa-4c92-8efd-6d91d842c235
-      Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -3571,271 +2318,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-05653f2b-622d-41c4-99f1-36c3e2002f6f
-      Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0ef51a51-3ca9-4266-be1d-ba10d88cf604
-      Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3850,7 +2333,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -3861,52 +2344,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-427d934c-9508-4d71-8f9e-90ca8593c1f1
+      - req-f58e217d-1fee-4b01-8cb3-eb781109620a
       Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
+      - Thu, 25 Oct 2018 18:20:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -3954,20 +2402,187 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63fa622f04674ed4a4a6bd2df37f8f56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9928b513-0c8e-4902-ad6a-0047ab1e95db
+      Date:
+      - Thu, 25 Oct 2018 18:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3982,7 +2597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -3993,28 +2608,184 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2dc1eed0-d62f-40bf-963d-738022271f5b
+      - req-c991867b-f814-42cc-a5da-7739e12780dc
       Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
+      - Thu, 25 Oct 2018 18:20:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63fa622f04674ed4a4a6bd2df37f8f56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1d687b89-2422-40d3-8823-c2ca612c31f8
+      Date:
+      - Thu, 25 Oct 2018 18:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -4034,6 +2805,97 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:26 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63fa622f04674ed4a4a6bd2df37f8f56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ba82aedf-3ee5-4535-8162-c73f680316e9
+      Date:
+      - Thu, 25 Oct 2018 18:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -4086,20 +2948,169 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:28 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63fa622f04674ed4a4a6bd2df37f8f56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f3f89b19-748f-4ff6-8e40-5316832a1f1b
+      Date:
+      - Thu, 25 Oct 2018 18:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4117,13 +3128,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:28 GMT
+      - Thu, 25 Oct 2018 18:20:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0fd7fbb-697f-426c-a287-3393985ab0e2
+      - req-23a7ac6f-5dde-4aaf-aec4-e6ea7fabd875
       Content-Length:
       - '4118'
       Connection:
@@ -4132,10 +3143,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:29.020215", "expires":
-        "2018-09-26T19:43:29Z", "id": "e816b059857d44d5862c99a9e1be5b4f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:27.402507", "expires":
+        "2018-10-25T19:20:27Z", "id": "f69916843b0e4a8fae307ea1259c7676", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["-LLs8HEuS5adjLnSSO60eg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gr2f5sCCRwSNN96ZtIV3mw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4179,7 +3190,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -4194,7 +3205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -4205,28 +3216,52 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4c3efb78-45b9-4983-851b-6859cd4959cd
+      - req-84609bbd-30bb-41e7-9da8-b5b9151978a7
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -4274,44 +3309,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -4326,7 +3337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -4337,28 +3348,184 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1a7c718a-d6ab-4d2e-bac6-5edc175f636a
+      - req-addbe0d7-29e5-4f70-b0fd-727e93cbec37
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-db03b15f-1ebf-4dec-b28f-07fc23c87228
+      Date:
+      - Thu, 25 Oct 2018 18:20:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -4378,6 +3545,757 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:27 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-aee93c8b-d1fa-4d47-8c8d-281b4136cddb
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-45dacfca-bff6-41de-bb8c-02102e04a4cc
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d8c8b1ec-fa13-48ec-94c9-d0462400f13f
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f55303a2-240c-4588-b428-2f9eca4cdaba
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-09a31e45-3706-4c60-8b7d-653dcb393051
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7607502e-ea23-435d-baf1-cfaf0cad3cba
+      Date:
+      - Thu, 25 Oct 2018 18:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -4430,20 +4348,37 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -4458,7 +4393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -4469,9 +4404,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-636e9b20-96b5-4b2e-8366-9cae49abc385
+      - req-45087ba8-1ec1-4e29-b0f9-f24ccd0e2362
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4486,7 +4421,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4501,7 +4436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -4512,9 +4447,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-cebe5283-083d-43aa-9947-25e3f29ecbd6
+      - req-0e141367-dd98-44e0-aff1-2509f97ed902
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4550,7 +4485,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4565,7 +4500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -4576,9 +4511,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-e9723a60-f4c3-48d7-a101-1b0cb150ccf4
+      - req-63b5162c-d824-4658-a763-76fa384ea206
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4614,7 +4549,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4629,7 +4564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -4640,9 +4575,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-b00bfa1b-f428-40ac-98b2-c81187fafc64
+      - req-8439ff33-282a-4bae-9131-b8a2c4cbb37f
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4678,7 +4613,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4693,7 +4628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -4704,9 +4639,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-fb5a9e8c-516d-42a1-a03b-a62b9dfe774c
+      - req-2061d381-6fc0-465b-9293-538e45915db1
       Date:
-      - Wed, 26 Sep 2018 18:43:29 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4742,7 +4677,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:29 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4757,7 +4692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -4768,9 +4703,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-9595fd4a-a644-4817-91ed-3bde52f21a98
+      - req-315ad307-cc88-48a8-89bc-b4673695a867
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4806,7 +4741,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4821,7 +4756,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -4832,9 +4767,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-bff2aa12-b4ba-430e-afe1-5422f9e2c622
+      - req-ed5ffb8d-afb5-4170-9ae3-71eecaa194a6
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4870,7 +4805,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4885,7 +4820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -4896,9 +4831,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-7510cb4c-4c36-475b-bd9c-cc942f0d17d1
+      - req-459dfd94-54ab-4f34-90df-1a991575c441
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4934,7 +4869,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4949,7 +4884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -4960,9 +4895,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-fca2f4bd-c37e-4627-b584-5a5b836ddd30
+      - req-ab5f8efd-4ca6-41a3-8b9e-99490000604c
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4998,7 +4933,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -5013,7 +4948,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -5024,9 +4959,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-7f4fe5b9-0f3e-448f-9842-d54c34a21432
+      - req-47ce6228-67b9-437f-b4c0-242673985b43
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5035,7 +4970,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -5050,7 +4985,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -5061,9 +4996,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-d05b46ed-8e4c-4bb5-a71a-43ebb1603e4d
+      - req-6e0e1671-cadd-44a9-bcb8-e8ca2cfc93e4
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5149,7 +5084,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5164,7 +5099,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -5175,9 +5110,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-9c57941f-2462-428c-b8a4-cb208a18d80c
+      - req-c7382c56-3d02-41f8-b9d1-b66e4a33dd13
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -5191,7 +5126,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5209,13 +5144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:30 GMT
+      - Thu, 25 Oct 2018 18:20:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7eb1e881-c053-4c7f-91c0-665638a97e0f
+      - req-632f4194-267a-4e0f-a586-3977f07b4e75
       Content-Length:
       - '4117'
       Connection:
@@ -5224,10 +5159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-09-26T18:43:30.910681", "expires":
-        "2018-09-26T19:43:30Z", "id": "b78c540f976142e99222984c424320ff", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-10-25T18:20:30.369443", "expires":
+        "2018-10-25T19:20:30Z", "id": "3f4cc4b7b7e24246a2ed48f35d2937f3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LUPaV4prQXiG3eKNWyCjhQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["chG8bbF-QrC4ZPWtqxUVhg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5271,7 +5206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:30 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5286,22 +5221,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b78c540f976142e99222984c424320ff
+      - 3f4cc4b7b7e24246a2ed48f35d2937f3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5997f6ac-4939-47aa-b99c-d3ef10d3b291
+      - req-652dffa4-8db5-49ba-ae20-6903abef136b
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-5997f6ac-4939-47aa-b99c-d3ef10d3b291
+      - req-652dffa4-8db5-49ba-ae20-6903abef136b
       Date:
-      - Wed, 26 Sep 2018 18:43:31 GMT
+      - Thu, 25 Oct 2018 18:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5322,7 +5257,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5337,22 +5272,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b78c540f976142e99222984c424320ff
+      - 3f4cc4b7b7e24246a2ed48f35d2937f3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-72f79093-9af1-4743-8f5f-d07b0aeb462d
+      - req-77c4fabd-1faf-44f2-b3ae-2bfbae8b3122
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-72f79093-9af1-4743-8f5f-d07b0aeb462d
+      - req-77c4fabd-1faf-44f2-b3ae-2bfbae8b3122
       Date:
-      - Wed, 26 Sep 2018 18:43:31 GMT
+      - Thu, 25 Oct 2018 18:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -5373,7 +5308,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:31 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -5388,7 +5323,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5401,12 +5336,12 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-268ae5ed-4ffd-45ba-badb-4e60bac300a2
+      - req-454b89c7-699c-4af2-8fa5-8c996a80ffcc
       Date:
-      - Wed, 26 Sep 2018 18:43:32 GMT
+      - Thu, 25 Oct 2018 18:20:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"server": {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z",
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
@@ -5430,7 +5365,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -5445,7 +5380,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5458,9 +5393,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-4607e177-49a2-4870-aeff-a45b808d1aa9
+      - req-3b73539f-03ef-4904-ab3b-94dc08f63a12
       Date:
-      - Wed, 26 Sep 2018 18:43:32 GMT
+      - Thu, 25 Oct 2018 18:20:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -5468,7 +5403,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -5483,7 +5418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5496,9 +5431,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-3cddad24-0c73-4aa7-b941-bcfa89e3b659
+      - req-902ee120-8052-488b-8823-be0c97937815
       Date:
-      - Wed, 26 Sep 2018 18:43:32 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -5550,7 +5485,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:32 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -5565,7 +5500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5578,14 +5513,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-9077d67a-ea39-4ab8-bcb9-3beec972f100
+      - req-bdde8ce7-c576-43db-b762-9d3be83c09ff
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -5600,7 +5535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -5611,9 +5546,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-d0d3d4c9-f574-41d0-9405-7e96c6617689
+      - req-0b4b412c-3278-4fb5-bfc9-139a12c3f92e
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5622,7 +5557,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
@@ -5637,7 +5572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -5648,9 +5583,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Openstack-Request-Id:
-      - req-39eee6fd-37d2-46ee-8682-4639eaff2478
+      - req-7c96041b-6f85-4bac-b11a-ce5034a4cec6
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -5659,7 +5594,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5674,20 +5609,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0189a67f20a2490698dd9c373f38f71f'
+      - 63af1f8154ad41e6a0862aa1e413369e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2fe21a10-5bf1-44f9-9cb4-f8138caab3d2
+      - req-4fc180ae-f349-43b9-9948-7d4c5ed461c0
       Content-Length:
       - '500'
       Connection:
@@ -5704,7 +5639,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -5719,7 +5654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5732,9 +5667,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-2797b1df-07ee-49c2-a6cb-4afb557da457
+      - req-18850e8f-88bf-44ac-871e-18d16539f391
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -5743,7 +5678,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -5758,7 +5693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a76407a279084dccbb7591a269ee0152
+      - 566a56322f6343068a6c5b9f9adcd20c
   response:
     status:
       code: 200
@@ -5769,9 +5704,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e4bedda8-5917-4d0d-8194-7b60a5e93bf8
+      - req-45bf64e6-d1fa-4ca5-adf2-5318025deb56
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -5782,7 +5717,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -5797,7 +5732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1a58d222e1349439c6bf0ccac0ef4a1
+      - 9a5e4d7a8d234d56b6d0186a36d142a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5810,9 +5745,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ce211889-591b-4977-a7d2-5b5a42ea96d7
+      - req-2ea07a3d-21f0-4eb0-bf61-76f6b8f9b534
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5822,7 +5757,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5837,7 +5772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a1a58d222e1349439c6bf0ccac0ef4a1
+      - 9a5e4d7a8d234d56b6d0186a36d142a2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5850,9 +5785,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-47932f78-57d3-45e4-ade9-827feded2215
+      - req-a2aefaff-ec48-4a41-b926-a68ae183a6dd
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5862,7 +5797,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -5877,7 +5812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecb6f82ad9fa4d6ba0ac10eb5a87641b
+      - 18fd93bee33e48709b93255d6bab9550
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5890,9 +5825,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8b7e951e-f718-4831-8db5-cff014c375d3
+      - req-cc0f17a3-e782-4f41-92b3-d17a9bb2ce57
       Date:
-      - Wed, 26 Sep 2018 18:43:33 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5902,7 +5837,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:33 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5917,7 +5852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecb6f82ad9fa4d6ba0ac10eb5a87641b
+      - 18fd93bee33e48709b93255d6bab9550
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5930,9 +5865,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-10536a25-8e1d-42bc-9074-e49d7bdc22ef
+      - req-acf19e06-5556-46c1-90c6-40d86acf17e5
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5942,7 +5877,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -5957,7 +5892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5970,9 +5905,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-3462d4e2-8023-4673-81ba-d5759ccc6c5e
+      - req-97b97910-f044-4829-a4e5-42de2a15cd6f
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5982,7 +5917,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5997,7 +5932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6010,9 +5945,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1c6dd3a9-c76c-4b9a-8057-4517ee9e529e
+      - req-532464bc-368a-4d9b-b5de-e7c3c5696edb
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -6022,7 +5957,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -6037,7 +5972,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9480f578090146ddadf7c4470a0513e8
+      - 40b2a4c92b4e4ca3bba30613156bded9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6050,9 +5985,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-864c72de-e6dc-494e-8e97-db53f8934a0f
+      - req-7552426f-a81c-44e8-a7dd-9eb0c9061285
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -6062,7 +5997,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -6077,7 +6012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9480f578090146ddadf7c4470a0513e8
+      - 40b2a4c92b4e4ca3bba30613156bded9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6090,9 +6025,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-53636096-c4be-4003-8a8a-54f8de680499
+      - req-ca3746a3-af6d-426c-af47-e3fb560cda9d
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -6102,7 +6037,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -6117,7 +6052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6130,9 +6065,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-06611958-5d9c-4a6c-8a67-59d94a2bbc5d
+      - req-b6241de6-31d2-4b72-82f8-14a58d55764e
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -6141,7 +6076,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -6156,7 +6091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09d2ddbc5c6147649bd8c0fd1547bbbb'
+      - 0564c5e3558741d9a30288fe73a41418
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6169,15 +6104,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-aafd71c9-586e-4339-81b1-2b35e24d2346
+      - req-c56f59c7-435d-4994-8036-8847ff44c72b
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -6192,7 +6127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -6203,9 +6138,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-efb469ac-b34c-4abc-bd79-6219827c1774
+      - req-2e07dbe8-9c98-4023-904f-0c701cfb22e5
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
@@ -6215,7 +6150,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -6230,7 +6165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -6241,9 +6176,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-1ca36dd1-51c2-4e4a-875e-ef489e80699b
+      - req-8fb81297-2d77-4763-a957-b4d6a0dfa2ad
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -6253,7 +6188,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:34 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -6268,7 +6203,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -6279,46 +6214,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-36a946a1-38d3-44ca-a9a1-716f2056fde1
+      - req-041f752b-8cfb-4648-999a-e5eb3cbceadc
       Date:
-      - Wed, 26 Sep 2018 18:43:34 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -6326,12 +6260,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -6344,34 +6272,41 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6385,7 +6320,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6400,7 +6335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -6411,12 +6346,150 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1bd08c8a-1b77-4f28-89da-dfc4897c3cca
+      - req-c01cb7c7-158a-4047-bb5d-634967744281
       Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 371865eb4ce842ea983d259a8c5daae2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-30042ef3-2ad6-4b09-9e20-a67fa0dbc8e8
+      Date:
+      - Thu, 25 Oct 2018 18:20:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -6498,12 +6571,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
@@ -6517,7 +6584,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -6532,7 +6599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -6543,363 +6610,99 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2a1b6feb-50f4-4d00-96a9-e7cabdab111a
+      - req-2696430d-d216-4d22-a1d2-73ce89bd0c75
       Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7b896eae-27ed-474f-86e6-075e5a6e2f54
-      Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-aeb52250-bb91-4433-9e7a-9391b13295c8
-      Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6913,7 +6716,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6928,7 +6731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -6939,144 +6742,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1f384aa7-0144-4efe-918e-c609c0975bba
+      - req-deaaa603-9fbc-450f-a817-0847f543cbc3
       Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-92a9087f-46a0-4527-9a15-ea29baa637b1
-      Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -7158,12 +6835,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
@@ -7177,10 +6848,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:35 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:34 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -7192,7 +6863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -7203,68 +6874,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6e0a6f2d-d942-4936-8930-f7e2b551a53b
+      - req-cf6e83ca-efaf-427d-9519-682110930c51
       Date:
-      - Wed, 26 Sep 2018 18:43:35 GMT
+      - Thu, 25 Oct 2018 18:20:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -7296,138 +6944,29 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-59ce1ed3-30ec-4dd5-92d0-f39df2df43d1
-      Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
         false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -7441,7 +6980,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7456,7 +6995,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -7467,28 +7006,81 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5786cdf9-9fc1-4424-a0ae-3bfa34a70626
+      - req-3a9273f2-a124-4d60-855f-d79173b85ab5
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7501,6 +7093,62 @@ http_interactions:
         "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
         "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 63fa622f04674ed4a4a6bd2df37f8f56
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9bd92741-1ba7-4b28-9c62-cad5f46dc4e3
+      Date:
+      - Thu, 25 Oct 2018 18:20:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
@@ -7508,6 +7156,12 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -7560,23 +7214,40 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -7588,7 +7259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -7599,12 +7270,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-27794acc-0a85-40e0-88c7-e21f815b23b3
+      - req-958761d1-6b4a-4447-b51e-c04460a1d61b
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -7686,12 +7363,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
@@ -7705,10 +7376,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -7720,7 +7391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -7731,46 +7402,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-04d84be2-e7cf-40fc-bb40-94196cc3b534
+      - req-6754eb81-69a1-4931-b4a5-737160f44295
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -7778,12 +7448,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -7796,34 +7460,41 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -7837,7 +7508,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7852,7 +7523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -7863,12 +7534,18 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0d4c2be7-bb20-43eb-8163-05e91e137917
+      - req-14302b75-1296-4a13-8155-ceed40cde131
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -7950,12 +7627,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
@@ -7969,7 +7640,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
         "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7984,7 +7655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -7995,46 +7666,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e25a6356-bc62-4675-9f48-21f919198545
+      - req-a74ba70d-22c7-4c48-a693-2a65c2c727eb
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
-        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21",
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.51.2",
-        "end": "192.168.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.51.0/24", "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8042,12 +7712,6 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
@@ -8060,34 +7724,41 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
         "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
-        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
-        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
-        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8101,7 +7772,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:36 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8116,7 +7787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8127,52 +7798,17 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-304ee195-2213-4e89-8dd8-bc54aefd1fd9
+      - req-11e1ffeb-ae96-4c78-8deb-88a4a7d3f0c9
       Date:
-      - Wed, 26 Sep 2018 18:43:36 GMT
+      - Thu, 25 Oct 2018 18:20:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
+        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -8220,20 +7856,187 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-162c0a13-e4f4-4cd5-a7ed-397c8da48704
+      Date:
+      - Thu, 25 Oct 2018 18:20:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -8248,7 +8051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -8259,28 +8062,184 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ef65a41f-1c81-4a99-84b4-a5562aa599d2
+      - req-7f8d4ec7-2705-4d7f-86b3-1fb1b87e178f
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9bf4e7bd-3930-4cd5-bfb6-8009c58ce325
+      Date:
+      - Thu, 25 Oct 2018 18:20:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8300,6 +8259,97 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-102c6f59-4d3c-4f78-ba1b-33c5f5061faf
+      Date:
+      - Thu, 25 Oct 2018 18:20:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
+        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -8352,20 +8402,169 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:36 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f69916843b0e4a8fae307ea1259c7676
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-067f4ddf-1c46-4ef8-a9b9-66abc3e07aec
+      Date:
+      - Thu, 25 Oct 2018 18:20:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -8380,7 +8579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8391,9 +8590,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-13e0f97c-5ac5-49c9-a8a1-c1facc005354
+      - req-07fe0016-780e-45e6-8f9a-5d099a106bd0
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8408,7 +8607,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8423,7 +8622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -8434,9 +8633,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-baec31f6-6b8c-4044-a336-24202464950a
+      - req-a5ed9bc0-20ff-4221-9852-63b7614114c1
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8472,7 +8671,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8487,7 +8686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be39f6f50d2a48bd8419347c884b309a
+      - 243def16d5da4d85bc7fc5d469a751d5
   response:
     status:
       code: 200
@@ -8498,9 +8697,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-784fa267-e093-42c9-ae65-ea7a013d7dea
+      - req-8b029848-2976-40e4-a137-dc668355ea00
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8536,7 +8735,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8551,7 +8750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -8562,9 +8761,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-5901e53a-5a62-4de1-bd7d-9b85059f29eb
+      - req-9ef4f4f2-9e67-436f-ab6c-35fb52d4fdc3
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8600,7 +8799,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8615,7 +8814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24aa559c93004fd4bf9fe1dc23f1a590
+      - 371865eb4ce842ea983d259a8c5daae2
   response:
     status:
       code: 200
@@ -8626,9 +8825,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-0276e664-ab4d-42ce-a7e9-4b4322446c0f
+      - req-2f382233-146f-4366-9dab-f93232456697
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8664,7 +8863,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8679,7 +8878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8690,9 +8889,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-e5751264-9787-4767-bfb2-012dd30fce1f
+      - req-fd6130dd-78fc-400c-9715-9196f2a628dc
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8728,7 +8927,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8743,7 +8942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8754,9 +8953,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a2d5e365-c785-4f6c-b463-6446912f09c3
+      - req-25807423-21b8-4181-a96f-c5eb31d1a9a1
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8792,7 +8991,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:37 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -8807,7 +9006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -8818,9 +9017,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-81e6b300-39f0-45c9-b0ec-662913a18520
+      - req-304065f9-787c-4f3c-8898-56e5b25acf63
       Date:
-      - Wed, 26 Sep 2018 18:43:37 GMT
+      - Thu, 25 Oct 2018 18:20:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8856,7 +9055,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -8871,7 +9070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e816b059857d44d5862c99a9e1be5b4f
+      - f69916843b0e4a8fae307ea1259c7676
   response:
     status:
       code: 200
@@ -8882,9 +9081,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-7f53579d-7161-4484-9bf1-08e1e3a1af26
+      - req-90ff9623-fb55-4cf3-b5cc-d2c974311834
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8920,7 +9119,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -8935,7 +9134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8946,9 +9145,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-dbfc41c4-a5c2-413b-9b60-9503b101c74d
+      - req-be909b09-5c20-4122-a54a-0db0dc328415
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8957,7 +9156,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -8972,7 +9171,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -8983,9 +9182,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-c5797a50-db74-4168-92b7-e399050b749e
+      - req-d51ed974-7246-479c-afc8-56491929ddda
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -9071,7 +9270,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -9086,7 +9285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4780c3e22e6c4098bcc271b969cfd041
+      - 63fa622f04674ed4a4a6bd2df37f8f56
   response:
     status:
       code: 200
@@ -9097,9 +9296,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-8fee89ed-cdfd-47ed-8b16-e520c18d1a2b
+      - req-7ee63c02-4924-428d-afb5-7f09b1793b65
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -9113,7 +9312,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -9128,22 +9327,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b78c540f976142e99222984c424320ff
+      - 3f4cc4b7b7e24246a2ed48f35d2937f3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b97228e5-5585-4926-a686-ae974f238bf0
+      - req-953588ad-010e-44cb-b1db-b732415266b1
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-b97228e5-5585-4926-a686-ae974f238bf0
+      - req-953588ad-010e-44cb-b1db-b732415266b1
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -9164,7 +9363,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -9179,22 +9378,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b78c540f976142e99222984c424320ff
+      - 3f4cc4b7b7e24246a2ed48f35d2937f3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5298c3de-9cd8-42f9-8564-2b093a6c7e11
+      - req-5abb3837-5c46-4a8c-ae1c-90cec51fc7ff
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-5298c3de-9cd8-42f9-8564-2b093a6c7e11
+      - req-5abb3837-5c46-4a8c-ae1c-90cec51fc7ff
       Date:
-      - Wed, 26 Sep 2018 18:43:38 GMT
+      - Thu, 25 Oct 2018 18:20:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -9215,5 +9414,5 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Wed, 26 Sep 2018 18:43:38 GMT
+  recorded_at: Thu, 25 Oct 2018 18:20:38 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Changes necessary to use fog-openstack supporting "version less" endpoint (including identity) and which avoid tempering with URL path.

Tested: Cloud/Infra on Gaprindashvili and master

Requires https://github.com/ManageIQ/manageiq-gems-pending/pull/386