### PR TITLE
Use nil as initialiser for @orchestration_stacks to prevent looping.

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -46,7 +46,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
     @host_aggregates           = []
     @key_pairs                 = []
     @images                    = []
-    @orchestration_stacks      = []
+    @orchestration_stacks      = nil
     @quotas                    = []
     @vms                       = []
     @vnfs                      = []

--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -113,7 +113,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
     # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
     # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
     # can't get list of detailed stacks in one API call.
-    return @orchestration_stacks if @orchestration_stacks.any?
+    return @orchestration_stacks unless @orchestration_stacks.nil?
     @orchestration_stacks = if openstack_heat_global_admin?
                                 orchestration_service.handled_list(:stacks, {:show_nested => true, :global_tenant => true}, true).collect(&:details)
                               else

--- a/app/models/manageiq/providers/openstack/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/network_manager.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::NetworkManager < Man
     # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
     # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
     # can't get list of detailed stacks in one API call.
-    return @orchestration_stacks if @orchestration_stacks.any?
+    return @orchestration_stacks unless @orchestration_stacks.nil?
     @orchestration_stacks = if openstack_heat_global_admin?
                                 orchestration_service.handled_list(:stacks, {:show_nested => true, :global_tenant => true}, true).collect(&:details)
                               else

--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -81,7 +81,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
 
   def orchestration_stacks
     return [] if targets_by_association(:orchestration_stacks).blank?
-    return @orchestration_stacks if @orchestration_stacks.any?
+    return @orchestration_stacks unless @orchestration_stacks.nil?
     @orchestration_stacks = targets_by_association(:orchestration_stacks).collect do |target|
       get_orchestration_stack(target.manager_ref[:ems_ref], target.options[:tenant_id])
     end.compact


### PR DESCRIPTION
Hi everyone,

This PR resolves an issue I discovered where we will query Heat more than once per tenant during the NetworkManager refresh in environments where there are no orchestration stacks.

Where there are no orchestration stacks an empty list is always returned, which causes .any? to return False, and so doesn't stop another round of queries to Heat the next time orchestration_stacks is called.

The number of queries scales according to the number of cloud networks and security groups in the environment, as we attempt to match up their parent stack by calling orchestration_stacks...which triggers yet another batch of queries to Heat, one per tenant.

I did see a possible opportunity to adjust the initialisers for the other lists in Collector to also use the same logic, but given I'm not intimately familiar with the code I figured I'd narrow this PR to just orchestration_stacks and look at the others later, if there's interest.

Thanks!