### PR TITLE
bug 1513086: add cores per socket to OpenStack cloud inventory parser

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -330,6 +330,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       hardware = persister.hardwares.find_or_build(server)
       hardware.vm_or_template = server
       hardware.cpu_sockets = flavor.try(:vcpus)
+      hardware.cpu_cores_per_socket = 1
       hardware.cpu_total_cores = flavor.try(:vcpus)
       hardware.cpu_speed = parent_host.try(:hardware).try(:cpu_speed)
       hardware.memory_mb = flavor.try(:ram)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1513086

For OpenStack cloud, cpu_cores_per_socket was always set to 1 in the legacy refresh_parser
since OpenStack flavors only have a single "number of CPUs" param. The new inventory
parser was not setting this param at all, though, leaving it as nil.