### PR TITLE
Filter Keystone Projects by domain_id

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -122,7 +122,8 @@ module OpenstackHandle
     def list_user_projects_tenants(user_id)
       if respond_to?(:projects)
         # V3
-        list_user_projects(user_id).body['projects']
+        # filter projects by domain_id to ensure having projects only from domain_id entered in Provider form
+        list_user_projects(user_id).body['projects'].select { |project| project['domain_id'] == @os_handle.domain_id }
       else
         # V2
         user_projects = []


### PR DESCRIPTION
In order to connect from MIQ to OpenStack, MIQ lists projects
accessible for current User.

OpenStack provides list of all projects accessible for the User. But
MIQ allows to specify domain_id in Add provider form, so it is
expected see only project within such domain.

Adding filtering of projects available for the user by domain_id.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593923