### PR TITLE
Use empty name for volume if only size provided

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -54,10 +54,11 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
         indexed_key = :"#{key}_#{volumes.length + 1}"
         new_volume[key.to_sym] = values[indexed_key] if values.key?(indexed_key)
       end
-      if new_volume.blank?
+      if new_volume.blank? || new_volume.values.all?(&:blank?)
         prepare_volumes = false
       else
-        new_volume[:size] = "1" if new_volume[:size].empty?
+        new_volume[:size] = "1" if new_volume[:size].blank?
+        new_volume[:name] = "" unless new_volume.key?(:name)
         volumes.push new_volume
       end
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -434,15 +434,27 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
         expect(volumes[1]).to eq(:name => "v2n", :size => "v2s", :delete_on_terminate => false)
       end
-      it "with defaulr size" do
+      it "with default size" do
         volumes = workflow.prepare_volumes_fields(
           :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
           :name_2 => "v2n", :size_2 => "", :delete_on_terminate_2 => false,
+          :name_3 => "v3n", :delete_on_terminate_3 => false,
+          :other_irrelevant_key => 1
+        )
+        expect(volumes.length).to eq(3)
+        expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
+        expect(volumes[1]).to eq(:name => "v2n", :size => "1", :delete_on_terminate => false)
+        expect(volumes[2]).to eq(:name => "v3n", :size => "1", :delete_on_terminate => false)
+      end
+      it "with empty name if only size given" do
+        volumes = workflow.prepare_volumes_fields(
+          :name_1 => "v1n", :size_1 => "v1s", :delete_on_terminate_1 => true,
+          :size_2 => "v2s", :delete_on_terminate_2 => false,
           :other_irrelevant_key => 1
         )
         expect(volumes.length).to eq(2)
         expect(volumes[0]).to eq(:name => "v1n", :size => "v1s", :delete_on_terminate => true)
-        expect(volumes[1]).to eq(:name => "v2n", :size => "1", :delete_on_terminate => false)
+        expect(volumes[1]).to eq(:name => "", :size => "v2s", :delete_on_terminate => false)
       end
     end
 


### PR DESCRIPTION
Volumes that don't have name should be filtered from provisioning. When there is no name infinite loop may appear, so I added `index` variable.

https://bugzilla.redhat.com/show_bug.cgi?id=1625970

@aufi @mansam 