### PR TITLE
Take an optional "name" parameter when restoring volume backups

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup.rb
@@ -5,9 +5,9 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup < ::CloudV
   supports :delete
   supports :backup_restore
 
-  def raw_restore(volumeid)
+  def raw_restore(volumeid = nil, name = nil)
     with_provider_object do |backup|
-      backup.restore(volumeid)
+      backup.restore(volumeid, name)
     end
   rescue => e
     _log.error("backup=[#{name}], error: #{e}")


### PR DESCRIPTION
Fixes `raw_restore` to better reflect the Cinder API's ability to restore backups to brand new volumes.
Depends on core PR and a new fog-openstack release including https://github.com/fog/fog-openstack/pull/419

https://bugzilla.redhat.com/show_bug.cgi?id=1514970