### PR TITLE
Add StorageManager modules to fix CinderManager import paths

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
 
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
+  require_nested :StorageManager
   require_nested :TargetCollection
 
   attr_reader :availability_zones

--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager
+  require_nested :CinderManager
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
+  require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager
+  require_nested :CinderManager
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
   require_nested :NetworkManager
-  require_nested :CinderManager
+  require_nested :StorageManager
   require_nested :TargetCollection
 
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager
+  require_nested :CinderManager
+end


### PR DESCRIPTION
One of the recent inventory refactor PRs moved the location of the CinderManager inventory modules, which causes problems in the console and in other situations because the `require_nested :CinderManager` calls don't work. This adds modules to fix the import path and updates the `require_nested` call.