### PR TITLE
Make `default_security_group` visible in the API

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
+  virtual_has_one :default_security_group, :uses => :security_groups
+
   include ManageIQ::Providers::Openstack::HelperMethods
   has_and_belongs_to_many :miq_templates,
                           :foreign_key             => "cloud_tenant_id",


### PR DESCRIPTION
The `virtual_has_one` for `default_security_group` makes `default_security_group ` visible in the `cloud_tenants` API as shown below -

```
{
      "href": "http://localhost:3000/api/cloud_tenants/8",
      "id": "8",
      "name": "Massachusetts",
      "description": "",
      "enabled": true,
      "ems_ref": "52cf9d53e2a84e21b62e6c815157c59a",
      "ems_id": "7",
      "created_at": "2017-11-07T20:27:52Z",
      "updated_at": "2017-11-07T20:27:52Z",
      "type": "ManageIQ::Providers::Openstack::CloudManager::CloudTenant",
      "parent_id": null,
      "default_security_group": {
        "id": "117",
        "name": "default",
        "description": "Default security group",
        "type": "ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup",
        "ems_id": "8",
        "ems_ref": "e8b2d278-0968-4324-a027-6157c66ecbc6",
        "cloud_network_id": null,
        "cloud_tenant_id": "8",
        "orchestration_stack_id": null,
        "network_group_id": null,
        "network_router_id": null,
        "cloud_subnet_id": null
      }
    }
```

