### PR TITLE
[WIP] Download image data using url and upload it using fog

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -76,7 +76,9 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
 
   def self.raw_create_image(ext_management_system, create_options)
     ext_management_system.with_provider_connection(:service => 'Image') do |service|
-      service.create_image(create_options)
+      url = create_options.delete(:url)
+      image = service.images.create(create_options)
+      ManageIQ::Providers::Openstack::CloudManager::UploadImageWorkflow.create_job(ext_management_system, image.id, url)
     end
   rescue => err
     _log.error("image=[#{name}], error=[#{err}]")

--- a/app/models/manageiq/providers/openstack/cloud_manager/upload_image_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/upload_image_workflow.rb
@@ -1,0 +1,91 @@
+class ManageIQ::Providers::Openstack::CloudManager::UploadImageWorkflow < Job
+  def self.create_job(ext_management_system_id, image_id, url, timeout: 1.hour, poll_interval: 1.minute)
+    options = {
+      :ext_management_system_id => ext_management_system_id,
+      :url                      => url,
+      :image_id                 => image_id,
+      :timeout                  => timeout,
+      :poll_interval            => poll_interval,
+    }
+
+    super(name, options)
+  end
+
+  def upload_image
+    ext_management_system_id, image_id, url = options.values_at(:ext_management_system, :image_id, :url)
+
+    EmsCloud.find(ext_management_system_id).with_provider_connection(:service => 'Image') do |service|
+      options[:uploading] = true
+      started_on = Time.now.utc
+      update_attributes!(:started_on => started_on)
+      miq_task.update_attributes!(:started_on => started_on)
+      queue_signal(:poll_runner)
+
+      image = service.images.find_by_id(image_id)
+      service.handle_upload(image, url)
+      options[:uploading] = false
+    end
+    rescue => err
+      _log.error("image=[#{name}], error=[#{err}]")
+      queue_signal(:abort, "Failed to upload image", "error")
+  end
+
+  def poll_runner
+    uploading = context[:uploading?]
+    if uploading
+      if started_on + options[:timeout] < Time.now.utc
+        queue_signal(:abort, "Playbook has been running longer than timeout", "error")
+      else
+        queue_signal(:poll_runner, :deliver_on => deliver_on)
+      end
+    else
+      queue_signal(:post_upload_image)
+    end
+  end
+
+  alias initializing dispatch_start
+  alias start        upload_image
+  alias finish       process_finished
+  alias abort_job    process_abort
+  alias cancel       process_cancel
+  alias error        process_error
+
+  protected
+
+  def queue_signal(*args, deliver_on: nil)
+    role     = options[:role] || "ems_operations"
+    priority = options[:priority] || MiqQueue::NORMAL_PRIORITY
+
+    MiqQueue.put(
+      :class_name  => self.class.name,
+      :method_name => "signal",
+      :instance_id => id,
+      :priority    => priority,
+      :role        => role,
+      :zone        => zone,
+      :task_id     => guid,
+      :args        => args,
+      :deliver_on  => deliver_on,
+      :server_guid => MiqServer.my_server.guid,
+    )
+  end
+
+  def deliver_on
+    Time.now.utc + options[:poll_interval]
+  end
+
+  def load_transitions
+    self.state ||= 'initialize'
+
+    {
+      :initializing => {'initialize'       => 'waiting_to_start'},
+      :start        => {'waiting_to_start' => 'upload_image'},
+      :upload_image => {'upload_image'     => 'running'},
+      :poll_runner  => {'running'          => 'running'},
+      :finish       => {'*'                => 'finished'},
+      :abort_job    => {'*'                => 'aborting'},
+      :cancel       => {'*'                => 'canceling'},
+      :error        => {'*'                => '*'}
+    }
+  end
+end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
@@ -45,5 +45,13 @@ module OpenstackHandle
       @os_handle.accessor_for_accessible_tenants(
         SERVICE_NAME, :images_with_pagination_loop, :id)
     end
+
+    def handle_upload(image, url)
+      file = open(url) if url =~ URI::DEFAULT_PARSER.make_regexp
+      image.upload_data(file)
+    ensure
+      file.close
+      file.unlink
+    end
   end
 end


### PR DESCRIPTION
This PR adds method `handle_upload ` for downloading an image using link, and the uploads it to openstack.
I think it's the easiest way to upload image iso using miq. I don't find `open` method suitable here, but I'm also not sure if we have some replacement in miq. 
Please share your opinions @aufi @andyvesel @mansam 
https://github.com/ManageIQ/manageiq-ui-classic/issues/3944