### PR TITLE
Pass openstack_admin? flag to volume snapshot template collection

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
   def volume_snapshot_templates
     return [] unless volume_service
     return @volume_snapshot_templates if @volume_snapshot_templates.any?
-    @volume_snapshot_templates = volume_service.handled_list(:list_snapshots_detailed, :status => "available", :__request_body_index => "snapshots").select do |s|
+    @volume_snapshot_templates = volume_service.handled_list(:list_snapshots_detailed, {:status => "available", :__request_body_index => "snapshots"}, openstack_admin?).select do |s|
       volumes_by_id[s["volume_id"]] && (volumes_by_id[s["volume_id"]].attributes["bootable"].to_s == "true")
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:14 GMT
+      - Mon, 24 Sep 2018 20:27:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e44905d6-64b2-41b2-b489-ec8ed0268454
+      - req-ee8a5715-2e80-4de4-9062-58d14606ae49
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:14.384528", "expires":
-        "2018-08-06T17:57:14Z", "id": "078eaa69e9c543878ec7c68aecb0c5e8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:42.930932", "expires":
+        "2018-09-24T21:27:42Z", "id": "3d7818fb3e90444baf0a00cc6491ce70", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["l9qbFqv6Q526yrzzPruQrA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["p6Sdcy0IRK6nqTALKz9bbg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:57:14 GMT
+      - Mon, 24 Sep 2018 20:27:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-8cdaca07-9993-4cf5-897c-838216b40f5c
+      - req-3a020b9d-0291-423f-a8c8-35b508bfbe05
       Date:
-      - Mon, 06 Aug 2018 16:57:14 GMT
+      - Mon, 24 Sep 2018 20:27:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:15 GMT
+      - Mon, 24 Sep 2018 20:27:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7fa3c2ea-c8e4-4447-9eb9-224e11622701
+      - req-d30403e8-9b00-4e0e-8d8a-aab4af6507e8
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:15.212709", "expires":
-        "2018-08-06T17:57:15Z", "id": "0ba8b8791b9e44aa94346ec3c8eb29a6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:43.471730", "expires":
+        "2018-09-24T21:27:43Z", "id": "cd8b873bf49d4060b758f6ed41847ac1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["alQEUIb0R_y_f53JMo6WsQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pNUTtnt_RLOAg38LsSULyQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1199358b-e037-4d08-b6b5-24d94144f4ef
+      - req-6bf740c2-9baa-4563-94b0-1f34be788d7a
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-1199358b-e037-4d08-b6b5-24d94144f4ef
+      - req-6bf740c2-9baa-4563-94b0-1f34be788d7a
       Date:
-      - Mon, 06 Aug 2018 16:57:15 GMT
+      - Mon, 24 Sep 2018 20:27:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:15 GMT
+      - Mon, 24 Sep 2018 20:27:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-01e3b811-ef86-42fc-84bd-f7d61a3030bf
+      - req-63fae567-0a19-4693-a25f-b22f0d40956a
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:15.758472", "expires":
-        "2018-08-06T17:57:15Z", "id": "5476d7db35b64f88a1fe7b6e6700830f", "audit_ids":
-        ["X_IQ4sMLRTasVgrw8_VNrg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:43.906083", "expires":
+        "2018-09-24T21:27:43Z", "id": "da4564e882424027b3f9feceedf607ce", "audit_ids":
+        ["HhYljPXJRbGWV8XiGPfsiQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5476d7db35b64f88a1fe7b6e6700830f
+      - da4564e882424027b3f9feceedf607ce
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:15 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d16d7d3-08d5-4a77-8047-8573ec791ae1
+      - req-ad9f84ab-a4c9-422e-ae28-f1c30d3c1827
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"5476d7db35b64f88a1fe7b6e6700830f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"da4564e882424027b3f9feceedf607ce"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:16 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37ed4162-aba6-4c03-ac27-11b9030d30e6
+      - req-f1d2069a-b445-49d5-afb0-7dd8887b1294
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:16.227625", "expires":
-        "2018-08-06T17:57:15Z", "id": "2a6b4ce579924a9d8b68b5781d094f0f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:44.259988", "expires":
+        "2018-09-24T21:27:43Z", "id": "66a81451cd97430889f268b799ef939d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Slkk_tbfSlqZC35NQ4DENQ",
-        "X_IQ4sMLRTasVgrw8_VNrg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["G41rVMN-RqeeA3zH8Yd_QQ",
+        "HhYljPXJRbGWV8XiGPfsiQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5476d7db35b64f88a1fe7b6e6700830f
+      - da4564e882424027b3f9feceedf607ce
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:16 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-95666deb-9e79-4e7f-8e35-58366d46b9b9
+      - req-a0e9aaa4-b8b2-4b9e-91b7-a8013b150ef3
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:16 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-64e5576a-4c4c-4c4e-8f19-cf899685347f
+      - req-c71fbfb4-b62a-480e-9ead-176fbcdaad20
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:16.793382", "expires":
-        "2018-08-06T17:57:16Z", "id": "4aafc2c7239043219b0cb7566f19d2e9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:44.573797", "expires":
+        "2018-09-24T21:27:44Z", "id": "7c25be18749b49c3ac8235d331cb56c0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9nkpnLHLRN238DMd8PN4mg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BcPnkPzYTxuEORN5rSzDxA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:57:16 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:17 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1a2581f5-1d0f-4f4e-b47b-c189c683f0a0
+      - req-e7245ce7-fea9-4f1d-892a-834371fdbb66
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:17.273608", "expires":
-        "2018-08-06T17:57:17Z", "id": "5c242fc7622b4e68a0397f0d7c2e5168", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:44.824800", "expires":
+        "2018-09-24T21:27:44Z", "id": "f85d4c9df914491a8d80ecbcd0a9527c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kQK9Xc1pTlGA3-hyFHmIgA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-ftF55v0RVeGQsK2Tp9UEw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:57:17 GMT
+      - Mon, 24 Sep 2018 20:27:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:17 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-509a9994-3639-4ae4-a443-eb1ba6f44808
+      - req-73d3f7e3-5fbb-4dd1-ae10-2069239fa2a6
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:17.601488", "expires":
-        "2018-08-06T17:57:17Z", "id": "0ee26b136abb42faa6ddceba1fa46897", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:45.089858", "expires":
+        "2018-09-24T21:27:45Z", "id": "610f04f6d54c43e2b94e0a1440ddc947", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1VLRw12XR8eGrjOLLz41DA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["J0qeWfyLTxmDar0PpzIfCQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:57:17 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d8c8657c-64ef-4eea-b5a6-2855d7698afd
+      - req-3df1777e-2a04-44ba-8f1c-cc2750204820
       Date:
-      - Mon, 06 Aug 2018 16:57:18 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1ac4e352-1d88-40ac-9ef9-f68b9b051531
+      - req-a7cce6af-5f99-407f-89b5-53562847919b
       Date:
-      - Mon, 06 Aug 2018 16:57:18 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-499b2771-731e-4084-8bb9-76475dea6354
+      - req-ead181d4-c37a-4495-8396-1e7263dfd802
       Date:
-      - Mon, 06 Aug 2018 16:57:18 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-83b48cca-172a-4977-acd4-b642df8ca8ac
+      - req-ce133088-0a54-468b-986a-cb5dbe1d19be
       Date:
-      - Mon, 06 Aug 2018 16:57:19 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b6eb027f-dbfb-4311-a68e-8bbe4f5a3e2d
+      - req-4723d55c-9802-4c7a-b139-0f0ddeb8dc07
       Date:
-      - Mon, 06 Aug 2018 16:57:19 GMT
+      - Mon, 24 Sep 2018 20:27:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1e926000-0690-4e83-a004-4e98137479e7
+      - req-4004e267-e8f9-4351-839f-00c7383e4bb9
       Date:
-      - Mon, 06 Aug 2018 16:57:19 GMT
+      - Mon, 24 Sep 2018 20:27:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:46.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-253f5d5d-b775-42d2-b09c-81fa1f44edb5
+      - req-c9782772-65c6-4b52-8b74-c7e536ae3b2a
       Date:
-      - Mon, 06 Aug 2018 16:57:19 GMT
+      - Mon, 24 Sep 2018 20:27:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:46.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9ca286f9-3ead-4846-b3d6-0aeb42b87443
+      - req-95076752-474b-4cb6-a3cc-e49b24972660
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:57:10.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:27:46.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:27:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:57:12.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:27:45.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:57:10.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:27:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:57:10.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:27:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-880d3b56-ad19-4e58-a2c8-5af579549bc7
+      - req-f5155622-9645-4129-bbe9-b93536622708
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-0f54ea48-61e7-47ef-b469-5348019f0c3e
+      - req-ff8ead9b-3a0d-44bd-b889-3ccf1f0c53cd
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-8e6123a2-07c2-445e-954f-02ab2a9765e6
+      - req-16780d7c-0a00-49e9-a4ff-f67cd892bae8
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-e0022011-2dd6-4f48-ab1d-62754f7ed1ea
+      - req-82bfffc8-5d58-49bb-9d23-4e484d111653
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1400,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d1e20db8-3c59-41d1-bfe2-e44a2474f547
+      - req-c3d1e0ce-19ae-4584-919e-94d874480f0b
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:20 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d6f4942e-fdad-4cac-871f-60a805d8fbc4
+      - req-5bceb26a-a9bb-4d57-a5f2-f3df75ba2949
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1441,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:21.073526", "expires":
-        "2018-08-06T17:57:21Z", "id": "89b70f91398e45419f2e24ab3afc1b36", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:47.412058", "expires":
+        "2018-09-24T21:27:47Z", "id": "f613251cb9d34db887750ee9a74ceec0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YIs6ObHlRtydhXg5i8cn-g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["s5QHP-a9RVOqZz4ygcoc2w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,7 +1489,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89b70f91398e45419f2e24ab3afc1b36
+      - f613251cb9d34db887750ee9a74ceec0
   response:
     status:
       code: 300
@@ -1515,7 +1515,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:57:21 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -1528,7 +1528,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:21 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-580af0cc-0262-4f26-afbe-ab3e4580af71
+      - req-82bffef5-5363-4c35-9865-6615dc384a03
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:21.389086", "expires":
-        "2018-08-06T17:57:21Z", "id": "c2835f47fcd645e8820d15c2a30d4bc5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:47.676456", "expires":
+        "2018-09-24T21:27:47Z", "id": "4b670c66ee1840688ff31ec62e522e21", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GojZzZILSYWMSWcnk-I5SA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2fwC7duLSmqii44nJttopg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2835f47fcd645e8820d15c2a30d4bc5
+      - 4b670c66ee1840688ff31ec62e522e21
   response:
     status:
       code: 200
@@ -1634,9 +1634,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-927dfba4-9902-4ad2-a32b-9487250d07e5
+      - req-ab4f3982-df02-411d-8586-b1d6fb9d4ca7
       Date:
-      - Mon, 06 Aug 2018 16:57:21 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1678,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2835f47fcd645e8820d15c2a30d4bc5
+      - 4b670c66ee1840688ff31ec62e522e21
   response:
     status:
       code: 200
@@ -1704,14 +1704,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-efe5e07c-55b5-4d57-bd02-74f0e10f445d
+      - req-9d81311c-a9bd-41c8-8a9a-f1458da59344
       Date:
-      - Mon, 06 Aug 2018 16:57:21 GMT
+      - Mon, 24 Sep 2018 20:27:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1729,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:21 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a647d8e-af9e-463a-b3a9-7227078bea91
+      - req-a6a23683-788d-46bb-b84a-47ab0300afde
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1744,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:22.108729", "expires":
-        "2018-08-06T17:57:22Z", "id": "ebea12ca90a44a778d7f66a3efc49a56", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:48.138612", "expires":
+        "2018-09-24T21:27:48Z", "id": "62b8eac794dc4c13b9c8380bc221eb32", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UA9u1ZzUTAGO_AyAHwrwag"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["vuXPTBAKSFmsQmbFNYhM-w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1791,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebea12ca90a44a778d7f66a3efc49a56
+      - 62b8eac794dc4c13b9c8380bc221eb32
   response:
     status:
       code: 200
@@ -1817,9 +1817,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a419c51b-1266-4512-9965-d1501c1c3edc
+      - req-a9353663-9b1e-4366-961e-d7f11455d219
       Date:
-      - Mon, 06 Aug 2018 16:57:22 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1861,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebea12ca90a44a778d7f66a3efc49a56
+      - 62b8eac794dc4c13b9c8380bc221eb32
   response:
     status:
       code: 200
@@ -1887,14 +1887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-16237b71-c35e-4cb8-ac82-e1b4e952ff9a
+      - req-1aa6c1e4-c91b-4f13-b345-e7cba97219eb
       Date:
-      - Mon, 06 Aug 2018 16:57:22 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89b70f91398e45419f2e24ab3afc1b36
+      - f613251cb9d34db887750ee9a74ceec0
   response:
     status:
       code: 200
@@ -1920,9 +1920,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-66bd886a-6504-4613-8524-e6b9e5bbcc07
+      - req-866c35ca-5925-46cf-93dd-f3aebb3d93c7
       Date:
-      - Mon, 06 Aug 2018 16:57:23 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1964,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89b70f91398e45419f2e24ab3afc1b36
+      - f613251cb9d34db887750ee9a74ceec0
   response:
     status:
       code: 200
@@ -1990,14 +1990,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-02a8fb02-b2e2-41cd-b3bc-6bb7e5f0f6f9
+      - req-38cf4164-7830-4d6b-b0b1-de6b7500a008
       Date:
-      - Mon, 06 Aug 2018 16:57:23 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +2015,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:23 GMT
+      - Mon, 24 Sep 2018 20:27:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a932ada-04cf-4685-9786-f547397ded23
+      - req-dfa4af10-b5c4-4997-abc8-88f02a6dac5e
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +2030,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:23.738999", "expires":
-        "2018-08-06T17:57:23Z", "id": "37e1db40c62c4c028a5d164e30758c41", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:49.032318", "expires":
+        "2018-09-24T21:27:49Z", "id": "3e9a540c1e1f4ba2b61f545cc2fd163c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ao15b_o2RdiVtYeuWpYg5w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F5NeXXuHRdCWppWkUW3qFw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +2077,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +2092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37e1db40c62c4c028a5d164e30758c41
+      - 3e9a540c1e1f4ba2b61f545cc2fd163c
   response:
     status:
       code: 200
@@ -2103,9 +2103,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1f3d719d-0411-4ae7-991b-fc34ed41f6e8
+      - req-b45a77aa-618e-4368-93c8-1f51a15dff04
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +2147,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +2162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37e1db40c62c4c028a5d164e30758c41
+      - 3e9a540c1e1f4ba2b61f545cc2fd163c
   response:
     status:
       code: 200
@@ -2173,14 +2173,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-320aee33-cdbb-4cb1-af6c-6bb8e2f99ca3
+      - req-2edea41c-4e21-4b40-9502-61af99a00ca3
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2208,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-647b2713-f697-44f0-960e-45533cb0dc42
+      - req-0c84bad2-e88b-4ccd-9656-a12f10cd3dec
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2220,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2248,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d44e8d63-2f53-4b3b-8b36-be4599e9f035
+      - req-be0d9f32-953c-4eab-89a1-c4f7d917eead
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2260,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a6a652e0-a118-4860-91b9-6e609b96d265
+      - req-e352790d-178f-4cd1-ba6d-5b21cdee6ec0
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2300,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2328,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-fc089e0a-39f3-4232-ab58-bade3c71372f
+      - req-36c14302-9b8e-4169-81d3-927b80636daa
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2340,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2368,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d7e2a50e-5cf1-436b-9176-4d1468d83df4
+      - req-0c52342a-23db-4b26-a496-932b606f337c
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2380,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-20a96c74-108f-4e50-84dc-4f3c664e2e27
+      - req-29eabc63-fd39-4f0d-b4e8-81ad673389b9
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2420,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2448,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-49fe008d-049e-49d6-af10-d8c671c0ef61
+      - req-bf745b1c-ff00-4d3d-8480-79b68b7fa911
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2460,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2488,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-f20d8dec-3a4d-4b8e-baf3-c183980f243f
+      - req-5bcc0e38-1c90-485e-b9fb-b7eee2e77d2b
       Date:
-      - Mon, 06 Aug 2018 16:57:24 GMT
+      - Mon, 24 Sep 2018 20:27:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2500,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2518,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:25 GMT
+      - Mon, 24 Sep 2018 20:27:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-476b425b-489e-4f7c-b090-d495adfa1335
+      - req-83f6df54-0042-45a2-90d5-982016c4ea01
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2533,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:25.283441", "expires":
-        "2018-08-06T17:57:25Z", "id": "563414bd6a354ebabc7436dace579f99", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:50.336073", "expires":
+        "2018-09-24T21:27:50Z", "id": "0a1a22685be64efda2ab2219edf9b285", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["u-cVx4yVQBS21d9gJdq31A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tCK7B25PTK2knHLurwkmZw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2599,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:25 GMT
+      - Mon, 24 Sep 2018 20:27:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f26d89f2-0f3d-45db-a996-6c9ac8ebacf2
+      - req-552ee0ab-a1b4-4cef-a345-834852f6206a
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2614,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:25.494953", "expires":
-        "2018-08-06T17:57:25Z", "id": "4f02042fa9d14dd592d7b848b02771e6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:50.521239", "expires":
+        "2018-09-24T21:27:50Z", "id": "5e5a71e084eb4f2a8778cea24e5776cf", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EFcOjI4gREqul33Nl0Qb_g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KJMTudZ6Tvmoj-MqhGZt6Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2661,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -2687,9 +2687,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-ed2a6b23-08a2-430a-952b-9b7dcb9a8906
+      - req-99080ac4-58d3-419d-9933-cf4d426e98c1
       Date:
-      - Mon, 06 Aug 2018 16:57:25 GMT
+      - Mon, 24 Sep 2018 20:27:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2723,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -2749,14 +2749,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-763528bf-d00d-4b2d-ab0f-3789c0e681b4
+      - req-77869dfe-c94c-4792-8821-b37e4af3177b
       Date:
-      - Mon, 06 Aug 2018 16:57:25 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2774,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:25 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-316e8166-4fb5-4915-b183-eeab39f473cf
+      - req-7553998d-7a70-450f-a0aa-5d8bce0d4366
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2789,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:26.030458", "expires":
-        "2018-08-06T17:57:26Z", "id": "018558d0a26340809b0d267393f9ed47", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:51.199618", "expires":
+        "2018-09-24T21:27:51Z", "id": "1c86fbf1fdd74c3080c0fc106558829e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["85BWgzCAT8iHuOqEKnR5Vw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pQRvQUm4Q-S9wNL0wBKTPw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2836,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '018558d0a26340809b0d267393f9ed47'
+      - 1c86fbf1fdd74c3080c0fc106558829e
   response:
     status:
       code: 200
@@ -2862,14 +2862,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-97f81259-7df5-4522-8d7e-2d5c154a3e65
+      - req-4311cd1a-d731-4f8a-b105-c87d861e1282
       Date:
-      - Mon, 06 Aug 2018 16:57:26 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 563414bd6a354ebabc7436dace579f99
+      - 0a1a22685be64efda2ab2219edf9b285
   response:
     status:
       code: 200
@@ -2895,14 +2895,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cb8b6dd2-bfbc-40f4-b801-f376880fff27
+      - req-54df71b6-e269-4eec-aa4f-615d9cfb07c5
       Date:
-      - Mon, 06 Aug 2018 16:57:26 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:26 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-721c6fe2-5628-4c14-a3ad-d0c1f30b3c96
+      - req-d0edd1cf-b96b-4b3a-b8d8-23d21560baf6
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:26.710214", "expires":
-        "2018-08-06T17:57:26Z", "id": "2e2b7948134e419d802f404b3e9ff8b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:51.724027", "expires":
+        "2018-09-24T21:27:51Z", "id": "80e4877684244e8b8062b0f403410454", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8rMeploMRpmRqTpfk6ZNzA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["6wyRmR-6Qc-M2RiLFilgyQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2982,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2e2b7948134e419d802f404b3e9ff8b3
+      - 80e4877684244e8b8062b0f403410454
   response:
     status:
       code: 200
@@ -3008,14 +3008,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-65fb128d-1180-40a9-8eff-3e340fbdc673
+      - req-5a75c599-47ee-4a36-b938-2fd94167d492
       Date:
-      - Mon, 06 Aug 2018 16:57:26 GMT
+      - Mon, 24 Sep 2018 20:27:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8b6f5d57-2394-4158-90cb-f853f07ca86a
+      - req-1f0d240b-feef-42e4-9e28-2f9d853a62bf
       Date:
-      - Mon, 06 Aug 2018 16:57:27 GMT
+      - Mon, 24 Sep 2018 20:27:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +3070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +3085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3096,9 +3096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-45d1634c-b343-44da-921c-e6706b60c36f
+      - req-8c680be7-e9ba-4bf8-b6a0-3976074b185e
       Date:
-      - Mon, 06 Aug 2018 16:57:28 GMT
+      - Mon, 24 Sep 2018 20:27:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +3125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +3140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3151,9 +3151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-acc9a746-967f-445d-b233-d3ee0ab89f81
+      - req-507c6bca-680b-4661-be4d-eb691c24263f
       Date:
-      - Mon, 06 Aug 2018 16:57:29 GMT
+      - Mon, 24 Sep 2018 20:27:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3206,9 +3206,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2a9b53e9-12cd-4452-b0e5-c227777de8b8
+      - req-b7e07ece-2775-46d5-822f-8316300e9206
       Date:
-      - Mon, 06 Aug 2018 16:57:29 GMT
+      - Mon, 24 Sep 2018 20:27:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3264,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3290,9 +3290,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-143abf17-16c2-4ac3-be6e-bd74a1ea014f
+      - req-6d38cf1e-718a-47bb-a656-85873bb1ffd6
       Date:
-      - Mon, 06 Aug 2018 16:57:29 GMT
+      - Mon, 24 Sep 2018 20:27:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3304,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,13 +3332,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-304a6d7d-834d-4998-9483-0fa3ce983a25
+      - req-53ed1214-dbe4-46e8-b6dd-498795e09015
       Date:
-      - Mon, 06 Aug 2018 16:57:30 GMT
+      - Mon, 24 Sep 2018 20:27:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:07Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -3380,7 +3380,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3408,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-d9f9f200-d5a4-4eba-adff-88b13b560a5e
+      - req-ae4eaef0-b6ac-40de-a1fa-8075e2b184a4
       Date:
-      - Mon, 06 Aug 2018 16:57:31 GMT
+      - Mon, 24 Sep 2018 20:27:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3434,7 +3434,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:59:17Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -3456,7 +3456,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,13 +3484,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-2d24952e-cf5f-49a8-9bc2-75896a178ba7
+      - req-2b702c67-9670-4cd8-94f0-4eaee017f14e
       Date:
-      - Mon, 06 Aug 2018 16:57:31 GMT
+      - Mon, 24 Sep 2018 20:27:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:02Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -3511,7 +3511,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -3534,7 +3534,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3562,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-76270dd2-c846-4ac7-99ee-e2b0fceb5228
+      - req-cf28bb3f-a910-4a76-9c6a-3f09819d38ae
       Date:
-      - Mon, 06 Aug 2018 16:57:31 GMT
+      - Mon, 24 Sep 2018 20:27:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3606,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-d06de6c9-3bea-4563-af3e-df6588a8e4aa
+      - req-789a51e7-eb36-4d97-bee4-9dfd1f3a26bc
       Date:
-      - Mon, 06 Aug 2018 16:57:32 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3659,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3687,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-9233cc84-9f6a-4c08-9f0d-c72b98dda7e7
+      - req-c913742a-6c3e-4d7c-977f-1de4f3fbeee3
       Date:
-      - Mon, 06 Aug 2018 16:57:32 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3722,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-503c8f02-bd14-4435-8e15-038686f63ff8
+      - req-d8eb6946-2ead-419d-9eda-d965203b9e57
       Date:
-      - Mon, 06 Aug 2018 16:57:32 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3757,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-346ad0eb-b16e-49e0-8adf-752669230814
+      - req-8e54c4f0-0535-4772-b4a2-dc0023507388
       Date:
-      - Mon, 06 Aug 2018 16:57:32 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3790,9 +3790,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4e253dc6-a8ab-4851-8301-d7facc040ab0
+      - req-8385bc8a-c9c3-4bc0-b3c5-9bc839027d77
       Date:
-      - Mon, 06 Aug 2018 16:57:32 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3848,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3874,9 +3874,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c8d76dd0-bb0e-412f-8bbc-2a401d0e9e39
+      - req-f8dd4e71-3f47-42b8-8ee9-55f698f21aef
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3888,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2b5148b7-e9f0-46d6-a14d-6310dcc0c768
+      - req-b1cf9bed-1e18-4c22-93df-da6f31149778
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3972,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3987,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f02042fa9d14dd592d7b848b02771e6
+      - 5e5a71e084eb4f2a8778cea24e5776cf
   response:
     status:
       code: 200
@@ -3998,9 +3998,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-dfab3524-2fcf-40be-bad7-4a4c38840f3c
+      - req-2a0855c0-73fe-440a-af11-db73ce5211c7
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +4012,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +4027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +4040,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-962d0a0f-5866-4136-b87d-24fdaf625029
+      - req-23aca11e-38ca-4a24-8d58-a4b7953d13b9
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +4051,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +4066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c242fc7622b4e68a0397f0d7c2e5168
+      - f85d4c9df914491a8d80ecbcd0a9527c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +4079,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-71bdb20d-598d-4852-82f9-3b80c24877dc
+      - req-6c9f2b0f-9922-468d-a75f-6be81b8ff8af
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +4090,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +4105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +4118,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-74941136-1513-433d-b142-a1c549f0c4fc
+      - req-2533ede3-53de-4fad-abde-f55f08c55f1e
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +4129,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ee26b136abb42faa6ddceba1fa46897
+      - 610f04f6d54c43e2b94e0a1440ddc947
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +4157,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-81ecd6b1-af50-40d9-9a12-4151005dbd67
+      - req-96830c76-8b00-4251-a36b-59ffb80f94bb
       Date:
-      - Mon, 06 Aug 2018 16:57:33 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4168,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4186,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:34 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1afe23f3-2a7c-4f18-bb7b-3bd9f820534a
+      - req-9da087cb-36f1-4e0b-9203-02297d566295
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4201,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:34.275881", "expires":
-        "2018-08-06T17:57:34Z", "id": "7090925b3b954307813e2467e7dd908d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:27:59.560506", "expires":
+        "2018-09-24T21:27:59Z", "id": "49534d898b8f4245b65478223c7ff2dc", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BSHAnUwLS6mmIPDVLCJHNw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5ur-IuNmReaWkF92mJa8jQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4248,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bccd6614-a1ce-4a0f-98b6-3e58ffd6fae6
+      - req-446c3141-49d7-4849-848a-a6b79783171d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bccd6614-a1ce-4a0f-98b6-3e58ffd6fae6
+      - req-446c3141-49d7-4849-848a-a6b79783171d
       Date:
-      - Mon, 06 Aug 2018 16:57:34 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4288,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:27:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4306,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:34 GMT
+      - Mon, 24 Sep 2018 20:27:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3db4b271-dd05-4e0f-ab4e-a3434428822e
+      - req-5674b644-945d-47d7-b63b-af4a3fa000e9
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4321,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:34.941678", "expires":
-        "2018-08-06T17:57:34Z", "id": "57c2ba61eb0b49de944f293a8d4ed095", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:00.024390", "expires":
+        "2018-09-24T21:28:00Z", "id": "671f3e5caf9542b4ba0a8b0190d47f4a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["H6ri1B-xRTWOThKsIWVDCg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2grPRTJUTHWFrCiY5FGoOw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4368,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4383,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57c2ba61eb0b49de944f293a8d4ed095
+      - 671f3e5caf9542b4ba0a8b0190d47f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91e125a3-dc9c-4cf0-b5d3-798e02301c36
+      - req-bc4634f6-fa94-4e21-bf60-a760b332fab0
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-91e125a3-dc9c-4cf0-b5d3-798e02301c36
+      - req-bc4634f6-fa94-4e21-bf60-a760b332fab0
       Date:
-      - Mon, 06 Aug 2018 16:57:35 GMT
+      - Mon, 24 Sep 2018 20:28:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4408,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4423,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-070e7410-2a09-48f3-bd54-e173f472e7bd
+      - req-e097149e-3f08-4a1f-8f24-a6697df4b9e9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-070e7410-2a09-48f3-bd54-e173f472e7bd
+      - req-e097149e-3f08-4a1f-8f24-a6697df4b9e9
       Date:
-      - Mon, 06 Aug 2018 16:57:35 GMT
+      - Mon, 24 Sep 2018 20:28:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4448,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:35 GMT
+      - Mon, 24 Sep 2018 20:28:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e0a7a6ec-d377-46d0-8d23-3920cc492e41
+      - req-3d1be3c7-1e01-4349-9ffa-971d1b1c1f03
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:36.032736", "expires":
-        "2018-08-06T17:57:36Z", "id": "f33b74384ee7469da63c4cd45454349c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:00.748391", "expires":
+        "2018-09-24T21:28:00Z", "id": "8223cf8e522c4de5bd2cc030b12bebe5", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xupt7mIsTl2ZAjOr8XUU-Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8AP9A2TwQbaXJSK4_O2Phw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4543,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f33b74384ee7469da63c4cd45454349c
+      - 8223cf8e522c4de5bd2cc030b12bebe5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-88be64c4-ccfb-440d-af98-093fd4f64489
+      - req-73515daf-8ed2-4ab0-a26e-53c9ae6403a8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-88be64c4-ccfb-440d-af98-093fd4f64489
+      - req-73515daf-8ed2-4ab0-a26e-53c9ae6403a8
       Date:
-      - Mon, 06 Aug 2018 16:57:36 GMT
+      - Mon, 24 Sep 2018 20:28:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4568,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:36 GMT
+      - Mon, 24 Sep 2018 20:28:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bf4ae0ce-139f-48a1-8afe-40001c7a6a7b
+      - req-e291d4d9-c649-459d-84f0-436e892d5cd6
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:36.706126", "expires":
-        "2018-08-06T17:57:36Z", "id": "b6bfb521bad14ac487a2884792f844bc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:01.521096", "expires":
+        "2018-09-24T21:28:01Z", "id": "89717f3162eb4815803cfb8015f968c4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DwPZefJWQSuSA1Nq92Cf0w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mK79FfRFSWuA4zFIRliX0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,7 +4649,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -4664,7 +4664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6bfb521bad14ac487a2884792f844bc
+      - 89717f3162eb4815803cfb8015f968c4
   response:
     status:
       code: 200
@@ -4675,13 +4675,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:57:36 GMT
+      - Mon, 24 Sep 2018 20:28:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4699,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:36 GMT
+      - Mon, 24 Sep 2018 20:28:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-255133e0-7811-4f2f-abb2-8e852701aa23
+      - req-795197b9-caf3-4444-8b4c-830b8c8fcf85
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4714,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:37.121481", "expires":
-        "2018-08-06T17:57:37Z", "id": "5a15beacaa9f4534b7d7383f2a614d2e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:01.784701", "expires":
+        "2018-09-24T21:28:01Z", "id": "f970a649322240a1b84c089a828e79fd", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kA3GOxQYSu-7mEJbREgXCg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["VWIfzDIDQqyr-i6pfKAA-w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4761,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a15beacaa9f4534b7d7383f2a614d2e
+      - f970a649322240a1b84c089a828e79fd
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-78b5cb12-3270-4b1c-9c0a-d68a8969b1d8
+      - req-124914ce-d515-4e66-9d1d-891ac4084ab2
       Date:
-      - Mon, 06 Aug 2018 16:57:37 GMT
+      - Mon, 24 Sep 2018 20:28:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4814,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:37 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3b27f4e7-dce4-438e-b4a8-861037a4c3e4
+      - req-a75bb630-6b00-44ea-a20f-26f05bea057e
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4829,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:37.812790", "expires":
-        "2018-08-06T17:57:37Z", "id": "50ac831e4bb344f19bad38a5545bfba4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:02.124791", "expires":
+        "2018-09-24T21:28:02Z", "id": "2e1322e11c5d414ba81f284dc891611e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["b_TdRB1fRrmqzkgM1sYAsA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pyxiW8moQgifP2f_WB1mEA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4876,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50ac831e4bb344f19bad38a5545bfba4
+      - 2e1322e11c5d414ba81f284dc891611e
   response:
     status:
       code: 200
@@ -4902,16 +4902,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e275c4f7-b594-476b-beac-a2176b4fe241
+      - req-f6f357a0-6574-4c57-ba0d-99cb7b175645
       Date:
-      - Mon, 06 Aug 2018 16:57:38 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b6bfb521bad14ac487a2884792f844bc
+      - 89717f3162eb4815803cfb8015f968c4
   response:
     status:
       code: 200
@@ -4937,16 +4937,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-fb6d91a0-fb2b-4c0c-9099-e30279786fbf
+      - req-4e89c524-5a28-43ca-9210-139f58a45be2
       Date:
-      - Mon, 06 Aug 2018 16:57:38 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:38 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-850d80ef-035c-4c26-a39b-2e1f102603de
+      - req-a30fc382-7cc6-4e7a-84ab-390f329f2965
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:38.774177", "expires":
-        "2018-08-06T17:57:38Z", "id": "41cd06dca68b4dc8aca6aba47e058bb3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:02.603860", "expires":
+        "2018-09-24T21:28:02Z", "id": "fe0486da345f4e8884171568223f45e5", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xPObz_VGROGtC4IjikENxw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vG7A4mSOT--oIaG8IHGo2A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +5026,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +5041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41cd06dca68b4dc8aca6aba47e058bb3
+      - fe0486da345f4e8884171568223f45e5
   response:
     status:
       code: 200
@@ -5052,16 +5052,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-6acac745-5c8b-42da-87cc-1de85ae9196f
+      - req-29c1239f-00b7-412f-a134-14c12debb56f
       Date:
-      - Mon, 06 Aug 2018 16:57:39 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +5076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +5089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-938a6406-cfd4-49ef-90f2-fe928916d826
+      - req-884eb886-bcc2-4066-8ffc-15e410c508be
       Date:
-      - Mon, 06 Aug 2018 16:57:39 GMT
+      - Mon, 24 Sep 2018 20:28:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +5114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +5129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +5142,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1fffd602-8170-4185-9a73-40d650fe91dd
+      - req-270acc45-6f42-411e-858d-4da24984d8ad
       Date:
-      - Mon, 06 Aug 2018 16:57:39 GMT
+      - Mon, 24 Sep 2018 20:28:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +5167,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +5182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +5195,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-5f8646c4-1906-422f-9c7a-dbb749bec3bb
+      - req-4381d2d2-c703-4816-84cc-d2c2faee7a85
       Date:
-      - Mon, 06 Aug 2018 16:57:39 GMT
+      - Mon, 24 Sep 2018 20:28:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5220,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5248,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-bb90a561-3627-4f19-a65c-b2b3913b401a
+      - req-178c9d48-6289-4e3c-9a21-0c83f44828d1
       Date:
-      - Mon, 06 Aug 2018 16:57:40 GMT
+      - Mon, 24 Sep 2018 20:28:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5273,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5301,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1ca7c613-e0b6-4b31-8282-f2c80f85fedb
+      - req-37d05c92-d5c4-4bad-a0dc-f911baa08943
       Date:
-      - Mon, 06 Aug 2018 16:57:40 GMT
+      - Mon, 24 Sep 2018 20:28:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5326,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5354,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c1eecc91-ae05-4bdb-9709-d05536133d4f
+      - req-f72e4b05-1249-4d49-9034-eb60109eb2e6
       Date:
-      - Mon, 06 Aug 2018 16:57:40 GMT
+      - Mon, 24 Sep 2018 20:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5390,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3429e20b-1d0c-46c3-9e2f-0bdd073e7e6c
+      - req-10245cf0-f55f-4221-9f12-e1f64d3fde5d
       Date:
-      - Mon, 06 Aug 2018 16:57:40 GMT
+      - Mon, 24 Sep 2018 20:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5415,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5443,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-74ff6b02-95c8-4819-9025-6e1830c8238d
+      - req-177ab30e-e111-4126-9f7b-5fe5a137f090
       Date:
-      - Mon, 06 Aug 2018 16:57:40 GMT
+      - Mon, 24 Sep 2018 20:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5479,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-42ccdc57-f7d8-47d3-804b-ba364d5799c3
+      - req-613c5d11-d118-452c-9a46-9ea576769f01
       Date:
-      - Mon, 06 Aug 2018 16:57:41 GMT
+      - Mon, 24 Sep 2018 20:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5504,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5532,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-b56d9503-ae54-4ccf-8ad6-532111362290
+      - req-90e4cc1f-27a5-4454-ae80-1e63c4bf96f4
       Date:
-      - Mon, 06 Aug 2018 16:57:41 GMT
+      - Mon, 24 Sep 2018 20:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5557,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aafc2c7239043219b0cb7566f19d2e9
+      - 7c25be18749b49c3ac8235d331cb56c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5585,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-91b264d5-9af5-4b26-a5a2-7b8a7c54feac
+      - req-a145a504-4253-49f5-a803-ac8795cd4331
       Date:
-      - Mon, 06 Aug 2018 16:57:41 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5610,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5628,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:42 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2c4eec1-7f7a-428e-a078-f70f2231f851
+      - req-5fc1c0b7-0865-49a4-8dab-0f60d4ae612a
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5643,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.227441", "expires":
-        "2018-08-06T17:57:42Z", "id": "8381b78e078d4d05baf39ec32f109e37", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:05.273447", "expires":
+        "2018-09-24T21:28:05Z", "id": "7e74099bb4724ee5ac65fd93b46bfbec", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NNPA06YhTnmWwByDb4rrAQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ZUdi4jhWThO8U9R91UVZ3g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,13 +5691,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"8381b78e078d4d05baf39ec32f109e37"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"7e74099bb4724ee5ac65fd93b46bfbec"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5709,13 +5709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:42 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b73d55a7-ce3b-46c5-9030-c24220f260a6
+      - req-32f76ec9-5a9e-40ef-b2cc-08474eb21d7a
       Content-Length:
       - '4196'
       Connection:
@@ -5724,10 +5724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.452231", "expires":
-        "2018-08-06T17:57:42Z", "id": "0508fc0f99f74fcab682c4eb80c81b84", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:05.443105", "expires":
+        "2018-09-24T21:28:05Z", "id": "3b64d20fb84147fda83ea6d748d17478", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8X2W7KNcRRe18BZeHOTtoQ", "NNPA06YhTnmWwByDb4rrAQ"]},
+        "name": "admin"}, "audit_ids": ["p5FOmjrjQPKbPLBcefFpmg", "ZUdi4jhWThO8U9R91UVZ3g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5772,7 +5772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:42 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8a72ff0b-abe9-4c3c-a0d2-a93ac90e7704
+      - req-680bc33d-9244-43a2-bdc5-318a7df9427d
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:42.773822", "expires":
-        "2018-08-06T17:57:42Z", "id": "dc650f367f40425f8da1d91bdf14b619", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:05.663934", "expires":
+        "2018-09-24T21:28:05Z", "id": "4ee2ba6b8fac45f9bebaa73d439a5f7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8VLGoTYiQze8Y3XxYPfTLw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["cLlMXH20TqKtYKZrhiJfCQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,13 +5853,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"dc650f367f40425f8da1d91bdf14b619"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"4ee2ba6b8fac45f9bebaa73d439a5f7f"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5871,13 +5871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:42 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9a10f984-4959-4b1c-b4f2-21b35f317cf8
+      - req-270a4a36-f5d8-4be1-834e-9a996d09428b
       Content-Length:
       - '4196'
       Connection:
@@ -5886,10 +5886,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:43.037412", "expires":
-        "2018-08-06T17:57:42Z", "id": "3afb64507b6f416ab3b7c64d26f6e61e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:05.831768", "expires":
+        "2018-09-24T21:28:05Z", "id": "f763985ab08846108339bdcfa54e54b4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["LKAGM51qRPiy5vJ8K9N6zw", "8VLGoTYiQze8Y3XxYPfTLw"]},
+        "name": "admin"}, "audit_ids": ["6My_OULmQKy6xJxNEB6yzw", "cLlMXH20TqKtYKZrhiJfCQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5934,7 +5934,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '078eaa69e9c543878ec7c68aecb0c5e8'
+      - 3d7818fb3e90444baf0a00cc6491ce70
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5962,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-6506627a-35d6-4e43-a094-e3a18923a1de
+      - req-35a152af-596c-4375-b428-d0951194c09a
       Date:
-      - Mon, 06 Aug 2018 16:57:43 GMT
+      - Mon, 24 Sep 2018 20:28:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5984,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c76efeb8-42d3-4385-8784-046516c062f8
+      - req-8b8459af-2ba0-416e-9758-55e022d1117f
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-c76efeb8-42d3-4385-8784-046516c062f8
+      - req-8b8459af-2ba0-416e-9758-55e022d1117f
       Date:
-      - Mon, 06 Aug 2018 16:57:43 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +6032,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +6047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25f0705d-3c70-4809-9939-e29f1c17711f
+      - req-9caa4c89-e415-402f-80ce-da6060b164cb
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-25f0705d-3c70-4809-9939-e29f1c17711f
+      - req-9caa4c89-e415-402f-80ce-da6060b164cb
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +6079,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +6094,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57c2ba61eb0b49de944f293a8d4ed095
+      - 671f3e5caf9542b4ba0a8b0190d47f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a100ecc-712b-4965-9ec5-5a671beb54d6
+      - req-cbd2a0b7-487e-4963-94a4-c1327da57791
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4a100ecc-712b-4965-9ec5-5a671beb54d6
+      - req-cbd2a0b7-487e-4963-94a4-c1327da57791
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +6129,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a766368-6572-41b9-93de-951f51ff6c15
+      - req-1c75f315-b4b1-4dc3-8203-e3b25ddc63c9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8a766368-6572-41b9-93de-951f51ff6c15
+      - req-1c75f315-b4b1-4dc3-8203-e3b25ddc63c9
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +6164,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f33b74384ee7469da63c4cd45454349c
+      - 8223cf8e522c4de5bd2cc030b12bebe5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7839e31c-13e6-4ff1-a517-d6f59677e806
+      - req-912b82e6-9e0d-45ae-aaa1-60d23e1407c2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7839e31c-13e6-4ff1-a517-d6f59677e806
+      - req-912b82e6-9e0d-45ae-aaa1-60d23e1407c2
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +6199,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d66d8781-0810-4833-9b6b-f5f619207355
+      - req-c6d3b8e9-505c-4f89-abfa-41fae81cf294
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-d66d8781-0810-4833-9b6b-f5f619207355
+      - req-c6d3b8e9-505c-4f89-abfa-41fae81cf294
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +6229,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +6244,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-44268025-29cb-4ab4-babc-1de9c81f1200
+      - req-e3521dde-fcf9-41b4-ab76-6ca2c297ca5f
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-44268025-29cb-4ab4-babc-1de9c81f1200
+      - req-e3521dde-fcf9-41b4-ab76-6ca2c297ca5f
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +6274,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +6289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57c2ba61eb0b49de944f293a8d4ed095
+      - 671f3e5caf9542b4ba0a8b0190d47f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f0720bbb-9256-4b6b-b015-fe13b56cd9c0
+      - req-e871542f-312c-428d-af5a-f183ceeab7b3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f0720bbb-9256-4b6b-b015-fe13b56cd9c0
+      - req-e871542f-312c-428d-af5a-f183ceeab7b3
       Date:
-      - Mon, 06 Aug 2018 16:57:44 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +6324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57c2ba61eb0b49de944f293a8d4ed095
+      - 671f3e5caf9542b4ba0a8b0190d47f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e298a624-b36e-4e8d-9dd5-5baf75f81dcf
+      - req-90ce8840-fa6b-4988-8197-1f2032260e9b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e298a624-b36e-4e8d-9dd5-5baf75f81dcf
+      - req-90ce8840-fa6b-4988-8197-1f2032260e9b
       Date:
-      - Mon, 06 Aug 2018 16:57:45 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd9483a2-ed77-44e8-942b-232feec08fac
+      - req-75401a8f-83c0-47d2-a1d5-ee3bb9e5c3a7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dd9483a2-ed77-44e8-942b-232feec08fac
+      - req-75401a8f-83c0-47d2-a1d5-ee3bb9e5c3a7
       Date:
-      - Mon, 06 Aug 2018 16:57:45 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-afdd1005-9012-4516-b359-72f653e7ddfc
+      - req-196bc750-45a0-4278-bedf-03ce48849e2c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-afdd1005-9012-4516-b359-72f653e7ddfc
+      - req-196bc750-45a0-4278-bedf-03ce48849e2c
       Date:
-      - Mon, 06 Aug 2018 16:57:45 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f33b74384ee7469da63c4cd45454349c
+      - 8223cf8e522c4de5bd2cc030b12bebe5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9ce6bd3-ca6a-4c05-85c3-3a5276b62761
+      - req-0ebb454c-330d-4d3a-bfcd-56a10aeaef5b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e9ce6bd3-ca6a-4c05-85c3-3a5276b62761
+      - req-0ebb454c-330d-4d3a-bfcd-56a10aeaef5b
       Date:
-      - Mon, 06 Aug 2018 16:57:45 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f33b74384ee7469da63c4cd45454349c
+      - 8223cf8e522c4de5bd2cc030b12bebe5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a161aca3-ce6e-40da-acbb-8b809db84744
+      - req-4bd13310-45ef-47d9-ae4e-fc18c4d473f4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a161aca3-ce6e-40da-acbb-8b809db84744
+      - req-4bd13310-45ef-47d9-ae4e-fc18c4d473f4
       Date:
-      - Mon, 06 Aug 2018 16:57:45 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6499,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c50e0c1c-9499-4b25-b305-c345c1c2ba71
+      - req-f6c7ea8d-12b3-41cc-a72a-aa66219683d5
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-c50e0c1c-9499-4b25-b305-c345c1c2ba71
+      - req-f6c7ea8d-12b3-41cc-a72a-aa66219683d5
       Date:
-      - Mon, 06 Aug 2018 16:57:46 GMT
+      - Mon, 24 Sep 2018 20:28:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6547,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6562,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6b36a64-4fef-4f2d-985a-2211bc731805
+      - req-9dd67b15-331f-4ec8-b944-574d4815b860
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-b6b36a64-4fef-4f2d-985a-2211bc731805
+      - req-9dd67b15-331f-4ec8-b944-574d4815b860
       Date:
-      - Mon, 06 Aug 2018 16:57:46 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6618,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6633,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4fec052d-2c14-4d34-bbba-d8f5bcd20a07
+      - req-2dd6f313-8fc4-46f5-b492-c9f1e3de995e
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-4fec052d-2c14-4d34-bbba-d8f5bcd20a07
+      - req-2dd6f313-8fc4-46f5-b492-c9f1e3de995e
       Date:
-      - Mon, 06 Aug 2018 16:57:46 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6682,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6697,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7090925b3b954307813e2467e7dd908d
+      - 49534d898b8f4245b65478223c7ff2dc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f8e17a5-cbfa-4677-9e4b-95561f2a17a2
+      - req-08825b30-49ce-4524-bdcf-686365b4e2af
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4f8e17a5-cbfa-4677-9e4b-95561f2a17a2
+      - req-08825b30-49ce-4524-bdcf-686365b4e2af
       Date:
-      - Mon, 06 Aug 2018 16:57:47 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6732,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57c2ba61eb0b49de944f293a8d4ed095
+      - 671f3e5caf9542b4ba0a8b0190d47f4a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-88dbc837-e886-4c67-a9f7-1052935e581c
+      - req-23d883cd-15ce-4a8d-9ea2-e2b3402b56ca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-88dbc837-e886-4c67-a9f7-1052935e581c
+      - req-23d883cd-15ce-4a8d-9ea2-e2b3402b56ca
       Date:
-      - Mon, 06 Aug 2018 16:57:47 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6767,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ba8b8791b9e44aa94346ec3c8eb29a6
+      - cd8b873bf49d4060b758f6ed41847ac1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bdb696fe-adbd-436c-b8ad-4b3d93461960
+      - req-5ed26c13-51bb-4bbb-807a-9b45d534a98d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bdb696fe-adbd-436c-b8ad-4b3d93461960
+      - req-5ed26c13-51bb-4bbb-807a-9b45d534a98d
       Date:
-      - Mon, 06 Aug 2018 16:57:47 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6802,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f33b74384ee7469da63c4cd45454349c
+      - 8223cf8e522c4de5bd2cc030b12bebe5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f017cb3-e95e-444c-8097-5c842e605aec
+      - req-3c1a1541-e59c-4478-82f6-d0736632eb26
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0f017cb3-e95e-444c-8097-5c842e605aec
+      - req-3c1a1541-e59c-4478-82f6-d0736632eb26
       Date:
-      - Mon, 06 Aug 2018 16:57:47 GMT
+      - Mon, 24 Sep 2018 20:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6840,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:48 GMT
+      - Mon, 24 Sep 2018 20:28:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9f4a7a8-9130-4fc9-a32f-b29c8323cbb6
+      - req-3a4920fc-b69d-4627-a0c6-9d5b1efceb2c
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6855,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:49.187206", "expires":
-        "2018-08-06T17:57:49Z", "id": "dd57888855324c91a179cb7006ca8254", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:10.884323", "expires":
+        "2018-09-24T21:28:10Z", "id": "eac76119eda74f9d82c7ea0b25546fa0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["VclPafzVR9GTxcJCi6UFew"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DyZbABtXToqpTmK_z1Tjfw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6903,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:49 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13436c7e-5076-4cec-826e-6c2adea8697d
+      - req-455d931e-9856-4bd7-a07b-ec6ff9e02081
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6936,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:49.606674", "expires":
-        "2018-08-06T17:57:49Z", "id": "6580d3d4ca194423aca5e349bb6e8405", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:11.067946", "expires":
+        "2018-09-24T21:28:11Z", "id": "7f23c3d227b8449dadb56b982fba6751", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3g5PCKERRB-7o2TA8OzY9w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Q90-rMS2RqCKt5wYpQkSBg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6984,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -7010,9 +7010,9 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-44d858fc-dbb0-4ed7-b534-b9724c75af04
+      - req-b70533c4-4716-4637-b886-6f3cce622d87
       Date:
-      - Mon, 06 Aug 2018 16:57:50 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
@@ -7082,7 +7082,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +7100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:50 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-490adb6d-47a5-4ae0-9f4a-0fa10bb61b5a
+      - req-b8b21115-fafc-4a0e-b84b-95ae2918bac5
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +7115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:50.313088", "expires":
-        "2018-08-06T17:57:50Z", "id": "9e5d0d94a7d44f918721b716bd706c07", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:11.440279", "expires":
+        "2018-09-24T21:28:11Z", "id": "58f11c15981943fea234070b14caaf9d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["JPf_rMigTTW7icUuuTB_mQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["d1G063EIRxOOC-gk_47TDw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,7 +7163,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7181,13 +7181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:50 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-83588a47-a060-425b-bf5d-02e9e0845e52
+      - req-ca7f7616-3d67-46c6-9233-fb019bf83296
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +7196,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:50.508478", "expires":
-        "2018-08-06T17:57:50Z", "id": "28deb78239334386bf4059015f8a4029", "audit_ids":
-        ["o5u6svz_T36jhJmDkJ91EA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:11.610426", "expires":
+        "2018-09-24T21:28:11Z", "id": "61a5e4dc24ad46c98e2bcae79391b1e9", "audit_ids":
+        ["rtQuZl-5QP2Nmp2JtnYxvw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +7217,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28deb78239334386bf4059015f8a4029
+      - 61a5e4dc24ad46c98e2bcae79391b1e9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:50 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a8d4e66-b661-4902-aee3-a429a7a3a98a
+      - req-62b6583a-f19a-4c5f-a4b5-a5f4d85ffe9a
       Content-Length:
       - '500'
       Connection:
@@ -7247,13 +7247,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"28deb78239334386bf4059015f8a4029"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"61a5e4dc24ad46c98e2bcae79391b1e9"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7265,13 +7265,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:50 GMT
+      - Mon, 24 Sep 2018 20:28:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c9b4b5c9-a2d4-4be3-9ab9-9dc8a261cd47
+      - req-6d98ecae-9bbc-4d6a-926e-6a3fc424d0d5
       Content-Length:
       - '4143'
       Connection:
@@ -7280,11 +7280,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.035031", "expires":
-        "2018-08-06T17:57:50Z", "id": "16d137641b3a4633ae709b93f4addcab", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:11.913502", "expires":
+        "2018-09-24T21:28:11Z", "id": "00a9d38eac2a40669ce2d38d558599b1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sFYwbaqwQ82JaWkIdJaTAg",
-        "o5u6svz_T36jhJmDkJ91EA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yeVmJNyET2yyx73vFdEp0w",
+        "rtQuZl-5QP2Nmp2JtnYxvw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7328,7 +7328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7343,20 +7343,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28deb78239334386bf4059015f8a4029
+      - 61a5e4dc24ad46c98e2bcae79391b1e9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:51 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1785e0fc-d1e0-41e1-afc4-747ede533e36
+      - req-b8fcadd5-d3fe-439c-802d-a0f1e7be6802
       Content-Length:
       - '500'
       Connection:
@@ -7373,7 +7373,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +7391,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:51 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4a1d6115-d556-443c-89d3-699ea80b4618
+      - req-0ec68c86-a1bb-4d9a-b65a-25e9f2c58294
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +7406,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.564893", "expires":
-        "2018-08-06T17:57:51Z", "id": "b3211cb00ade41bba702ecc60cbca352", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:12.224475", "expires":
+        "2018-09-24T21:28:12Z", "id": "d1ebaa4c0854441fb5e0154e370cdb5a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BM2kd74uSCenz15y2P2pOg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rUSouBQbRYKdwu-rtyDSnw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +7453,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +7471,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:51 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-285064d5-5464-48df-85dd-5236176f6f3e
+      - req-5d5b883e-b376-47d7-96ec-76c68e28ab13
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7486,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:51.992766", "expires":
-        "2018-08-06T17:57:51Z", "id": "3b0d9774798c4ce39073f5999ac99c74", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:12.402138", "expires":
+        "2018-09-24T21:28:12Z", "id": "65d82e20ace741c6b3e0f3e80b258ead", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eQ5Iu0ZNRg6us4jlKjxv9A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UYK2x4CLSMW51IUdBv3Uow"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7533,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7551,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:52 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47acbcb0-ae9a-4f43-85b4-27919e79d7bf
+      - req-d19b01ff-e7d6-43a3-9d71-4eb920d28ef7
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7566,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:52.215565", "expires":
-        "2018-08-06T17:57:52Z", "id": "b9e4cf23459043e78059f36316f6ad6c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:12.581999", "expires":
+        "2018-09-24T21:28:12Z", "id": "4a86fef1d87c4c53aeb8df93c92dbe98", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Pxrlr0o2Sm2L5GW0_piJgA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["mOK3Dg4XTwGN9yAi3f1Nqw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7613,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7631,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:52 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5ee38814-f10d-4795-8294-20d99dad7080
+      - req-b55543da-56c5-4470-bc0c-a809a4d191a2
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7646,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:52.418709", "expires":
-        "2018-08-06T17:57:52Z", "id": "97270ec95e3f4658a3b06b6dd2eb5e9b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:12.762634", "expires":
+        "2018-09-24T21:28:12Z", "id": "3d137f70778c4c2183a75ee16b4cd46c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9E8umNwlSPyXFVc1kCxOug"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["nMJSvrcQQ_ytO8QA93puIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7693,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -7719,9 +7719,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-ebc838a2-20a3-4181-a49c-acaf17be085f
+      - req-f5661d8e-4961-4801-bcf2-637e68e6db43
       Date:
-      - Mon, 06 Aug 2018 16:57:52 GMT
+      - Mon, 24 Sep 2018 20:28:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7755,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -7781,14 +7781,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ddf09db8-bf99-4561-a1ad-1b49aff3aeaf
+      - req-d45fd048-8dc9-4526-92cf-619d0e6fb346
       Date:
-      - Mon, 06 Aug 2018 16:57:52 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7806,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:53 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49d7e653-55f6-4937-8593-326660184385
+      - req-55b4911e-73d4-4c16-8c10-2fe73767a99e
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7821,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:53.179080", "expires":
-        "2018-08-06T17:57:53Z", "id": "1b87cc2b937b417da18fb6ef67a3f25c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:13.250852", "expires":
+        "2018-09-24T21:28:13Z", "id": "ff0ae6ccd5a64944b639ad51e5ffdd4b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aMzPNuHQQymqZqCkphmXfQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BYD9LRVVSySwHs9_xj0Yqw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7868,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7883,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b87cc2b937b417da18fb6ef67a3f25c
+      - ff0ae6ccd5a64944b639ad51e5ffdd4b
   response:
     status:
       code: 200
@@ -7894,14 +7894,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-89bb3092-a0e4-4678-a1ff-d23fec95bdd0
+      - req-87a7a70d-d8bd-44dc-ae29-ac300ce062a9
       Date:
-      - Mon, 06 Aug 2018 16:57:53 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e5d0d94a7d44f918721b716bd706c07
+      - 58f11c15981943fea234070b14caaf9d
   response:
     status:
       code: 200
@@ -7927,14 +7927,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f4096b94-ef84-4e63-9d40-ca30842c2d94
+      - req-7b8e8b7b-56b3-4167-8573-a1ae843f923c
       Date:
-      - Mon, 06 Aug 2018 16:57:53 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7952,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:54 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68d6c272-bd8d-4cd4-bf86-d3a41877affd
+      - req-e2a01162-8561-40fc-a2dd-5038b2e85ffd
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7967,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:54.261776", "expires":
-        "2018-08-06T17:57:54Z", "id": "2f28f691c6a440488f8a0f36ae15a686", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:13.732711", "expires":
+        "2018-09-24T21:28:13Z", "id": "5efae7718a664e5f855df0cf13dd30aa", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["toceDb3JTaC2rNkiLnHvIg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yU_lLjsYSRqoyK9ruc7vqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +8014,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +8029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f28f691c6a440488f8a0f36ae15a686
+      - 5efae7718a664e5f855df0cf13dd30aa
   response:
     status:
       code: 200
@@ -8040,14 +8040,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3cd1cb39-ea42-440b-a09c-980ecefa14e7
+      - req-b85eb1db-0b35-4df0-b794-592de5e9a551
       Date:
-      - Mon, 06 Aug 2018 16:57:54 GMT
+      - Mon, 24 Sep 2018 20:28:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +8062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8073,9 +8073,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ec84223a-7bbd-4b84-ba12-dc8e647b103d
+      - req-83f1499c-3326-45ab-a862-fa4231e5e0aa
       Date:
-      - Mon, 06 Aug 2018 16:57:55 GMT
+      - Mon, 24 Sep 2018 20:28:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +8102,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +8117,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8128,9 +8128,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2a579b5f-5578-4909-8dc8-9abc0dc9bc7c
+      - req-1923b2cb-f433-4047-9b1e-c91b7fbad41c
       Date:
-      - Mon, 06 Aug 2018 16:57:57 GMT
+      - Mon, 24 Sep 2018 20:28:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +8157,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +8172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8183,9 +8183,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-23156b55-8057-4de6-8c2e-6f485730db78
+      - req-ad1db6d3-fcb7-44b3-8198-a5a383356781
       Date:
-      - Mon, 06 Aug 2018 16:57:57 GMT
+      - Mon, 24 Sep 2018 20:28:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +8212,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +8227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8238,9 +8238,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-936bfb5c-8283-40f3-b36e-5dc26dcd0717
+      - req-b5395fbe-4c22-42d0-8240-5ad4a34bac5c
       Date:
-      - Mon, 06 Aug 2018 16:57:57 GMT
+      - Mon, 24 Sep 2018 20:28:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +8252,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +8267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8278,9 +8278,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-417fa88f-f768-4059-8862-a5466a497644
+      - req-cff49551-e0e0-4d28-896c-71c4e177603f
       Date:
-      - Mon, 06 Aug 2018 16:57:57 GMT
+      - Mon, 24 Sep 2018 20:28:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +8292,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +8307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97270ec95e3f4658a3b06b6dd2eb5e9b
+      - 3d137f70778c4c2183a75ee16b4cd46c
   response:
     status:
       code: 200
@@ -8318,9 +8318,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-455d1bc1-be08-4aba-9340-352472a1bd2a
+      - req-930aa5c8-e998-4226-83f1-0299e98da2e4
       Date:
-      - Mon, 06 Aug 2018 16:57:57 GMT
+      - Mon, 24 Sep 2018 20:28:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +8332,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +8350,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:58 GMT
+      - Mon, 24 Sep 2018 20:28:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fcf63cd1-62d7-468a-bbf3-09a91b11e618
+      - req-6edf0df5-26e6-4a6c-aaea-16217dbb1391
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +8365,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:58.189777", "expires":
-        "2018-08-06T17:57:58Z", "id": "ebca8a3245c74e5d8fe718cd15f2d453", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:15.509650", "expires":
+        "2018-09-24T21:28:15Z", "id": "317e2beee081424f86ccf48cd84a85c9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0gj4YHYzRoekJPRSTkVlwg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_Wz3ra1_S52GL7nHB379OA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +8412,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +8427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -8438,27 +8438,178 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d4f81d09-5343-4629-a099-7e7592f2210e
+      - req-0a28274b-3c65-4dc4-b15d-df1f3a911a04
       Date:
-      - Mon, 06 Aug 2018 16:57:58 GMT
+      - Mon, 24 Sep 2018 20:28:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 317e2beee081424f86ccf48cd84a85c9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1e357ebc-18e7-4f56-9a92-804f2af037a5
+      Date:
+      - Mon, 24 Sep 2018 20:28:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8507,30 +8658,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8544,139 +8677,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e4cbe544-a8d9-40bc-8510-289fe54300e6
-      Date:
-      - Mon, 06 Aug 2018 16:57:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8694,13 +8695,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:58 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b25c7cf2-af53-4b71-bbdc-817a68af9ebf
+      - req-64e22909-0980-4609-869e-aab9077307c9
       Content-Length:
       - '4131'
       Connection:
@@ -8709,10 +8710,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:58.911829", "expires":
-        "2018-08-06T17:57:58Z", "id": "28f1ee43c2b844b8837e4f4a4c1c9bcb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:16.069199", "expires":
+        "2018-09-24T21:28:16Z", "id": "4a9fab910fa346159e33f0a9f8c1b040", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["5z6HttG5QPK94C7Fd3Q-Rw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["6VvbmWolQR6uxWHZhb95fQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8756,7 +8757,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8771,7 +8772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -8782,28 +8783,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-bc097615-ce8d-4d27-8a3b-27aff3442b59
+      - req-14cfdd20-4952-4b0b-8b51-17a25fdbe198
       Date:
-      - Mon, 06 Aug 2018 16:57:59 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -8816,79 +8842,55 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8903,7 +8905,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -8914,27 +8916,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3dade0a8-2e50-4652-a4ea-1003745b9682
+      - req-a2b6604d-c596-4b44-8a8d-dda8b3189448
       Date:
-      - Mon, 06 Aug 2018 16:57:59 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8983,30 +9003,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9020,7 +9022,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9035,7 +9037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -9046,9 +9048,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8f1eb7e0-9c90-4380-b240-420c99a2795a
+      - req-d5cbe781-4b60-4dad-b885-0a3430142d12
       Date:
-      - Mon, 06 Aug 2018 16:57:59 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -9152,7 +9154,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9167,7 +9169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -9178,28 +9180,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-15fd2da5-5ed4-4a17-a1f0-f42514f90a36
+      - req-e4f517be-c337-4328-a7fe-37c729c70711
       Date:
-      - Mon, 06 Aug 2018 16:58:00 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -9212,79 +9239,55 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9302,13 +9305,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:00 GMT
+      - Mon, 24 Sep 2018 20:28:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68ef61bb-4384-4250-a27c-8132a33af2a3
+      - req-3ab774cb-e20d-4f08-92f2-c011bd1fc2e4
       Content-Length:
       - '4118'
       Connection:
@@ -9317,10 +9320,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:00.435681", "expires":
-        "2018-08-06T17:58:00Z", "id": "e5b45e72f7c545e0848ce2189e655c70", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:17.011039", "expires":
+        "2018-09-24T21:28:16Z", "id": "c2f677e9f9934f3289c0e935672a929e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Q3ppyOPjTg2kNIswRQUZ7g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BqQCI178Qs21AWMtfa9IRw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9364,7 +9367,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9379,7 +9382,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -9390,68 +9393,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2114197d-4c33-4c11-a454-f07058cf5cf4
+      - req-c524e86a-f8a2-4169-bc6d-3e4f1ba55513
       Date:
-      - Mon, 06 Aug 2018 16:58:00 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -9483,20 +9463,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9511,7 +9514,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -9522,9 +9525,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9db08189-8205-4523-ba12-02fca065d7ce
+      - req-fe0feff7-f01c-4082-a590-61f47ae2cc51
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -9628,7 +9631,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9643,7 +9646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -9654,9 +9657,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3c63fc51-aced-4cfb-9fad-77ec7a9886da
+      - req-d3366d20-1580-4161-92bf-866304b2ae64
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9698,7 +9701,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9713,7 +9716,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -9724,9 +9727,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-369d245e-80de-4780-9091-321e6b15d3f3
+      - req-4d962de9-dab6-4b7b-8c29-30dcf14213a4
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9768,7 +9771,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9783,7 +9786,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -9794,9 +9797,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9057010d-b4c9-4290-8b12-23615acf1b3f
+      - req-6f631da2-13fc-447e-984f-4727ede86a8a
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9838,7 +9841,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9853,7 +9856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -9864,9 +9867,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5f993e44-cbe2-4544-be6f-765071478cb4
+      - req-882e359b-a838-4d27-80eb-78127c61599a
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9908,7 +9911,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9923,7 +9926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -9934,9 +9937,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6ecd0003-91c0-4d52-85fb-37b90f587670
+      - req-7db5e0f7-091e-4455-af41-d2d22ee7fe18
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9978,7 +9981,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9993,7 +9996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -10004,9 +10007,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0048b54b-bfca-447a-8f5a-08a164a4c28b
+      - req-e521cb5c-aa7e-4cd0-96ca-baa2f7ac3dbe
       Date:
-      - Mon, 06 Aug 2018 16:58:01 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10048,7 +10051,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10063,7 +10066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -10074,9 +10077,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a8bc7e6e-b985-44b2-9b39-164f711654c1
+      - req-72e53476-dd63-47b1-8914-b9179f1fe033
       Date:
-      - Mon, 06 Aug 2018 16:58:02 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10118,7 +10121,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10133,7 +10136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -10144,9 +10147,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c4b8ab85-0885-4084-9ca3-f618bad4b96a
+      - req-07510286-d478-4d1f-b021-4fb4d1481835
       Date:
-      - Mon, 06 Aug 2018 16:58:02 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10188,7 +10191,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10203,7 +10206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -10214,9 +10217,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-39955d62-49f3-4239-bcf9-34d7c1a7681c
+      - req-a2e18690-b00d-4888-89c6-aec253c7153e
       Date:
-      - Mon, 06 Aug 2018 16:58:02 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10619,7 +10622,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10634,7 +10637,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -10645,9 +10648,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ec845b99-23d8-4ab1-9a81-4917e4a14dd4
+      - req-4c3146f7-5340-4f65-af1a-2794075d9283
       Date:
-      - Mon, 06 Aug 2018 16:58:02 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11050,7 +11053,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11065,7 +11068,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -11076,9 +11079,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8df45697-e5a1-46e2-b196-37dd6aca2d99
+      - req-f070a2a0-f88a-479c-b36c-3c1a24ba03b9
       Date:
-      - Mon, 06 Aug 2018 16:58:03 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11481,7 +11484,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11496,7 +11499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -11507,9 +11510,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-60c49536-bcaa-4755-bfc1-2a36268a8f7f
+      - req-1a4a13c5-93ad-403c-ba04-76492b78537a
       Date:
-      - Mon, 06 Aug 2018 16:58:03 GMT
+      - Mon, 24 Sep 2018 20:28:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11912,7 +11915,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11927,7 +11930,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -11938,9 +11941,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-893a3a1e-ae1b-434d-9d5d-bb4df93e4e1d
+      - req-3e3f9a3a-de46-4d74-9dc1-9eeb355f0f6a
       Date:
-      - Mon, 06 Aug 2018 16:58:03 GMT
+      - Mon, 24 Sep 2018 20:28:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12343,7 +12346,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12358,7 +12361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -12369,9 +12372,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4d33d86c-b357-40fd-9654-959f90e06cf2
+      - req-6f6459ef-543f-430a-9edf-5b5c7d845b38
       Date:
-      - Mon, 06 Aug 2018 16:58:03 GMT
+      - Mon, 24 Sep 2018 20:28:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12774,7 +12777,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12789,7 +12792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -12800,9 +12803,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f34e6fda-7f95-4f02-aa6d-c7e629416a5d
+      - req-0db3b794-9edb-4b76-97fa-f82996553c42
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13205,7 +13208,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13220,7 +13223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -13231,9 +13234,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b3e4d363-63d7-4970-a2cc-4433b03e6f32
+      - req-a6cc4f95-bcf3-4686-bd87-37b622b54cea
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13636,7 +13639,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13651,7 +13654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -13662,9 +13665,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a4fe7987-961c-45f7-9401-9cb73609dfee
+      - req-0d201c94-0e2d-419b-b574-0614c116f349
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13696,7 +13699,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13711,7 +13714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -13722,9 +13725,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-dbbd2311-78aa-45e5-9492-ee214fe00e23
+      - req-27b0e0bc-9eb6-47f9-9a56-8e8532f8cf51
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13756,7 +13759,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13771,7 +13774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -13782,9 +13785,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8b202cf1-53cf-4631-bb3a-50e583d78431
+      - req-cd09aec3-4d20-4562-8d25-10abe27e8a75
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13816,7 +13819,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13831,7 +13834,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -13842,9 +13845,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-c27ce2d4-033b-448b-8408-e56d9805f979
+      - req-8672c95c-ed38-4a8d-9b11-37dc348976d0
       Date:
-      - Mon, 06 Aug 2018 16:58:04 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13876,7 +13879,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13891,7 +13894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -13902,9 +13905,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-34b97ffe-7d7e-409a-a779-5b48d4c72b5c
+      - req-a2b2b215-825c-4be8-a3d6-9229a202a4b3
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13936,7 +13939,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13951,7 +13954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -13962,9 +13965,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9a5c8bdb-a088-4613-b9cc-fff72e12d350
+      - req-6bf49a36-0335-4aee-a1fd-c48d55ec0dcf
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13996,7 +13999,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14011,7 +14014,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -14022,9 +14025,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d35e0188-4482-4948-8247-a7d45791d8d6
+      - req-639f7f3f-4e53-491c-983a-9f70ad7fa957
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14056,7 +14059,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14071,7 +14074,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -14082,9 +14085,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ce49134a-4b19-4519-a24f-198871872700
+      - req-63d2c5f4-4591-490e-8e7c-13a49f6b0658
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14116,7 +14119,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14131,7 +14134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -14142,9 +14145,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2750d2f5-4cf0-4e6b-993e-f94ba61f7391
+      - req-924383de-28e5-4a1e-804e-13d7e2b84192
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14186,7 +14189,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14201,7 +14204,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -14212,9 +14215,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-19217c11-b8d9-4d75-8009-638f8e3794d1
+      - req-f2a92a19-47a5-41d2-95e5-ff276893e908
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14257,7 +14260,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14272,7 +14275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -14283,9 +14286,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-8bb3b333-18d4-4023-a85c-74f014afa0c5
+      - req-bf152026-3360-4e26-a557-e4b31a5bd8da
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14320,7 +14323,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14335,7 +14338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebca8a3245c74e5d8fe718cd15f2d453
+      - 317e2beee081424f86ccf48cd84a85c9
   response:
     status:
       code: 200
@@ -14346,9 +14349,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-d17f8b56-b291-4da3-a67f-79ecbfcf28ae
+      - req-73be3177-de3b-441d-89aa-16fd24138c59
       Date:
-      - Mon, 06 Aug 2018 16:58:05 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14435,7 +14438,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14450,7 +14453,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -14461,9 +14464,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-117164b3-8125-43b5-9ac0-0a7231b8d316
+      - req-893ba9c2-bef1-4841-9255-b1168b05c502
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14505,7 +14508,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14520,7 +14523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -14531,9 +14534,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7d4c01e4-e081-4cd1-bb3b-b48a1e599704
+      - req-64f243f4-88ad-4660-89fa-42b2f243a128
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14576,7 +14579,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14591,7 +14594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -14602,9 +14605,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2215fe27-e212-428b-8e3a-b5f798638dfa
+      - req-a50c5c29-91c1-45b4-863e-efc4a12ba0e3
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14639,7 +14642,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14654,7 +14657,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 28f1ee43c2b844b8837e4f4a4c1c9bcb
+      - 4a9fab910fa346159e33f0a9f8c1b040
   response:
     status:
       code: 200
@@ -14665,9 +14668,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-6147a530-3e68-43d8-8fb4-25422b8468d0
+      - req-e3a68b69-1fb9-4a30-8ce8-90744cdb6ffd
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14754,7 +14757,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14769,7 +14772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -14780,9 +14783,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e3d4aaa8-1e6c-4fd9-86e5-f5a5ce75f095
+      - req-2ca64135-9530-47c0-8003-c5b6b4e5c281
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14824,7 +14827,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14839,7 +14842,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -14850,9 +14853,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-72d50d05-1ce2-4cf8-bfcf-9b79634b8f1e
+      - req-d656f6e6-6905-4f44-bd91-1e9c303fc601
       Date:
-      - Mon, 06 Aug 2018 16:58:06 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14895,7 +14898,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14910,7 +14913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -14921,9 +14924,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-1296b837-c1d7-4276-bf9a-11d0e2e91925
+      - req-8e21e09c-f32f-4437-9a81-321f8a4f0f3f
       Date:
-      - Mon, 06 Aug 2018 16:58:07 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14958,7 +14961,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14973,7 +14976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6580d3d4ca194423aca5e349bb6e8405
+      - 7f23c3d227b8449dadb56b982fba6751
   response:
     status:
       code: 200
@@ -14984,9 +14987,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-ac23658e-af8b-4e63-b336-fdc8b327bd2c
+      - req-4efae71b-183d-4ce3-9e48-462271bfe76e
       Date:
-      - Mon, 06 Aug 2018 16:58:07 GMT
+      - Mon, 24 Sep 2018 20:28:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15073,7 +15076,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15088,7 +15091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -15099,9 +15102,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e78d7761-c88e-46a9-bbb7-369bbea7b34b
+      - req-f8f710c7-a393-46dd-965c-ada53f87055e
       Date:
-      - Mon, 06 Aug 2018 16:58:07 GMT
+      - Mon, 24 Sep 2018 20:28:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15143,7 +15146,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15158,7 +15161,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -15169,9 +15172,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b487ea0e-48e0-44b1-a357-163de480e5d5
+      - req-fcab075f-e18e-4a2e-99cf-1c1ea9d5f971
       Date:
-      - Mon, 06 Aug 2018 16:58:07 GMT
+      - Mon, 24 Sep 2018 20:28:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15214,7 +15217,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15229,7 +15232,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -15240,9 +15243,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-1c79df6b-1077-4ac8-aa92-7fb23f5ad00c
+      - req-ed3d8efa-1c31-438b-83dc-f425efdd195d
       Date:
-      - Mon, 06 Aug 2018 16:58:07 GMT
+      - Mon, 24 Sep 2018 20:28:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15277,7 +15280,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15292,7 +15295,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5b45e72f7c545e0848ce2189e655c70
+      - c2f677e9f9934f3289c0e935672a929e
   response:
     status:
       code: 200
@@ -15303,9 +15306,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-d57fb18d-c1a9-45be-8824-4ff8f05f9893
+      - req-99ee9381-5053-4d74-8ee0-4711ad9e4712
       Date:
-      - Mon, 06 Aug 2018 16:58:08 GMT
+      - Mon, 24 Sep 2018 20:28:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15392,7 +15395,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15410,13 +15413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:08 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76def99f-4475-49e3-9901-0bf80de58aa4
+      - req-dc05b1c2-dec1-44c2-81d8-20caad833525
       Content-Length:
       - '4170'
       Connection:
@@ -15425,10 +15428,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:08.786420", "expires":
-        "2018-08-06T17:58:08Z", "id": "c45a6c362e614772aec9f34a6a7a3adf", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:23.126647", "expires":
+        "2018-09-24T21:28:23Z", "id": "8ffe0fea44c04993aedfbca2dbed5884", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["nyQQqrKSR0GHi9cymJDL_Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Y3JjdcexQ3mkduuvvf-d_g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15473,7 +15476,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15491,13 +15494,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:08 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f0e532c-3a33-4c48-abd3-bb15382f1700
+      - req-4371d1c5-20c4-4a2a-b0f5-6c360f732b5b
       Content-Length:
       - '4170'
       Connection:
@@ -15506,10 +15509,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:09.309394", "expires":
-        "2018-08-06T17:58:09Z", "id": "1a39c26dfda042d9a2bc616fa21f5ab5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:23.310329", "expires":
+        "2018-09-24T21:28:23Z", "id": "a2d3221ed7174b97b7bdfe61e5debaaf", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Br9qU0ROSJCTEAxB5YHqLQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HTkmS8jvTwOR9UbUntLyqQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15554,7 +15557,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15572,13 +15575,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:09 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ea7b1e86-97f8-416e-976a-679ca8eef099
+      - req-e80f3d12-000c-4e74-bb4e-2d144003bc47
       Content-Length:
       - '370'
       Connection:
@@ -15587,13 +15590,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:09.545425", "expires":
-        "2018-08-06T17:58:09Z", "id": "43397a2bf5514cfaa007bbd6fce93751", "audit_ids":
-        ["jYI8_x6oQ4WS3keEzIefRg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:23.461813", "expires":
+        "2018-09-24T21:28:23Z", "id": "a63e8b23a6a1428bb2d0541e10159f92", "audit_ids":
+        ["YYqW9Ox-R0yGaVLhS3bkeg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15608,20 +15611,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43397a2bf5514cfaa007bbd6fce93751
+      - a63e8b23a6a1428bb2d0541e10159f92
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:09 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8b8baf87-3eab-498b-8dcd-9356f9d50729
+      - req-fd716fe8-4565-4487-bc27-a30e59041511
       Content-Length:
       - '500'
       Connection:
@@ -15638,13 +15641,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"43397a2bf5514cfaa007bbd6fce93751"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"a63e8b23a6a1428bb2d0541e10159f92"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15656,13 +15659,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:09 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fa394b3a-aacb-4ce5-a4a7-a1c39a96df12
+      - req-369975f8-4ac5-4408-8ae7-bc41fafb9071
       Content-Length:
       - '4143'
       Connection:
@@ -15671,11 +15674,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:10.059561", "expires":
-        "2018-08-06T17:58:09Z", "id": "204d1822832141e898e0a037d4845cb6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:23.760458", "expires":
+        "2018-09-24T21:28:23Z", "id": "5e6e60a78bab43829bbee65d33c79a8c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OYXv7G77R_u468C6qTlHLw",
-        "jYI8_x6oQ4WS3keEzIefRg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["H9SrfTZZS0C4wtLk2P3Erw",
+        "YYqW9Ox-R0yGaVLhS3bkeg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15719,7 +15722,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15734,20 +15737,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43397a2bf5514cfaa007bbd6fce93751
+      - a63e8b23a6a1428bb2d0541e10159f92
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:10 GMT
+      - Mon, 24 Sep 2018 20:28:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f656bb1f-1ab5-49a2-9974-36e5010b12c7
+      - req-60b77297-5890-45ac-a608-a9c0bf62aabb
       Content-Length:
       - '500'
       Connection:
@@ -15764,7 +15767,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15782,13 +15785,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:10 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1ed92542-9802-490d-be59-37938d24efe4
+      - req-127b55b0-91a5-4d08-bccd-cc857227b78a
       Content-Length:
       - '4117'
       Connection:
@@ -15797,10 +15800,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:10.533686", "expires":
-        "2018-08-06T17:58:10Z", "id": "a1b5f52afe474f379a09ac4201219d7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:24.075062", "expires":
+        "2018-09-24T21:28:24Z", "id": "ed3014f9580d4d9bb68e53805883a5ca", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KI-J42_8Q_yqRpQzWmrqCQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_C02FGkwSdS8quU_r4v-AA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15844,7 +15847,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15862,13 +15865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:10 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-712c3c0b-62c1-4ee9-a220-482767e909fc
+      - req-021419d0-2f05-4168-bf93-566a9e323f60
       Content-Length:
       - '4131'
       Connection:
@@ -15877,10 +15880,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.003462", "expires":
-        "2018-08-06T17:58:10Z", "id": "122a4a23871846ba9fb32c62be41e8f5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:24.255810", "expires":
+        "2018-09-24T21:28:24Z", "id": "7ca184debff84f63be3d491f755134d6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aOIabNegQamhRuhPNJdZfg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["c3H-omuISGaQye1pc4KNqg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15924,7 +15927,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15942,13 +15945,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:11 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-044e9382-f4f5-4ac9-bda9-4f7e804b9db4
+      - req-b7617714-4be5-452c-a54f-6ce5ee82a62b
       Content-Length:
       - '4118'
       Connection:
@@ -15957,10 +15960,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.353077", "expires":
-        "2018-08-06T17:58:11Z", "id": "affcbfe46cf741368509a41d86187990", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:24.439664", "expires":
+        "2018-09-24T21:28:24Z", "id": "f5fd2f2e06034306af7d5260193b542a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FGgptCD-S0OqDigMa0usYQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e_ZzjljGQCeCjhw-1l35hQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16004,7 +16007,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16022,13 +16025,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:11 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c764e730-e0a5-4fcc-948a-50a7bd7de032
+      - req-2aa514ab-63ac-4db3-858d-dcc85b9441a0
       Content-Length:
       - '4117'
       Connection:
@@ -16037,10 +16040,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:11.629038", "expires":
-        "2018-08-06T17:58:11Z", "id": "cd02b4b039874654a5cf39bb78e41848", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:24.620458", "expires":
+        "2018-09-24T21:28:24Z", "id": "27f592a839574d9b94f9dd99a18fd005", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zCexhadsSp2_LlTQvBl5IQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SLXD13w3R4WF2Ldkd7wOYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16084,7 +16087,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16099,22 +16102,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-30fb9b27-aa44-4abc-be38-839b3b9af813
+      - req-1efdb04f-016b-4de8-b3e2-314eecbac273
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-30fb9b27-aa44-4abc-be38-839b3b9af813
+      - req-1efdb04f-016b-4de8-b3e2-314eecbac273
       Date:
-      - Mon, 06 Aug 2018 16:58:12 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16147,7 +16150,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16162,22 +16165,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61a2a9ec-1365-498d-b094-e813b39761bd
+      - req-755ddaad-ef2d-4fae-9020-929eaf036758
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-61a2a9ec-1365-498d-b094-e813b39761bd
+      - req-755ddaad-ef2d-4fae-9020-929eaf036758
       Date:
-      - Mon, 06 Aug 2018 16:58:12 GMT
+      - Mon, 24 Sep 2018 20:28:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16218,7 +16221,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16233,22 +16236,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a837afcf-7142-4c1a-aac6-5c90250e2964
+      - req-2f60a2ec-b4e5-41a6-972f-52dd22ada3cf
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a837afcf-7142-4c1a-aac6-5c90250e2964
+      - req-2f60a2ec-b4e5-41a6-972f-52dd22ada3cf
       Date:
-      - Mon, 06 Aug 2018 16:58:12 GMT
+      - Mon, 24 Sep 2018 20:28:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16282,7 +16285,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16297,27 +16300,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-84e6e1d7-de16-47ca-b201-82d89acaee2f
+      - req-cffaa816-54ad-44db-8d49-73dace62df17
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-84e6e1d7-de16-47ca-b201-82d89acaee2f
+      - req-cffaa816-54ad-44db-8d49-73dace62df17
       Date:
-      - Mon, 06 Aug 2018 16:58:12 GMT
+      - Mon, 24 Sep 2018 20:28:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16335,13 +16338,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:12 GMT
+      - Mon, 24 Sep 2018 20:28:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8737bff2-c973-4505-b382-4dc2a432d0b5
+      - req-7e6f9245-2f50-45dd-bd6f-5dac2f5c8390
       Content-Length:
       - '4131'
       Connection:
@@ -16350,10 +16353,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:13.080960", "expires":
-        "2018-08-06T17:58:13Z", "id": "7a0874fc80964edc829f1d82639a36a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:25.540396", "expires":
+        "2018-09-24T21:28:25Z", "id": "f996e3f0ce4d4066811e5f22d142e809", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gd5Bn7IeQvOOBkdOm16y0g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KR-ZD5j6QVK-HkSnl35i7g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16397,7 +16400,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16412,27 +16415,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed94a5db-d91f-4dea-9972-222292520b2a
+      - req-11faae02-955b-425e-bca3-6949a7620760
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ed94a5db-d91f-4dea-9972-222292520b2a
+      - req-11faae02-955b-425e-bca3-6949a7620760
       Date:
-      - Mon, 06 Aug 2018 16:58:13 GMT
+      - Mon, 24 Sep 2018 20:28:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16447,27 +16450,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-04a590da-6954-46c6-956b-a870d8f08f1f
+      - req-1a14f22a-9732-4854-ae7a-f918cabcbaa9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-04a590da-6954-46c6-956b-a870d8f08f1f
+      - req-1a14f22a-9732-4854-ae7a-f918cabcbaa9
       Date:
-      - Mon, 06 Aug 2018 16:58:13 GMT
+      - Mon, 24 Sep 2018 20:28:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16485,13 +16488,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:13 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0238a50a-e3d7-4156-aea5-ada1c6f146ce
+      - req-e5715765-ed96-415b-97e3-07d28f68b0ae
       Content-Length:
       - '4118'
       Connection:
@@ -16500,10 +16503,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:13.875328", "expires":
-        "2018-08-06T17:58:13Z", "id": "74975b8911e548af9490df36a6485b26", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:26.080170", "expires":
+        "2018-09-24T21:28:26Z", "id": "a085ee8ea73c4ccc84e25e8af24ad340", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nc63IVw-RcaYTsyebea7MQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["WyriwUQ4S4Swwl2dbrBC_w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16547,7 +16550,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16562,27 +16565,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5c965b1-83b5-417e-b4b7-54774d6a2b0c
+      - req-bc031e65-7c3a-4870-8cf6-a6040075fb39
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a5c965b1-83b5-417e-b4b7-54774d6a2b0c
+      - req-bc031e65-7c3a-4870-8cf6-a6040075fb39
       Date:
-      - Mon, 06 Aug 2018 16:58:14 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16597,22 +16600,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-741af599-b5b1-40b0-86fa-afc81628194d
+      - req-c0722e19-80ca-4273-9e48-1ae8f263b89c
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-741af599-b5b1-40b0-86fa-afc81628194d
+      - req-c0722e19-80ca-4273-9e48-1ae8f263b89c
       Date:
-      - Mon, 06 Aug 2018 16:58:14 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16627,7 +16630,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16642,22 +16645,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9466f7fc-be86-470b-aa8a-3e98d9ef9219
+      - req-61793d6a-b3ad-433e-8975-c2d86716f12f
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-9466f7fc-be86-470b-aa8a-3e98d9ef9219
+      - req-61793d6a-b3ad-433e-8975-c2d86716f12f
       Date:
-      - Mon, 06 Aug 2018 16:58:14 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16672,7 +16675,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16687,27 +16690,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3177b38c-2b00-4ac2-a0f4-db52e3c02486
+      - req-de5c62e9-03bb-46a1-ad57-d0327b114467
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3177b38c-2b00-4ac2-a0f4-db52e3c02486
+      - req-de5c62e9-03bb-46a1-ad57-d0327b114467
       Date:
-      - Mon, 06 Aug 2018 16:58:15 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16722,27 +16725,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a6a0b65b-3948-4d76-bd9c-4bc3a927ad03
+      - req-d91b9d04-7279-4f04-bccf-7856521d7949
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a6a0b65b-3948-4d76-bd9c-4bc3a927ad03
+      - req-d91b9d04-7279-4f04-bccf-7856521d7949
       Date:
-      - Mon, 06 Aug 2018 16:58:15 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16757,27 +16760,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae8044a4-1baf-4d4a-b19b-da7d8349c371
+      - req-e984758d-c936-4385-85b1-eb7342fbcba9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ae8044a4-1baf-4d4a-b19b-da7d8349c371
+      - req-e984758d-c936-4385-85b1-eb7342fbcba9
       Date:
-      - Mon, 06 Aug 2018 16:58:15 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16792,27 +16795,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c1ffb93-68cd-4a6f-9980-956cb297cb29
+      - req-566c35d8-394c-4833-93b3-1bae407f3597
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2c1ffb93-68cd-4a6f-9980-956cb297cb29
+      - req-566c35d8-394c-4833-93b3-1bae407f3597
       Date:
-      - Mon, 06 Aug 2018 16:58:15 GMT
+      - Mon, 24 Sep 2018 20:28:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16827,27 +16830,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2ce6df2-7387-4d39-be43-2ca93b8b591e
+      - req-5f89ad93-c9cd-4caa-af13-39f9d5805898
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2ce6df2-7387-4d39-be43-2ca93b8b591e
+      - req-5f89ad93-c9cd-4caa-af13-39f9d5805898
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16862,27 +16865,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70b60372-eac7-4e09-a60f-4a4f12b429f0
+      - req-49b332f8-ad46-4526-b280-5cc4dff0ec51
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-70b60372-eac7-4e09-a60f-4a4f12b429f0
+      - req-49b332f8-ad46-4526-b280-5cc4dff0ec51
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16897,27 +16900,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ec533a7-d0ff-41f8-9667-6d0c74b03de8
+      - req-42089e79-8d57-4575-8e7a-8ccb644ea89a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5ec533a7-d0ff-41f8-9667-6d0c74b03de8
+      - req-42089e79-8d57-4575-8e7a-8ccb644ea89a
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16932,27 +16935,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e4c912c6-9fec-4986-ade2-0f4ae2be9c16
+      - req-0da0dcf2-4b1b-4c84-810a-40a78eb09213
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e4c912c6-9fec-4986-ade2-0f4ae2be9c16
+      - req-0da0dcf2-4b1b-4c84-810a-40a78eb09213
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16967,27 +16970,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-48c87f85-fb88-4c2e-9cae-1dcc5897c22b
+      - req-e069a4ae-59f6-4874-8afb-177e35a78da0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-48c87f85-fb88-4c2e-9cae-1dcc5897c22b
+      - req-e069a4ae-59f6-4874-8afb-177e35a78da0
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17002,27 +17005,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05e06093-230a-4577-8d3f-770b629c8ef5
+      - req-e8a2c7cf-916b-49b5-ad73-183b93717836
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-05e06093-230a-4577-8d3f-770b629c8ef5
+      - req-e8a2c7cf-916b-49b5-ad73-183b93717836
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17037,27 +17040,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2d3a838-9cd2-44c6-a70a-65a0bc9678e9
+      - req-f67ca7d7-5995-4c04-9e75-dea3e0719ccb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e2d3a838-9cd2-44c6-a70a-65a0bc9678e9
+      - req-f67ca7d7-5995-4c04-9e75-dea3e0719ccb
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17072,27 +17075,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-86e69f32-7192-4bc5-adcf-ce93f171bae3
+      - req-8f192d7e-8d39-4fa2-a520-9d0dc7d625a8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-86e69f32-7192-4bc5-adcf-ce93f171bae3
+      - req-8f192d7e-8d39-4fa2-a520-9d0dc7d625a8
       Date:
-      - Mon, 06 Aug 2018 16:58:16 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17107,27 +17110,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa1132ad-efa3-4b88-9c39-ace8bb41f9aa
+      - req-737c582a-2e13-4e73-8e66-1d607c11524e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aa1132ad-efa3-4b88-9c39-ace8bb41f9aa
+      - req-737c582a-2e13-4e73-8e66-1d607c11524e
       Date:
-      - Mon, 06 Aug 2018 16:58:17 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17142,27 +17145,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f89928b-bb0d-4c96-8de2-2b63aa6b73a7
+      - req-57f2e05c-df5b-40a7-ad78-b8355f0e217f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4f89928b-bb0d-4c96-8de2-2b63aa6b73a7
+      - req-57f2e05c-df5b-40a7-ad78-b8355f0e217f
       Date:
-      - Mon, 06 Aug 2018 16:58:17 GMT
+      - Mon, 24 Sep 2018 20:28:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17177,22 +17180,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fbdcfc48-1600-40e2-99a6-0459ec7c2043
+      - req-914d75ce-21f0-4538-b7ee-c26ee5bbdba7
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fbdcfc48-1600-40e2-99a6-0459ec7c2043
+      - req-914d75ce-21f0-4538-b7ee-c26ee5bbdba7
       Date:
-      - Mon, 06 Aug 2018 16:58:17 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17204,7 +17207,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17219,22 +17222,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd02b4b039874654a5cf39bb78e41848
+      - 27f592a839574d9b94f9dd99a18fd005
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b41a97cb-7087-41e3-982a-b96323d1fa75
+      - req-7bb77daf-76c0-44af-9916-02a61758a2e3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b41a97cb-7087-41e3-982a-b96323d1fa75
+      - req-7bb77daf-76c0-44af-9916-02a61758a2e3
       Date:
-      - Mon, 06 Aug 2018 16:58:17 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17246,7 +17249,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17261,22 +17264,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-22501124-4bbc-4ee6-ad1d-76b4f3c3ea9c
+      - req-1fa0a80b-d4d5-4dce-b302-340f4271ee7d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-22501124-4bbc-4ee6-ad1d-76b4f3c3ea9c
+      - req-1fa0a80b-d4d5-4dce-b302-340f4271ee7d
       Date:
-      - Mon, 06 Aug 2018 16:58:17 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17288,7 +17291,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17303,22 +17306,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a0874fc80964edc829f1d82639a36a0
+      - f996e3f0ce4d4066811e5f22d142e809
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1250d72f-6145-4eb0-8886-8fe11912f8a9
+      - req-8bff258a-682e-439d-98d2-1d55a9834010
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1250d72f-6145-4eb0-8886-8fe11912f8a9
+      - req-8bff258a-682e-439d-98d2-1d55a9834010
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17330,7 +17333,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17345,22 +17348,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5d6d34b-956d-4bfb-8b22-004f7a748ba2
+      - req-53111ef2-f3e7-40a2-8eb6-ec91d96620d6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e5d6d34b-956d-4bfb-8b22-004f7a748ba2
+      - req-53111ef2-f3e7-40a2-8eb6-ec91d96620d6
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17372,7 +17375,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17387,22 +17390,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1a39c26dfda042d9a2bc616fa21f5ab5
+      - a2d3221ed7174b97b7bdfe61e5debaaf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ba0d749-27f3-4ec0-a315-40ea52be59d3
+      - req-1e229715-acce-4af5-a8d5-bcadbca15691
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3ba0d749-27f3-4ec0-a315-40ea52be59d3
+      - req-1e229715-acce-4af5-a8d5-bcadbca15691
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17414,7 +17417,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17429,22 +17432,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-107dfd0f-d3ad-405e-926c-41a35e13073f
+      - req-aac5cc11-63b1-48b1-a51d-213d90dc160d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-107dfd0f-d3ad-405e-926c-41a35e13073f
+      - req-aac5cc11-63b1-48b1-a51d-213d90dc160d
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17456,7 +17459,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17471,22 +17474,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 74975b8911e548af9490df36a6485b26
+      - a085ee8ea73c4ccc84e25e8af24ad340
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1852f0a1-d90f-42fc-8394-29b416f1fd62
+      - req-bb46b57c-01d0-4a02-a110-2e23a8b3a34c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1852f0a1-d90f-42fc-8394-29b416f1fd62
+      - req-bb46b57c-01d0-4a02-a110-2e23a8b3a34c
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17498,7 +17501,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17516,13 +17519,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:18 GMT
+      - Mon, 24 Sep 2018 20:28:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-19885b70-f4bd-4f23-bd5b-e4c85841fa90
+      - req-ceca5d66-3558-43f4-afb0-a5c0c70f3a0e
       Content-Length:
       - '4170'
       Connection:
@@ -17531,10 +17534,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:18.924647", "expires":
-        "2018-08-06T17:58:18Z", "id": "4e83aeed5d484917809eee610fcb7eb4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:28.983755", "expires":
+        "2018-09-24T21:28:28Z", "id": "fd65fe1b56984cd59972dfa02cf8267f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["MKIbnPqIQ8KpkpbC3QSbzg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["6ykFjnn_SQe39Rpxreuctg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17579,7 +17582,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17597,13 +17600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:19 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f7e46b3-29ee-4ed0-8da3-f1b7707d1e6f
+      - req-1bcee756-ef53-4409-b5d5-dd8547251db4
       Content-Length:
       - '4170'
       Connection:
@@ -17612,10 +17615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.312054", "expires":
-        "2018-08-06T17:58:19Z", "id": "1c5d03ccfb8f4ec7b349578773069908", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:29.207604", "expires":
+        "2018-09-24T21:28:29Z", "id": "d4d57b79c6d543989a68a600600dcdca", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["w1hRQQrbRky3TfBM6D2K-g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_omFNboPR26sku9DI7-oQw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17660,7 +17663,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17678,13 +17681,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:19 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-444287ea-2147-4266-a35b-b8e2bfa77745
+      - req-a4a058b1-13c5-4724-9467-69eb3c2547c0
       Content-Length:
       - '370'
       Connection:
@@ -17693,13 +17696,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.517058", "expires":
-        "2018-08-06T17:58:19Z", "id": "d6d8a76707c44fa1b74726c4cccb01a0", "audit_ids":
-        ["YpG1zWt9QCqHIPdId5eSZg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:29.369255", "expires":
+        "2018-09-24T21:28:29Z", "id": "91d5c6bf66f3459b8cd238cb8d3e854d", "audit_ids":
+        ["4RIhJQw-Q1uSOQu_rVIELQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17714,20 +17717,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6d8a76707c44fa1b74726c4cccb01a0
+      - 91d5c6bf66f3459b8cd238cb8d3e854d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:19 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04f5ee99-31e7-432c-b7d4-3b505553f7a6
+      - req-6385f8bc-7ab4-4eb9-8f85-4b6f263251de
       Content-Length:
       - '500'
       Connection:
@@ -17744,13 +17747,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"d6d8a76707c44fa1b74726c4cccb01a0"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"91d5c6bf66f3459b8cd238cb8d3e854d"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17762,13 +17765,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:19 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-87b56b9b-e77e-473d-a4b8-5f732a73e948
+      - req-16114b6f-551c-4d93-94a8-352c102b819e
       Content-Length:
       - '4143'
       Connection:
@@ -17777,11 +17780,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:19.926574", "expires":
-        "2018-08-06T17:58:19Z", "id": "b069567866c94658af6d5ac91a486433", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:29.657741", "expires":
+        "2018-09-24T21:28:29Z", "id": "f090831817464fd78d23f86038aa6710", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bKukrPWiSlCj57NyPPR7Kw",
-        "YpG1zWt9QCqHIPdId5eSZg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["t74hSBdOSC2Wee6yQl-Hmg",
+        "4RIhJQw-Q1uSOQu_rVIELQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17825,7 +17828,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17840,20 +17843,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6d8a76707c44fa1b74726c4cccb01a0
+      - 91d5c6bf66f3459b8cd238cb8d3e854d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:20 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d2c92e08-4e2b-48b2-8c40-fa1c4e7c6425
+      - req-6d25dbdb-c3a1-4f14-a3bd-2e66fdcc31b7
       Content-Length:
       - '500'
       Connection:
@@ -17870,7 +17873,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17888,13 +17891,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:20 GMT
+      - Mon, 24 Sep 2018 20:28:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e18a7c45-e0f0-43bd-b344-b6e7fb0a32c0
+      - req-fb3bb025-153f-41f2-bd25-f47ae17dc987
       Content-Length:
       - '4117'
       Connection:
@@ -17903,10 +17906,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:20.394521", "expires":
-        "2018-08-06T17:58:20Z", "id": "978c29f254c4495a995dd0d27b436c66", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:30.011713", "expires":
+        "2018-09-24T21:28:29Z", "id": "bbbb6e045f2a47fcb9a0d821fe628f39", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Z2NkwnjzQ4uW1tS24zK9FQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_UfqcOthTtmjrwPr00xnxg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17950,7 +17953,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17968,13 +17971,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:20 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9227d85-8ff6-4e7c-b7b5-51732c0a6462
+      - req-28f686f8-ee52-437e-8c20-c4d23873ac97
       Content-Length:
       - '4131'
       Connection:
@@ -17983,10 +17986,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:20.753524", "expires":
-        "2018-08-06T17:58:20Z", "id": "4f942d6adf394d68b02a12836040f4cb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:30.211287", "expires":
+        "2018-09-24T21:28:30Z", "id": "f1b173a4609041d3affef85c5f9072c0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Z3yJM8GXQjCh0ozGte8KNA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TLBoVBluTiGrHJM_DX51sg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18030,7 +18033,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18048,13 +18051,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:20 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2b663e15-115d-4f19-9cc3-e4c31ed5dce7
+      - req-7f546ed2-8bcb-4305-8aa6-f416c578f5cb
       Content-Length:
       - '4118'
       Connection:
@@ -18063,10 +18066,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:21.102500", "expires":
-        "2018-08-06T17:58:21Z", "id": "c12fa0d1909641b5804aa432e5698af0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:30.390485", "expires":
+        "2018-09-24T21:28:30Z", "id": "f0deed7fba134dd5ad406c65025fc8d4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4LPFUHxcSAu1pKxKXv8BUg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["n57ciVSgSkiuRAmrLb7iRA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18110,7 +18113,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18128,13 +18131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:21 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94d7b89a-0dba-4465-ad52-aea4c915deac
+      - req-94097bf5-dd5a-49b5-b0f8-c28c459c355f
       Content-Length:
       - '4117'
       Connection:
@@ -18143,10 +18146,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:21.446549", "expires":
-        "2018-08-06T17:58:21Z", "id": "255bc45c87f9432198831744313344ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:30.580376", "expires":
+        "2018-09-24T21:28:30Z", "id": "2b3c0bc12cb54e60bc9a480a45494c8b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["v4GZjI-dROaLpBwUC8Ndhw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["g724NpLzSiu6FnwYDeWGig"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18190,7 +18193,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18205,7 +18208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 255bc45c87f9432198831744313344ed
+      - 2b3c0bc12cb54e60bc9a480a45494c8b
   response:
     status:
       code: 200
@@ -18234,15 +18237,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txb1d1debe4f7343bb94b4a-005b687e2d
+      - tx602c91ca4956424ca0808-005ba948ee
       Date:
-      - Mon, 06 Aug 2018 16:58:21 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18257,7 +18260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 255bc45c87f9432198831744313344ed
+      - 2b3c0bc12cb54e60bc9a480a45494c8b
   response:
     status:
       code: 200
@@ -18286,14 +18289,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf96d47e9135949dfb2ba2-005b687e2d
+      - txcee5c7c6daa3441cbd61b-005ba948ee
       Date:
-      - Mon, 06 Aug 2018 16:58:21 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18311,13 +18314,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:22 GMT
+      - Mon, 24 Sep 2018 20:28:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b6c9a3e1-696e-4847-a09c-3e9ccfc8fdb8
+      - req-b14d8365-aecd-4db8-bfd3-4c2f691837b8
       Content-Length:
       - '4131'
       Connection:
@@ -18326,10 +18329,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:22.237091", "expires":
-        "2018-08-06T17:58:22Z", "id": "caf2ec60224e44029b9f392214f467f9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:31.006192", "expires":
+        "2018-09-24T21:28:30Z", "id": "7c25173860fe4ff1a75c16c1a723b633", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eqtwITeiRGeCanfuOM7q-Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dEXW3q1QRsKNyRNFWvuooA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18373,7 +18376,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18388,7 +18391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - caf2ec60224e44029b9f392214f467f9
+      - 7c25173860fe4ff1a75c16c1a723b633
   response:
     status:
       code: 200
@@ -18401,22 +18404,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574702.64951'
+      - '1537820911.16595'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574702.64951'
+      - '1537820911.16595'
       X-Trans-Id:
-      - tx0463b7d5bad9471a99e91-005b687e2e
+      - tx2f00ea393b7d4f858a0d7-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:22 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18431,7 +18434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c5d03ccfb8f4ec7b349578773069908
+      - d4d57b79c6d543989a68a600600dcdca
   response:
     status:
       code: 200
@@ -18444,22 +18447,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574703.24752'
+      - '1537820911.33245'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574703.24752'
+      - '1537820911.33245'
       X-Trans-Id:
-      - txa65ae97e8de745de872fe-005b687e2e
+      - tx8c01c25ace7b449cb0ee8-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:23 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18477,13 +18480,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:23 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5975d212-d5a4-40ff-a6b7-d3b87860d0cf
+      - req-5177c9c2-faca-469e-bce7-ef67117c11ac
       Content-Length:
       - '4118'
       Connection:
@@ -18492,10 +18495,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:23.499014", "expires":
-        "2018-08-06T17:58:23Z", "id": "717776244bc6473dadc5ee0aa1fe13b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:31.512591", "expires":
+        "2018-09-24T21:28:31Z", "id": "eff652d7f5b74c2282ca7fb24828355c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["F5NsyGexRr67qnNnc8e-6Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KNSvuKxsSxm4kh4UEQeZPQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18539,7 +18542,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18554,7 +18557,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 717776244bc6473dadc5ee0aa1fe13b5
+      - eff652d7f5b74c2282ca7fb24828355c
   response:
     status:
       code: 200
@@ -18567,22 +18570,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574703.79187'
+      - '1537820911.67771'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574703.79187'
+      - '1537820911.67771'
       X-Trans-Id:
-      - tx90a8146c694442b2b8f10-005b687e2f
+      - tx91b1584657794ffa83176-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:23 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -18597,7 +18600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 255bc45c87f9432198831744313344ed
+      - 2b3c0bc12cb54e60bc9a480a45494c8b
   response:
     status:
       code: 200
@@ -18618,9 +18621,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txac612dbf88914edda6569-005b687e2f
+      - tx7189c1e93b1c49bf8a60b-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:23 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -18630,7 +18633,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -18645,7 +18648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 255bc45c87f9432198831744313344ed
+      - 2b3c0bc12cb54e60bc9a480a45494c8b
   response:
     status:
       code: 200
@@ -18666,14 +18669,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx066b1504a6944a8fabb2d-005b687e2f
+      - tx3c241f535480424f854f8-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:24 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -18688,7 +18691,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 255bc45c87f9432198831744313344ed
+      - 2b3c0bc12cb54e60bc9a480a45494c8b
   response:
     status:
       code: 200
@@ -18709,12 +18712,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txa0a4ae1b98b34d5fadb43-005b687e30
+      - tx33fbcd4653744d02b89d8-005ba948ef
       Date:
-      - Mon, 06 Aug 2018 16:58:24 GMT
+      - Mon, 24 Sep 2018 20:28:31 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:33 GMT
+      - Mon, 24 Sep 2018 20:29:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f5b2c7da-1c15-4b63-a8c7-1df4cb3abcb7
+      - req-34ae2bad-95a3-4ce4-8dbb-4fa888b53c70
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:33.126068", "expires":
-        "2018-08-06T17:58:33Z", "id": "4ebf59a4fffa4e3ca02f9a5eee94c5c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:15.624887", "expires":
+        "2018-09-24T21:29:15Z", "id": "6b0cb8be9c974801a2e3e2932c02a8a5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6AR_kmuOSvq-LoLjYoHxKQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["3O4PgXI3QCCfbRswD-F2tg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:58:33 GMT
+      - Mon, 24 Sep 2018 20:29:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-a692d5a2-e2e4-45fb-bc49-7b9106aa8319
+      - req-7e9c46f8-5ea8-4ab7-b7d0-af7edf38790a
       Date:
-      - Mon, 06 Aug 2018 16:58:33 GMT
+      - Mon, 24 Sep 2018 20:29:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:33 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d824212a-47a1-417d-8fe0-d28bd12fbb8b
+      - req-ffc2dc18-e889-4f03-a958-1de8ab917d16
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:33.730159", "expires":
-        "2018-08-06T17:58:33Z", "id": "96f1c6ea1b754c319f0e5f0d9c3a67bc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:16.078425", "expires":
+        "2018-09-24T21:29:16Z", "id": "2dbacfcfe1134007a67457b4aa442c57", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["KFL_BUS0Tgih0RfuQa968g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["D-zTIijVTcGHjUgd1zwUVQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-44f0a672-c3bc-4bc2-9ac9-bbb315a65e83
+      - req-a9d8ec7c-37d3-4651-b4fa-d6dc0d85c1fc
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-44f0a672-c3bc-4bc2-9ac9-bbb315a65e83
+      - req-a9d8ec7c-37d3-4651-b4fa-d6dc0d85c1fc
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2a7a47a1-ca20-4561-8580-8c6153de7e30
+      - req-c5bb9309-8966-45cb-9747-e8f3f1676809
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:58:30.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:29:16.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:29:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:58:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:29:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:29:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:58:30.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:29:14.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-94256caa-de1e-4743-8b7f-203943eab544
+      - req-e00d2bc8-af27-48c5-a9aa-fa3fa771cca5
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:58:30.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:29:16.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:29:13.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:58:32.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:29:15.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:58:30.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:29:07.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:58:30.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:29:14.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +390,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-e86ee544-9393-45fa-a54e-b4a1cc970742
+      - req-cfdd42f0-6d35-467e-8f95-fa4bf82ae3d2
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +406,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +421,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-85aaa969-23f1-4194-88d5-c17e2040d35e
+      - req-59da7ab6-95b8-4a0d-89e9-e446ef4a5ed4
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +450,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +465,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +478,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-482ab363-1bd1-4cfd-a7fb-2ac7165c4913
+      - req-38cfdd99-fd02-4e73-b907-1b1a228f12bc
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +495,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +523,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-bca236f2-4f90-4b92-8a0f-5aaa7821b790
+      - req-23798545-d526-41a0-979a-ef86b6608a35
       Date:
-      - Mon, 06 Aug 2018 16:58:34 GMT
+      - Mon, 24 Sep 2018 20:29:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +535,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:35 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-701fbe72-4ff6-481b-9270-6578cb47750c
+      - req-5fe8c717-b517-4f8e-acaf-87a8dd15fcff
       Content-Length:
       - '4170'
       Connection:
@@ -568,10 +568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:35.198234", "expires":
-        "2018-08-06T17:58:35Z", "id": "0ecc31df08454f249f592dde69dfd5b4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:17.093954", "expires":
+        "2018-09-24T21:29:17Z", "id": "9839b98759b7471abd8be2b5463fdc3c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8l2sttNeQ6K3YSs_RAXfuQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FIcrZnLHR_6GGCrPx--ubg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -616,7 +616,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -631,20 +631,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ecc31df08454f249f592dde69dfd5b4
+      - 9839b98759b7471abd8be2b5463fdc3c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:35 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-34d16ea9-1ccc-4820-b1eb-24d3a3aed0bf
+      - req-996d8b5f-869b-43fd-a839-d219a7cdbc75
       Content-Length:
       - '500'
       Connection:
@@ -661,7 +661,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -676,7 +676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -689,15 +689,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-7d65f6b9-065f-47d9-8ca7-2c28dde3e23c
+      - req-7dd7ffdf-8c10-4b9f-8ca5-49245ab1b2d9
       Date:
-      - Mon, 06 Aug 2018 16:58:35 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -715,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:35 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b5857e23-8905-47c5-99df-da9a58d20bb8
+      - req-6c7c47e9-3fa5-406e-aa4e-12792f7ba3ec
       Content-Length:
       - '4170'
       Connection:
@@ -730,10 +730,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:35.666608", "expires":
-        "2018-08-06T17:58:35Z", "id": "398b62f954a64f78ac12354c9159e6b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:17.531996", "expires":
+        "2018-09-24T21:29:17Z", "id": "abbfe989a29249e086b52822866a92af", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zQ0HfZc3Rh2RZduDeihiRg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sYxVHn1dT-yQCiThEWylNA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -778,7 +778,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -793,7 +793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 398b62f954a64f78ac12354c9159e6b6
+      - abbfe989a29249e086b52822866a92af
   response:
     status:
       code: 300
@@ -804,7 +804,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:58:35 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -817,7 +817,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -832,7 +832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 398b62f954a64f78ac12354c9159e6b6
+      - abbfe989a29249e086b52822866a92af
   response:
     status:
       code: 200
@@ -843,14 +843,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-530dde98-1c3d-4c1b-a6c7-d81129600576
+      - req-adf1138b-c8a5-4f6a-b9a9-b8f91e9171ef
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -865,7 +865,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 398b62f954a64f78ac12354c9159e6b6
+      - abbfe989a29249e086b52822866a92af
   response:
     status:
       code: 200
@@ -876,9 +876,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-68403965-35f3-4a18-9ef2-e6043ee1cf86
+      - req-d400c831-0696-4c1c-8d45-400585a19827
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -920,7 +920,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -935,7 +935,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -948,9 +948,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ab700580-706d-4ec0-a842-082b774deef7
+      - req-db754aa2-bcab-4856-ae67-78b1fd573ea9
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -960,7 +960,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -975,7 +975,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -988,9 +988,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-14575cbc-fea9-4e6b-a9da-dbaac56dbaec
+      - req-b9656bb1-609a-4cdf-9c3a-7bc6ffe69dd3
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1000,7 +1000,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +1018,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0f6ee9c8-1210-4903-863a-72b5c6657f0f
+      - req-c579e501-74af-421e-b9a9-7fb364a16252
       Content-Length:
       - '4170'
       Connection:
@@ -1033,10 +1033,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:36.714201", "expires":
-        "2018-08-06T17:58:36Z", "id": "17fa0eb35a8b41b29043e32ec238b3f8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:18.326608", "expires":
+        "2018-09-24T21:29:18Z", "id": "45ce59d8aadd4821979e29710021f77c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["TvbWdRWtTKWhIc0awwlo4Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Za9Zq_UbSHyBuzZj-gj1wQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1081,7 +1081,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1099,13 +1099,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:36 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1fa26653-a854-43e6-9651-cd4afa9038d3
+      - req-5143de6b-a569-4ac5-9959-432208d7171d
       Content-Length:
       - '370'
       Connection:
@@ -1114,13 +1114,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:36.909029", "expires":
-        "2018-08-06T17:58:36Z", "id": "fc712f2ffa1c4e02b91e577aa66701cd", "audit_ids":
-        ["2tviKPqCTYqbIPS9GqlAPg"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:18.480145", "expires":
+        "2018-09-24T21:29:18Z", "id": "54c8415993a6411e8ba3e8f6f5607f7f", "audit_ids":
+        ["0rPkph0pQ86E4xCvludpxQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1135,20 +1135,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc712f2ffa1c4e02b91e577aa66701cd
+      - 54c8415993a6411e8ba3e8f6f5607f7f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:37 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b1ccb15f-c292-48d8-983b-529f9377b770
+      - req-df05c6fc-275d-48f8-b998-0f37ee010840
       Content-Length:
       - '500'
       Connection:
@@ -1165,13 +1165,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"fc712f2ffa1c4e02b91e577aa66701cd"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"54c8415993a6411e8ba3e8f6f5607f7f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1183,13 +1183,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:37 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c3cba92-dcf9-4d64-b7cc-e31bc72a7f29
+      - req-fd72e3b4-7691-4fc3-89ca-0c54b7063ec9
       Content-Length:
       - '4143'
       Connection:
@@ -1198,11 +1198,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:37.380434", "expires":
-        "2018-08-06T17:58:36Z", "id": "26def23b7455432c8e7bb476f18e8a13", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:18.777914", "expires":
+        "2018-09-24T21:29:18Z", "id": "9abd214d30d44662a218db9c3b680a74", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["c7Lj2f7iRB-v3KNFDFDB2Q",
-        "2tviKPqCTYqbIPS9GqlAPg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hbd9F0aLQVuqq-sxNUMFug",
+        "0rPkph0pQ86E4xCvludpxQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1246,7 +1246,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1261,20 +1261,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc712f2ffa1c4e02b91e577aa66701cd
+      - 54c8415993a6411e8ba3e8f6f5607f7f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:37 GMT
+      - Mon, 24 Sep 2018 20:29:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c009dd29-0ace-4fb8-a6e1-83f73deb6b2c
+      - req-61aab6b3-4812-464b-b9ac-694236a16871
       Content-Length:
       - '500'
       Connection:
@@ -1291,7 +1291,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1309,13 +1309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:37 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a500e178-e781-4e43-aeb4-43d9a3c1e815
+      - req-31fa43bd-71af-4011-b987-c130bf81959d
       Content-Length:
       - '4117'
       Connection:
@@ -1324,10 +1324,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:37.802699", "expires":
-        "2018-08-06T17:58:37Z", "id": "d94f732ed99e452d84cafd89d277cc7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:19.104204", "expires":
+        "2018-09-24T21:29:19Z", "id": "2472d9de355f4ed7b455abf8adfd92ed", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HxQJEVq1QMmQ9aQkgPx-6w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["aTxUdqcFQnmr69AXIfcNbA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1371,7 +1371,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1386,7 +1386,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d94f732ed99e452d84cafd89d277cc7e
+      - 2472d9de355f4ed7b455abf8adfd92ed
   response:
     status:
       code: 200
@@ -1397,7 +1397,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:58:37 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1406,7 +1406,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1424,13 +1424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:38 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a6fa9713-b6f8-4633-abb5-4e6c314e4c1b
+      - req-0cf6839b-e2f7-4fef-9413-533fbd144449
       Content-Length:
       - '4131'
       Connection:
@@ -1439,10 +1439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.155229", "expires":
-        "2018-08-06T17:58:38Z", "id": "806c4413c2914055ba268043ff4a1557", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:19.372152", "expires":
+        "2018-09-24T21:29:19Z", "id": "5bc161ef6c414d8a8e399fcd2b2c6c1a", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VJkXqGhkQUKAHpsr9OvBoQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eNN9Ma3dQZaklWUIp_i8LQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1486,7 +1486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1501,7 +1501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 806c4413c2914055ba268043ff4a1557
+      - 5bc161ef6c414d8a8e399fcd2b2c6c1a
   response:
     status:
       code: 200
@@ -1512,7 +1512,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:58:38 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1521,7 +1521,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1539,13 +1539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:38 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6c89109d-0c52-4c48-963f-8511dd57c5f9
+      - req-13a3dcc9-ad4e-4455-9d49-849234611fd1
       Content-Length:
       - '4118'
       Connection:
@@ -1554,10 +1554,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.431903", "expires":
-        "2018-08-06T17:58:38Z", "id": "6368f71d4447459794e46941aa627e9b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:19.636894", "expires":
+        "2018-09-24T21:29:19Z", "id": "d06ed831b7bc405a9bf1bd4c77a40828", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["oPMv8WD-T8aUX1roARUPSw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["YtGCDpG9T-Gx61gP30pIfw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1601,7 +1601,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1616,7 +1616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6368f71d4447459794e46941aa627e9b
+      - d06ed831b7bc405a9bf1bd4c77a40828
   response:
     status:
       code: 200
@@ -1627,7 +1627,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:58:38 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1636,7 +1636,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1654,13 +1654,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:38 GMT
+      - Mon, 24 Sep 2018 20:29:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a5faf062-4881-484f-9ff2-09c51d021048
+      - req-eb871dbe-9c2d-4e84-ba79-0995e3b989e5
       Content-Length:
       - '4117'
       Connection:
@@ -1669,10 +1669,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:38.709932", "expires":
-        "2018-08-06T17:58:38Z", "id": "ab4d6f43c6b1486cb45ce4d6a2a88ca4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:19.900734", "expires":
+        "2018-09-24T21:29:19Z", "id": "1252ea48ef9448448fc58f9bae56d65d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vcoRmKV4Truer8J_2X3FhQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TxunlS_JQLuAM8sO9EUr3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1716,7 +1716,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1731,7 +1731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -1742,9 +1742,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-08d8fe75-e74c-4f5e-ba5d-9d6906bd1b6c
+      - req-8bd7d4c8-10f8-4754-927c-e317b14e2118
       Date:
-      - Mon, 06 Aug 2018 16:58:39 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1778,7 +1778,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1793,7 +1793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -1804,14 +1804,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-98962cdd-72c9-4455-8435-93065aff6168
+      - req-fb91cee9-148d-4327-b236-54dc681f57d9
       Date:
-      - Mon, 06 Aug 2018 16:58:39 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1829,13 +1829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:39 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-79c6983c-aa3d-43fb-8b66-f2e6ad52e86f
+      - req-a61a3f64-de82-4547-b7ea-b0508a42fb1b
       Content-Length:
       - '4131'
       Connection:
@@ -1844,10 +1844,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:39.409333", "expires":
-        "2018-08-06T17:58:39Z", "id": "6f6088c4cc17498b86d60a4e1ad03903", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:20.365981", "expires":
+        "2018-09-24T21:29:20Z", "id": "baebf926aff4434597fb9384ca6818d0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["e6hLLJceQhGWbLyzoq1pjA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["67KABPBlR7CJ4eI6_1BLyQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1891,7 +1891,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1906,7 +1906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6f6088c4cc17498b86d60a4e1ad03903
+      - baebf926aff4434597fb9384ca6818d0
   response:
     status:
       code: 200
@@ -1917,14 +1917,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-acf19525-6a13-4c08-9a43-afa30858e545
+      - req-3400562a-5644-40e0-aca8-8627feccea49
       Date:
-      - Mon, 06 Aug 2018 16:58:39 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1939,7 +1939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 17fa0eb35a8b41b29043e32ec238b3f8
+      - 45ce59d8aadd4821979e29710021f77c
   response:
     status:
       code: 200
@@ -1950,14 +1950,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d2f80e33-fca2-4db0-b5ca-e5f079217a89
+      - req-bc3fa82a-cd1d-493e-b1e4-35ffcd0795d0
       Date:
-      - Mon, 06 Aug 2018 16:58:40 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1975,13 +1975,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:40 GMT
+      - Mon, 24 Sep 2018 20:29:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54cb2fc6-268d-45df-b2f3-42ff4ec2cbeb
+      - req-1dac910b-b57d-49f0-a8e3-02821200c90d
       Content-Length:
       - '4118'
       Connection:
@@ -1990,10 +1990,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:40.464906", "expires":
-        "2018-08-06T17:58:40Z", "id": "5404da4d73394d6b82bf6bd8489d7bd0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:20.865487", "expires":
+        "2018-09-24T21:29:20Z", "id": "1e96767cb78f44fa96b88882f2f1985f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jfRjnGYGTRy8Jtzsff12Wg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Glubi_n6QUW37BP84I6rbQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2037,7 +2037,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2052,7 +2052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5404da4d73394d6b82bf6bd8489d7bd0
+      - 1e96767cb78f44fa96b88882f2f1985f
   response:
     status:
       code: 200
@@ -2063,14 +2063,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-12d5c0ff-03bc-4e39-83b4-6c74f2abc743
+      - req-295c9bee-fd65-4db2-a15e-d09204361237
       Date:
-      - Mon, 06 Aug 2018 16:58:41 GMT
+      - Mon, 24 Sep 2018 20:29:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2085,7 +2085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2096,9 +2096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fa6c6c76-5ea1-4bb5-886f-07e936a0d9dd
+      - req-125c59a9-6f0d-4d2d-97df-dbdd1e85af07
       Date:
-      - Mon, 06 Aug 2018 16:58:41 GMT
+      - Mon, 24 Sep 2018 20:29:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2125,7 +2125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2140,7 +2140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2151,9 +2151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d3b0d8fa-e556-4dff-83e3-92a66e208b88
+      - req-3ff3ccc5-fce9-4bc9-a01a-7316fed7d16d
       Date:
-      - Mon, 06 Aug 2018 16:58:42 GMT
+      - Mon, 24 Sep 2018 20:29:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2180,7 +2180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2206,9 +2206,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1a88e110-9e8b-4977-8433-1c7f01d20487
+      - req-9bb290b8-5e9a-4024-bf89-923c32861cd3
       Date:
-      - Mon, 06 Aug 2018 16:58:44 GMT
+      - Mon, 24 Sep 2018 20:29:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2235,7 +2235,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -2250,7 +2250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2261,9 +2261,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-98607303-7f9d-40fa-9f51-3a9ead529dff
+      - req-02ca6abd-6e8c-47f5-9a00-15a37d28a4af
       Date:
-      - Mon, 06 Aug 2018 16:58:45 GMT
+      - Mon, 24 Sep 2018 20:29:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2319,7 +2319,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -2334,7 +2334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2345,9 +2345,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-57f4e030-91ff-4fb1-9171-852c16ab867e
+      - req-4b5029c0-620b-4174-a282-fd4c3c22418d
       Date:
-      - Mon, 06 Aug 2018 16:58:45 GMT
+      - Mon, 24 Sep 2018 20:29:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2359,7 +2359,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -2374,7 +2374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2387,13 +2387,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-2ffccbd9-6d2d-45a6-82d0-56f457554484
+      - req-f91bd9af-5028-45f9-982f-35de283f8af8
       Date:
-      - Mon, 06 Aug 2018 16:58:46 GMT
+      - Mon, 24 Sep 2018 20:29:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:07Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -2435,7 +2435,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -2450,7 +2450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2463,9 +2463,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-b5406ec7-d39a-4df6-a3b6-c3c2e46d1c3c
+      - req-5d886318-9fdc-43a7-ab3d-cbdc1218ab3e
       Date:
-      - Mon, 06 Aug 2018 16:58:46 GMT
+      - Mon, 24 Sep 2018 20:29:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -2489,7 +2489,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:59:17Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -2511,7 +2511,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -2526,7 +2526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2539,13 +2539,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-91ff243b-17ec-493b-bc8f-29d0abcc1a04
+      - req-27efebff-ec59-4148-8c2c-e39a34ae8c5b
       Date:
-      - Mon, 06 Aug 2018 16:58:47 GMT
+      - Mon, 24 Sep 2018 20:29:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:02Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -2566,7 +2566,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -2589,7 +2589,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -2604,7 +2604,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2617,9 +2617,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-a7c0be9e-f8a1-433f-920f-670f4c9129a2
+      - req-d48a9900-9aea-4c71-ab10-67b9eed9e9f9
       Date:
-      - Mon, 06 Aug 2018 16:58:48 GMT
+      - Mon, 24 Sep 2018 20:29:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2661,7 +2661,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2689,9 +2689,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-31021216-5abd-40d9-8c6d-a8eb3b70cd2c
+      - req-33484aa5-3d5d-49e3-8c94-6e0e8b8db951
       Date:
-      - Mon, 06 Aug 2018 16:58:48 GMT
+      - Mon, 24 Sep 2018 20:29:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2714,7 +2714,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2729,7 +2729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2740,9 +2740,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-018b455a-f638-4b4d-8897-928b6e15cdae
+      - req-04d9b3cc-3abe-4068-bfb6-58b14776d1c1
       Date:
-      - Mon, 06 Aug 2018 16:58:48 GMT
+      - Mon, 24 Sep 2018 20:29:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2798,7 +2798,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2813,7 +2813,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2824,9 +2824,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-23d1f76c-f90d-4264-b33f-e6d3d08bb8dd
+      - req-aec19c17-22cc-4220-9852-859c53c6788f
       Date:
-      - Mon, 06 Aug 2018 16:58:49 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2838,7 +2838,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2853,7 +2853,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2864,9 +2864,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c7f51efe-365d-4256-8ebb-c974ca819f92
+      - req-dc3400b7-d674-4351-8048-a7d7939cffe6
       Date:
-      - Mon, 06 Aug 2018 16:58:49 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2922,7 +2922,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2937,7 +2937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab4d6f43c6b1486cb45ce4d6a2a88ca4
+      - 1252ea48ef9448448fc58f9bae56d65d
   response:
     status:
       code: 200
@@ -2948,9 +2948,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-6e2da3fc-399f-485c-bec5-20e25cd86aa3
+      - req-c05ac9fd-e46f-4730-9106-b9de58d603f1
       Date:
-      - Mon, 06 Aug 2018 16:58:49 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2962,7 +2962,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2977,7 +2977,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d94f732ed99e452d84cafd89d277cc7e
+      - 2472d9de355f4ed7b455abf8adfd92ed
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2990,9 +2990,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-297f7f4d-d03a-43d6-ba62-900a7aa15134
+      - req-70eb9b03-2d3c-4a6a-b61a-32578c1a4c93
       Date:
-      - Mon, 06 Aug 2018 16:58:49 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3001,7 +3001,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3016,7 +3016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 806c4413c2914055ba268043ff4a1557
+      - 5bc161ef6c414d8a8e399fcd2b2c6c1a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3029,9 +3029,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-909333e7-66cd-4213-b765-84a42c36b41d
+      - req-048e7c4a-c9f7-4c08-b55e-4da34cab8526
       Date:
-      - Mon, 06 Aug 2018 16:58:50 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3040,7 +3040,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3055,7 +3055,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bc08aea2-5fa1-4187-b57a-0cd7ea4e15ae
+      - req-ff3d196a-526b-4731-8d47-3d8c54a0cb0d
       Date:
-      - Mon, 06 Aug 2018 16:58:50 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3079,7 +3079,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3094,7 +3094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6368f71d4447459794e46941aa627e9b
+      - d06ed831b7bc405a9bf1bd4c77a40828
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3107,9 +3107,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-473e4e27-34ce-43f9-86de-b8dba254b407
+      - req-206f87f7-45c2-4468-bb9c-ce849cf0e1b9
       Date:
-      - Mon, 06 Aug 2018 16:58:50 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3118,7 +3118,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3136,13 +3136,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:50 GMT
+      - Mon, 24 Sep 2018 20:29:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f0dee00-e397-42da-ab76-79e3ad9955c2
+      - req-16b139b1-3abb-4d29-ad4a-e69b69d2f699
       Content-Length:
       - '4117'
       Connection:
@@ -3151,10 +3151,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:51.009285", "expires":
-        "2018-08-06T17:58:50Z", "id": "77b554ddb3f342fe99724e6c38144fe7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:25.007839", "expires":
+        "2018-09-24T21:29:24Z", "id": "097959381abe4cec8dacde31893858b1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lcz6SD24SV-DJCkikhPszA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vGY9ZLtTSQO2s5Kg5XCr7g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3198,7 +3198,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3213,22 +3213,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77b554ddb3f342fe99724e6c38144fe7
+      - '097959381abe4cec8dacde31893858b1'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f72f05a9-21a6-449e-bf84-e0bd344ba712
+      - req-db0f2584-0933-4452-8b5f-15399869a40d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f72f05a9-21a6-449e-bf84-e0bd344ba712
+      - req-db0f2584-0933-4452-8b5f-15399869a40d
       Date:
-      - Mon, 06 Aug 2018 16:58:51 GMT
+      - Mon, 24 Sep 2018 20:29:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3238,7 +3238,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3256,13 +3256,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:51 GMT
+      - Mon, 24 Sep 2018 20:29:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8e3ccd07-c07f-4e4a-b616-7ebe82f5b4aa
+      - req-3e2938e6-741e-4681-a24a-e418bfd2f6ba
       Content-Length:
       - '4131'
       Connection:
@@ -3271,10 +3271,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:51.977023", "expires":
-        "2018-08-06T17:58:51Z", "id": "9e07ad07d60f434c83cd7e7f2cc5d8d9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:25.515433", "expires":
+        "2018-09-24T21:29:25Z", "id": "62657da7a8814395a610075a202f451b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fbYQ9fJcQ-6RU5QZ2glWWA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UosrfMr5SQ2eorSHMCF8Dw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3318,7 +3318,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3333,22 +3333,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
+      - 62657da7a8814395a610075a202f451b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3a6f278-2c4a-4442-be7b-3caaf77a754c
+      - req-cf7bc10a-eaa4-4509-8daa-52cc55e6b7dc
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b3a6f278-2c4a-4442-be7b-3caaf77a754c
+      - req-cf7bc10a-eaa4-4509-8daa-52cc55e6b7dc
       Date:
-      - Mon, 06 Aug 2018 16:58:52 GMT
+      - Mon, 24 Sep 2018 20:29:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3358,7 +3358,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3373,22 +3373,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f80540a3-4fda-4e15-99df-1970bfe9809b
+      - req-84da1a74-187a-4798-8a2b-fb21dccefc0e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f80540a3-4fda-4e15-99df-1970bfe9809b
+      - req-84da1a74-187a-4798-8a2b-fb21dccefc0e
       Date:
-      - Mon, 06 Aug 2018 16:58:53 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3398,7 +3398,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3416,13 +3416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:53 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ce9a84e7-0d31-4382-8748-cce59d859749
+      - req-d19f8bee-3cc1-415d-aaaf-c79269eed4ae
       Content-Length:
       - '4118'
       Connection:
@@ -3431,10 +3431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:53.656459", "expires":
-        "2018-08-06T17:58:53Z", "id": "95e5eaf00df847018b63061319e4692e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:26.243075", "expires":
+        "2018-09-24T21:29:26Z", "id": "46d5738ed3974c4da584d947177f8dac", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["L8oPrFSKQUK1WmJeA2v_3Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_P4rTuZSTJu0rjwxwvPQNA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3478,7 +3478,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3493,22 +3493,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 95e5eaf00df847018b63061319e4692e
+      - 46d5738ed3974c4da584d947177f8dac
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bfc46660-5ed0-47a8-81d5-db8fb68d8b1d
+      - req-af8525be-3bbb-4d74-a147-cdc796ababce
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bfc46660-5ed0-47a8-81d5-db8fb68d8b1d
+      - req-af8525be-3bbb-4d74-a147-cdc796ababce
       Date:
-      - Mon, 06 Aug 2018 16:58:54 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3518,7 +3518,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3536,13 +3536,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:54 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e661159d-0cc6-4995-b7e3-569ba53c0381
+      - req-199fe630-84da-4c87-badc-5bcc037ba0fb
       Content-Length:
       - '4170'
       Connection:
@@ -3551,10 +3551,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:54.262536", "expires":
-        "2018-08-06T17:58:54Z", "id": "7ee81ffd642c430d8e0c71a95d33d4a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:26.724253", "expires":
+        "2018-09-24T21:29:26Z", "id": "1bfb4a0c8c304d9ea7fada850fec3a39", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gmWS0SZTS_-0bUWTbUKH4w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["XjKPNMg3RFWhi0gGcfDblQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3599,7 +3599,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -3614,7 +3614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ee81ffd642c430d8e0c71a95d33d4a5
+      - 1bfb4a0c8c304d9ea7fada850fec3a39
   response:
     status:
       code: 200
@@ -3625,13 +3625,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:58:54 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3649,13 +3649,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:54 GMT
+      - Mon, 24 Sep 2018 20:29:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eef1fd29-f45a-4f2c-9fd5-8895cacd00fa
+      - req-59037d84-d4d6-4f5a-9678-2dce420e3d4d
       Content-Length:
       - '4117'
       Connection:
@@ -3664,10 +3664,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:54.615199", "expires":
-        "2018-08-06T17:58:54Z", "id": "38da0b87d3a942648c7a4025c404b6b8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:26.985734", "expires":
+        "2018-09-24T21:29:26Z", "id": "bdb4f746dc0e4ef2934becc83ac164a3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UqJF3FGPSQixOpYBTFmOWg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["m9QQWxxoTouQj1pi_0PSDQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3711,7 +3711,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3726,7 +3726,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38da0b87d3a942648c7a4025c404b6b8
+      - bdb4f746dc0e4ef2934becc83ac164a3
   response:
     status:
       code: 200
@@ -3737,16 +3737,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-aa98e46c-c5ae-40b9-a49d-8da3388f7068
+      - req-01702d1f-787a-4729-9de1-e0ac82f4adb7
       Date:
-      - Mon, 06 Aug 2018 16:58:55 GMT
+      - Mon, 24 Sep 2018 20:29:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3764,13 +3764,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:55 GMT
+      - Mon, 24 Sep 2018 20:29:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c8577b90-895c-43f4-a95f-f88320f9afea
+      - req-345a758f-4f13-46d7-8bb1-02b1987bb20e
       Content-Length:
       - '4131'
       Connection:
@@ -3779,10 +3779,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:55.301614", "expires":
-        "2018-08-06T17:58:55Z", "id": "2a9f4bbc74214ddcaa5922e314b3df65", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:27.327952", "expires":
+        "2018-09-24T21:29:27Z", "id": "2bb23445af7f46f7a8a7d6ebbcdac264", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_hzbLx34QcGFUNiYp0gOGQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_CW8dE6IRi2-7rH-cKLitw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3826,7 +3826,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3841,7 +3841,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2a9f4bbc74214ddcaa5922e314b3df65
+      - 2bb23445af7f46f7a8a7d6ebbcdac264
   response:
     status:
       code: 200
@@ -3852,16 +3852,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e63d685d-1020-4235-aad6-c99d6b73886c
+      - req-32c81f51-3507-4775-bd21-d39eb8000e8b
       Date:
-      - Mon, 06 Aug 2018 16:58:55 GMT
+      - Mon, 24 Sep 2018 20:29:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ee81ffd642c430d8e0c71a95d33d4a5
+      - 1bfb4a0c8c304d9ea7fada850fec3a39
   response:
     status:
       code: 200
@@ -3887,16 +3887,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-711f94b9-6e1b-4557-a4e2-ac6f770fea7a
+      - req-73c1ade7-bed7-40c8-8804-1e143be1f954
       Date:
-      - Mon, 06 Aug 2018 16:58:55 GMT
+      - Mon, 24 Sep 2018 20:29:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3914,13 +3914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:55 GMT
+      - Mon, 24 Sep 2018 20:29:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5038bbf7-ce15-4c47-a28e-c9820d703f9f
+      - req-edfcbb3d-06be-4ae1-be90-1645f75e142f
       Content-Length:
       - '4118'
       Connection:
@@ -3929,10 +3929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:55.906452", "expires":
-        "2018-08-06T17:58:55Z", "id": "1832ac46f9b34119a75798c23592396e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:28.009879", "expires":
+        "2018-09-24T21:29:27Z", "id": "95094f4363a64ae892a3329e49377561", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4ytxlz_oRhGVP0ONr0HkgA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MOfvCisaTCqE0XdEHZoF8A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3976,7 +3976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3991,7 +3991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1832ac46f9b34119a75798c23592396e
+      - 95094f4363a64ae892a3329e49377561
   response:
     status:
       code: 200
@@ -4002,16 +4002,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e07c7cab-4a86-4435-ac23-727665b9b8ab
+      - req-83353243-97ed-4d0d-b87b-f9d548f71e39
       Date:
-      - Mon, 06 Aug 2018 16:58:56 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4026,7 +4026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4039,14 +4039,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-8223844e-cfad-4320-ab86-3d594620e09f
+      - req-b6d126b2-a0c3-4b95-a062-4937c134b984
       Date:
-      - Mon, 06 Aug 2018 16:58:56 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4061,7 +4061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4074,14 +4074,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a596199c-fc3f-4373-972f-fcf0898055fb
+      - req-361b5e04-89ac-45f3-95f6-0685fb048902
       Date:
-      - Mon, 06 Aug 2018 16:58:56 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4096,7 +4096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4109,14 +4109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5f8cf60b-1767-4017-91e9-60d2185954a2
+      - req-823c86b0-eb39-4d64-9546-e8ccd31be726
       Date:
-      - Mon, 06 Aug 2018 16:58:57 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4131,7 +4131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4144,14 +4144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bf8ed835-04f8-4ce3-8e44-8732ecdefa97
+      - req-453e957b-2baa-404a-adf4-fc0c5a770f93
       Date:
-      - Mon, 06 Aug 2018 16:58:57 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4166,7 +4166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4179,14 +4179,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-275ce610-2346-4252-b828-3ce08baa77c7
+      - req-8ab43390-4652-4b39-a905-4addf5f6b722
       Date:
-      - Mon, 06 Aug 2018 16:58:57 GMT
+      - Mon, 24 Sep 2018 20:29:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4201,7 +4201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4214,15 +4214,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-450385bc-db21-4ed7-80bd-db08035f2053
+      - req-dbe8b6cd-5a43-4a3b-b375-b11158ded11f
       Date:
-      - Mon, 06 Aug 2018 16:58:57 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4237,7 +4237,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4250,14 +4250,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-cc6c784c-494a-4181-b032-df3f272a6b36
+      - req-122d4952-4ce2-48d6-82b9-b88935e4c553
       Date:
-      - Mon, 06 Aug 2018 16:58:58 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4272,7 +4272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4285,15 +4285,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-31e59294-cee0-455d-ad8c-d3367fed85c1
+      - req-37487191-bf52-444a-b133-5be3c044734b
       Date:
-      - Mon, 06 Aug 2018 16:58:58 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4308,7 +4308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4321,14 +4321,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-278af330-f069-4052-9a56-72dcdfd75904
+      - req-6e8fff59-9470-4729-a605-4b40e8662afd
       Date:
-      - Mon, 06 Aug 2018 16:58:58 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4343,7 +4343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4356,14 +4356,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c6c74b82-b217-4673-960d-9c897a13b2e1
+      - req-98f730c0-a557-4945-ac34-8bc3d8690914
       Date:
-      - Mon, 06 Aug 2018 16:58:59 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4378,7 +4378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4391,14 +4391,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-d572d166-b3da-459e-99c3-0aa2bcd00ca3
+      - req-1552c197-e9a7-4b17-b52c-0fb22d571140
       Date:
-      - Mon, 06 Aug 2018 16:58:59 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4416,13 +4416,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:59 GMT
+      - Mon, 24 Sep 2018 20:29:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-45a2d339-8c64-41d2-936b-e49c28bd7255
+      - req-b413a935-e42e-4ccc-95be-0f3357967854
       Content-Length:
       - '4170'
       Connection:
@@ -4431,10 +4431,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:59.685828", "expires":
-        "2018-08-06T17:58:59Z", "id": "5b9979a656354175a8944e75b4c721a2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:29.936675", "expires":
+        "2018-09-24T21:29:29Z", "id": "22b81f09c64c4aabac745478fa1ea353", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XmpvPFh0TYKPlaM4nDqHRg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["u5gzI6sVRuOq_44tKqF7Og"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4479,13 +4479,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"5b9979a656354175a8944e75b4c721a2"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"22b81f09c64c4aabac745478fa1ea353"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4497,13 +4497,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:58:59 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7473b01d-834b-49d4-a6ca-d2770964c403
+      - req-bb6ec20f-61b2-46d1-857c-c7b044cdc616
       Content-Length:
       - '4196'
       Connection:
@@ -4512,10 +4512,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:58:59.960016", "expires":
-        "2018-08-06T17:58:59Z", "id": "3ab6ff526e4945a48512b17da807f3c7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:30.106393", "expires":
+        "2018-09-24T21:29:29Z", "id": "8de4bb1782eb47e7a74766f56b8d3f71", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vr8D-kavSYW8mbp9ZpdH_w", "XmpvPFh0TYKPlaM4nDqHRg"]},
+        "name": "admin"}, "audit_ids": ["l2QeCd2jQNe8oQcJ22RCUw", "u5gzI6sVRuOq_44tKqF7Og"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4560,7 +4560,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:58:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4578,13 +4578,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:00 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e80ab592-956f-47d5-9d39-f96c17fc4c94
+      - req-cfad0d7d-7f90-4a4a-af4b-1d6edcef5d50
       Content-Length:
       - '4170'
       Connection:
@@ -4593,10 +4593,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:00.284181", "expires":
-        "2018-08-06T17:59:00Z", "id": "689b88e98f714916b428e9641d8590d9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:30.290941", "expires":
+        "2018-09-24T21:29:30Z", "id": "35cdd2ddfce544c7b6ce5bbed81622d6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tRn94WlZQEWDOeRvlRPS2g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sPZd1abQTVusnBLr4asPaQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4641,13 +4641,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"689b88e98f714916b428e9641d8590d9"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"35cdd2ddfce544c7b6ce5bbed81622d6"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -4659,13 +4659,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:00 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e771898-6a41-4307-b6eb-d9c2ee127999
+      - req-d0ba3ac9-f1f5-40a5-966c-494765456fa4
       Content-Length:
       - '4196'
       Connection:
@@ -4674,10 +4674,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:00.551782", "expires":
-        "2018-08-06T17:59:00Z", "id": "cffb230b3b81487a99965bb87844f7f0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:30.457359", "expires":
+        "2018-09-24T21:29:30Z", "id": "570e15dedc7b4b318d9cbd6912d1050a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["gLXDtMj8RXe_tA5fNC-jqQ", "tRn94WlZQEWDOeRvlRPS2g"]},
+        "name": "admin"}, "audit_ids": ["8ie76wPNTzmuesEw6YtBIQ", "sPZd1abQTVusnBLr4asPaQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4722,7 +4722,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -4737,7 +4737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ebf59a4fffa4e3ca02f9a5eee94c5c5
+      - 6b0cb8be9c974801a2e3e2932c02a8a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4750,14 +4750,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-78934f53-6ae1-4925-ac19-33516ef8f355
+      - req-1e85e865-60da-4cff-8739-77b18f272851
       Date:
-      - Mon, 06 Aug 2018 16:59:00 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -4772,22 +4772,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f39e440-8db4-4e1e-b5f7-ddac71bca834
+      - req-aac04375-d7ba-42db-ab12-1ca9a19ba1ab
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-0f39e440-8db4-4e1e-b5f7-ddac71bca834
+      - req-aac04375-d7ba-42db-ab12-1ca9a19ba1ab
       Date:
-      - Mon, 06 Aug 2018 16:59:01 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4820,7 +4820,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4835,22 +4835,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c635d002-553a-4cfb-a107-58098137d8a4
+      - req-33596c69-878f-4782-a936-3ae95c64f9c8
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-c635d002-553a-4cfb-a107-58098137d8a4
+      - req-33596c69-878f-4782-a936-3ae95c64f9c8
       Date:
-      - Mon, 06 Aug 2018 16:59:01 GMT
+      - Mon, 24 Sep 2018 20:29:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4867,167 +4867,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 77b554ddb3f342fe99724e6c38144fe7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-ad4640ed-5f12-4787-a83e-3241742d6af6
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1053'
-      X-Openstack-Request-Id:
-      - req-ad4640ed-5f12-4787-a83e-3241742d6af6
-      Date:
-      - Mon, 06 Aug 2018 16:59:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
-        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
-        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "created_at": "2016-11-11T13:49:40.000000", "size": 1, "id": "32b1ef6f-f8a6-4d6e-8e22-a5a3bb69da16",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
-        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
-        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 77b554ddb3f342fe99724e6c38144fe7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-0605e2ba-e44d-4327-ab84-0bd9f483872d
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1081'
-      X-Openstack-Request-Id:
-      - req-0605e2ba-e44d-4327-ab84-0bd9f483872d
-      Date:
-      - Mon, 06 Aug 2018 16:59:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
-        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
-        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "created_at": "2016-11-11T13:49:40.000000", "size": 1, "id": "32b1ef6f-f8a6-4d6e-8e22-a5a3bb69da16",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
-        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
-        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
-        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-5fd8bbf5-5136-4ac2-b62d-fa10e085a833
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-5fd8bbf5-5136-4ac2-b62d-fa10e085a833
-      Date:
-      - Mon, 06 Aug 2018 16:59:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9e07ad07d60f434c83cd7e7f2cc5d8d9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-83cbcefe-0380-4d13-bc34-f136c748d5e9
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-83cbcefe-0380-4d13-bc34-f136c748d5e9
-      Date:
-      - Mon, 06 Aug 2018 16:59:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5042,30 +4882,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-534398db-bf34-4748-97a2-722e34f31e8c
+      - req-ea2259a9-4ec8-41a4-a675-59675a9fc801
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-534398db-bf34-4748-97a2-722e34f31e8c
+      - req-ea2259a9-4ec8-41a4-a675-59675a9fc801
       Date:
-      - Mon, 06 Aug 2018 16:59:02 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
+    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available
     body:
       encoding: US-ASCII
       string: ''
@@ -5077,97 +4917,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16082d46-187b-4e75-9720-0cbde3a01c48
+      - req-27528f8f-c93d-4b60-b6d7-1471d1487040
       Content-Type:
       - application/json
       Content-Length:
-      - '17'
+      - '1098'
       X-Openstack-Request-Id:
-      - req-16082d46-187b-4e75-9720-0cbde3a01c48
+      - req-27528f8f-c93d-4b60-b6d7-1471d1487040
       Date:
-      - Mon, 06 Aug 2018 16:59:03 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
+      string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
+        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
+        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "created_at": "2016-11-11T13:49:40.000000", "size": 1, "id": "32b1ef6f-f8a6-4d6e-8e22-a5a3bb69da16",
+        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
+        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
+        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448",
+        "os-extended-snapshot-attributes:project_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
+        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 95e5eaf00df847018b63061319e4692e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-fe6a8362-50aa-4873-9a96-eb52c37a69bb
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-fe6a8362-50aa-4873-9a96-eb52c37a69bb
-      Date:
-      - Mon, 06 Aug 2018 16:59:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 95e5eaf00df847018b63061319e4692e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-11db1ee4-15b8-4f65-956d-15fe81ecc915
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-11db1ee4-15b8-4f65-956d-15fe81ecc915
-      Date:
-      - Mon, 06 Aug 2018 16:59:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -5182,22 +4962,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7eec5d2c-93aa-42fb-a8d2-1e3d997dff4c
+      - req-552c214f-e9b6-4694-81e0-2d71e12a1589
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-7eec5d2c-93aa-42fb-a8d2-1e3d997dff4c
+      - req-552c214f-e9b6-4694-81e0-2d71e12a1589
       Date:
-      - Mon, 06 Aug 2018 16:59:03 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5230,7 +5010,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5245,22 +5025,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b9ed9b8-a42f-4c21-aec6-9dc702979d63
+      - req-7e483c0f-8373-46b1-bb9e-479b7e515580
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-4b9ed9b8-a42f-4c21-aec6-9dc702979d63
+      - req-7e483c0f-8373-46b1-bb9e-479b7e515580
       Date:
-      - Mon, 06 Aug 2018 16:59:04 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5301,7 +5081,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5316,22 +5096,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46bcad44-adae-4873-a302-4bde916710bb
+      - req-004caca7-2249-49cc-94ec-f76adbd3e986
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-46bcad44-adae-4873-a302-4bde916710bb
+      - req-004caca7-2249-49cc-94ec-f76adbd3e986
       Date:
-      - Mon, 06 Aug 2018 16:59:04 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5365,7 +5145,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5380,27 +5160,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96f1c6ea1b754c319f0e5f0d9c3a67bc
+      - 2dbacfcfe1134007a67457b4aa442c57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-913e1a7d-a4a8-40e4-876d-b1d7c6b2de68
+      - req-3c178b5d-6a2f-43fb-99aa-a9f7ebda66f3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-913e1a7d-a4a8-40e4-876d-b1d7c6b2de68
+      - req-3c178b5d-6a2f-43fb-99aa-a9f7ebda66f3
       Date:
-      - Mon, 06 Aug 2018 16:59:04 GMT
+      - Mon, 24 Sep 2018 20:29:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5418,13 +5198,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:05 GMT
+      - Mon, 24 Sep 2018 20:29:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-70ee66a7-13ce-4e33-bb63-c6ecd372bf84
+      - req-da38f81c-5bf4-4701-b69c-7e958e82145e
       Content-Length:
       - '4170'
       Connection:
@@ -5433,10 +5213,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:05.912611", "expires":
-        "2018-08-06T17:59:05Z", "id": "05ea1c5ee3fd4982880ce1af52f8e708", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:32.774062", "expires":
+        "2018-09-24T21:29:32Z", "id": "bda20edaa5f34d48b5da89337a3dcea2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HvQr3QeMTgSpxXYLW_Xwlw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DON2vs1uQGudF3hijEr7NQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5481,7 +5261,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5499,13 +5279,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:06 GMT
+      - Mon, 24 Sep 2018 20:29:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d35beef9-1bb4-4aa0-b786-3b4ef5973214
+      - req-1780be74-7519-49c2-ab18-0e44a1e4ed82
       Content-Length:
       - '4170'
       Connection:
@@ -5514,10 +5294,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:06.209749", "expires":
-        "2018-08-06T17:59:06Z", "id": "d88b45aa6a6545f2ba07d009de85ad0a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:32.962714", "expires":
+        "2018-09-24T21:29:32Z", "id": "a2e9b72b92a443f4b4541c478ba2e127", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["-yGtszqXRXuxfCsel5AhWg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tbWhAvAvQD6jUc0riqLwGw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5562,7 +5342,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5577,7 +5357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -5588,9 +5368,9 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-dbceb32f-4c7d-4934-a100-5d894216f5cf
+      - req-2ad2841e-c4bc-46c9-858c-85865fa917ff
       Date:
-      - Mon, 06 Aug 2018 16:59:06 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
@@ -5598,7 +5378,17 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -5643,24 +5433,14 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        98}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5678,13 +5458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:06 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2750b74a-d301-43c5-a17b-2a20d92fec50
+      - req-2a5eb517-173e-4883-b1fc-384b639cb558
       Content-Length:
       - '4170'
       Connection:
@@ -5693,10 +5473,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:06.958661", "expires":
-        "2018-08-06T17:59:06Z", "id": "99e22869e52a463b88b8ad2ada2a135c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:33.382836", "expires":
+        "2018-09-24T21:29:33Z", "id": "73c3553bc7c9423ab6ece9f3458151fa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HCXjm0e8Q8ymPkYsNEcRDA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["yJkH8MCTS7ym-8ubc-9qQA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5741,7 +5521,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5759,13 +5539,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:07 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-93cca87a-5cdf-4f2e-b8c3-9e4bd0c85947
+      - req-b9eee5c1-e9d2-4b55-996b-2b343ddfd32e
       Content-Length:
       - '370'
       Connection:
@@ -5774,13 +5554,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:07.176896", "expires":
-        "2018-08-06T17:59:07Z", "id": "aabfcda393194d40bdaef290f2cf7a57", "audit_ids":
-        ["6lvZIaEASG6YMzuT0tlTHw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:33.532505", "expires":
+        "2018-09-24T21:29:33Z", "id": "049ce584da2047209acb51dae18dbfeb", "audit_ids":
+        ["6ldQX1loTKSKDsUshcCGgA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5795,20 +5575,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aabfcda393194d40bdaef290f2cf7a57
+      - '049ce584da2047209acb51dae18dbfeb'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:07 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a9c3761d-7b1d-4eb7-8b7f-7d54b64b0e75
+      - req-10f3865c-368a-46ca-8fe6-f52b2d250937
       Content-Length:
       - '500'
       Connection:
@@ -5825,13 +5605,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"aabfcda393194d40bdaef290f2cf7a57"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"049ce584da2047209acb51dae18dbfeb"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5843,13 +5623,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:07 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c87fc29f-6f85-4ad8-816a-b3c86c2feb12
+      - req-246f5d11-68d4-46cb-a3d6-d11404c1cb6e
       Content-Length:
       - '4143'
       Connection:
@@ -5858,11 +5638,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:07.626019", "expires":
-        "2018-08-06T17:59:07Z", "id": "8b695835c438498b85a4e8c5da2e15a0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:33.824807", "expires":
+        "2018-09-24T21:29:33Z", "id": "ff0302c0bb724a45872f26c5e0472693", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YhzDYicFSkGzH3xNSWXR3w",
-        "6lvZIaEASG6YMzuT0tlTHw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["u6qYXOjMS1ODQOj4qeHWkA",
+        "6ldQX1loTKSKDsUshcCGgA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -5906,7 +5686,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -5921,20 +5701,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aabfcda393194d40bdaef290f2cf7a57
+      - '049ce584da2047209acb51dae18dbfeb'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:07 GMT
+      - Mon, 24 Sep 2018 20:29:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-67ba66de-55df-4a4e-a297-d83180bf6518
+      - req-bd19d78b-6840-4efa-9349-f3a0c63b916f
       Content-Length:
       - '500'
       Connection:
@@ -5951,7 +5731,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5969,13 +5749,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:07 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86ac1d73-a0c0-46db-9832-1e649d2c8442
+      - req-cef957d1-1a73-4aeb-8f17-473ebdbcf230
       Content-Length:
       - '4117'
       Connection:
@@ -5984,10 +5764,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.120802", "expires":
-        "2018-08-06T17:59:08Z", "id": "b52e0fa29a63447fb953a79df4eeeeb8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:34.136422", "expires":
+        "2018-09-24T21:29:34Z", "id": "4b8e42516b904d84a36fd5eb49db3596", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wJ0MGL_pTc-RgUmEVXGihg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7zHJX3ooThKR8lYn_Y2MfA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6031,7 +5811,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6049,13 +5829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:08 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f32424e3-485a-49c8-95fd-bdf207967cf3
+      - req-00d2b7e2-d135-4511-b74a-9626289c25eb
       Content-Length:
       - '4131'
       Connection:
@@ -6064,10 +5844,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.400015", "expires":
-        "2018-08-06T17:59:08Z", "id": "2b9f6b5374844cf78a125ef661fdd920", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:34.311736", "expires":
+        "2018-09-24T21:29:34Z", "id": "90d9b3142c644a4b8a7704df1c726732", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CTNHElIaStaJMe8_ytwUTA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["m7yc6aWrRSuHgF5cEiIzUw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6111,7 +5891,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6129,13 +5909,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:08 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4a09be9d-fa82-4f1d-8036-3a974a99e22e
+      - req-81d413c7-173a-4ae2-97f1-277385c54d02
       Content-Length:
       - '4118'
       Connection:
@@ -6144,10 +5924,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:08.829533", "expires":
-        "2018-08-06T17:59:08Z", "id": "4d3c4ed36d044774a54710c7ea5325da", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:34.495938", "expires":
+        "2018-09-24T21:29:34Z", "id": "80680808a4fb460196df7ff950f5a6f7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["54_4E5OqQMiQX4KFJaJ-_g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["cj4wkLkGR_aKbA3rtHnBrQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6191,7 +5971,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6209,13 +5989,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:08 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-856e1f58-5d59-47f9-aae2-28a4dc8e1ba5
+      - req-0917d2c6-ce88-40c9-aaea-19bb07435299
       Content-Length:
       - '4117'
       Connection:
@@ -6224,10 +6004,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:09.060886", "expires":
-        "2018-08-06T17:59:09Z", "id": "b8f8e61a54d04baf8d56bcb75a06acf4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:34.675324", "expires":
+        "2018-09-24T21:29:34Z", "id": "ecc1ff765f7b43e1a176a6ba06e7ff4a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["d9HTSY4vRkaW9vmedAvJAg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TOTOWiVPSWucvQhCwf_SEA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6271,7 +6051,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6286,7 +6066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6297,9 +6077,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-fd770d44-3d66-4acd-b830-b9196ac601aa
+      - req-80e8c260-ae8d-4c4e-8afb-661cbfc3ae10
       Date:
-      - Mon, 06 Aug 2018 16:59:09 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6333,7 +6113,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6348,7 +6128,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6359,14 +6139,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cf325328-8db8-4bbf-a7b2-a3367a56a8d8
+      - req-3b78a0f2-3e2d-4f5d-8bb8-e30aac3f5f93
       Date:
-      - Mon, 06 Aug 2018 16:59:09 GMT
+      - Mon, 24 Sep 2018 20:29:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6384,13 +6164,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:09 GMT
+      - Mon, 24 Sep 2018 20:29:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06e124c3-00ab-4ae9-b237-46c2ff016a1d
+      - req-0ea898cc-904e-4390-a2ce-ae9009abf322
       Content-Length:
       - '4131'
       Connection:
@@ -6399,10 +6179,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:09.604954", "expires":
-        "2018-08-06T17:59:09Z", "id": "b36a8fdb3fc548569bda57e164ea3d7d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:35.143633", "expires":
+        "2018-09-24T21:29:35Z", "id": "695d840e017b420086e254ba8eb66609", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jjS6mdYzSnCopwC4widLoQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sivLbwRdTRS4EnezzBVNtA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6446,7 +6226,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6461,7 +6241,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b36a8fdb3fc548569bda57e164ea3d7d
+      - 695d840e017b420086e254ba8eb66609
   response:
     status:
       code: 200
@@ -6472,14 +6252,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b0f29f1c-c70d-4cec-a587-4e1f3e8b3442
+      - req-2999e5dc-f7d1-47f8-952c-37fdbf491ce9
       Date:
-      - Mon, 06 Aug 2018 16:59:09 GMT
+      - Mon, 24 Sep 2018 20:29:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6494,7 +6274,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99e22869e52a463b88b8ad2ada2a135c
+      - 73c3553bc7c9423ab6ece9f3458151fa
   response:
     status:
       code: 200
@@ -6505,14 +6285,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c533be79-d372-4155-bf05-a01e0c6335b1
+      - req-54f47c06-7d5c-4f6e-9cc0-af612ef0f7c6
       Date:
-      - Mon, 06 Aug 2018 16:59:10 GMT
+      - Mon, 24 Sep 2018 20:29:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6530,13 +6310,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:10 GMT
+      - Mon, 24 Sep 2018 20:29:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d827df86-a25c-4337-a59c-6358726a3c2e
+      - req-2e61bde2-a1f9-4424-b7b8-85a12daae3c1
       Content-Length:
       - '4118'
       Connection:
@@ -6545,10 +6325,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:10.257641", "expires":
-        "2018-08-06T17:59:10Z", "id": "f57be5a86efb4599882eed22efcb34ca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:35.665045", "expires":
+        "2018-09-24T21:29:35Z", "id": "bb0ec0f843c744ebbe6ae67eaa3240f0", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xnTEXAR9RgKYbrpLUCN91w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rv30nXcXTR2GDXhnB5MCSA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6592,7 +6372,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6607,7 +6387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f57be5a86efb4599882eed22efcb34ca
+      - bb0ec0f843c744ebbe6ae67eaa3240f0
   response:
     status:
       code: 200
@@ -6618,14 +6398,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-93009c5e-b294-4e3b-ac0f-9457d14ac6a3
+      - req-a89bb4d4-9a27-4b65-a7fd-dfb62fc18ceb
       Date:
-      - Mon, 06 Aug 2018 16:59:10 GMT
+      - Mon, 24 Sep 2018 20:29:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6640,7 +6420,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6651,9 +6431,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-4b6c1c9a-a38f-4978-b9f9-3f073df38856
+      - req-3f4f9675-30be-4a96-b92b-db86c791216e
       Date:
-      - Mon, 06 Aug 2018 16:59:11 GMT
+      - Mon, 24 Sep 2018 20:29:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6680,7 +6460,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6695,7 +6475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6706,9 +6486,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-73a7d2ec-8530-46e0-80d7-04c76cfc3a4a
+      - req-ab5b80fb-6f0e-4cbc-b75f-e2ff4c559f3c
       Date:
-      - Mon, 06 Aug 2018 16:59:13 GMT
+      - Mon, 24 Sep 2018 20:29:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6735,7 +6515,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6750,7 +6530,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6761,9 +6541,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fbd10a2c-f20b-4f6e-99fa-c0910179874c
+      - req-704af571-a926-450a-8a5f-4c82f3389c18
       Date:
-      - Mon, 06 Aug 2018 16:59:14 GMT
+      - Mon, 24 Sep 2018 20:29:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6790,7 +6570,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -6805,7 +6585,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6816,9 +6596,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ccfeecc6-bbcc-476d-acab-62abf73e3567
+      - req-b6dcb3e7-d865-4bf9-8ff6-1b9d9e8bc7cd
       Date:
-      - Mon, 06 Aug 2018 16:59:14 GMT
+      - Mon, 24 Sep 2018 20:29:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6830,7 +6610,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -6845,7 +6625,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6856,9 +6636,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-cd257390-e97b-44a2-a446-b447e34b912c
+      - req-ddf11add-bcff-4ec6-92c2-1de68372173f
       Date:
-      - Mon, 06 Aug 2018 16:59:14 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6870,7 +6650,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -6885,7 +6665,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8f8e61a54d04baf8d56bcb75a06acf4
+      - ecc1ff765f7b43e1a176a6ba06e7ff4a
   response:
     status:
       code: 200
@@ -6896,9 +6676,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-58eaec86-2003-425c-be5c-a02ab3f49c44
+      - req-2d18413f-4c9a-44d0-8730-be3fe7da77ca
       Date:
-      - Mon, 06 Aug 2018 16:59:14 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6910,7 +6690,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -6925,7 +6705,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -6936,9 +6716,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-05e645b3-28b9-4886-b07b-1b9925cd2d8f
+      - req-9eed03ba-4017-4f3a-b654-d8a2a1d7157b
       Date:
-      - Mon, 06 Aug 2018 16:59:15 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -7042,7 +6822,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7057,7 +6837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -7068,28 +6848,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c5638a6a-d0f8-4626-a94d-ae3166d70386
+      - req-499f21b4-2780-42ed-838c-8d51bcf28ba8
       Date:
-      - Mon, 06 Aug 2018 16:59:15 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -7102,79 +6907,55 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -7189,7 +6970,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -7200,9 +6981,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1781f3dc-52e7-4709-80f8-02ac3c82651d
+      - req-fe2bba0a-a153-46e9-94ac-351457f3b845
       Date:
-      - Mon, 06 Aug 2018 16:59:15 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7244,7 +7025,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -7259,7 +7040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -7270,9 +7051,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-579c4440-4546-4d33-8406-e902d8a0be41
+      - req-49be1f7a-c820-47e8-a60b-987fdb745888
       Date:
-      - Mon, 06 Aug 2018 16:59:15 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -7314,7 +7095,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -7329,7 +7110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -7340,9 +7121,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7864e2db-d530-4eb8-b1c7-2a2880d9d058
+      - req-1117a792-532e-4620-a0b1-8ce7570e0ad6
       Date:
-      - Mon, 06 Aug 2018 16:59:15 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7745,7 +7526,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -7760,7 +7541,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -7771,9 +7552,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5beac863-6721-426b-a595-6d789d926105
+      - req-b07f20b6-253b-454a-b940-8cdc9d04382b
       Date:
-      - Mon, 06 Aug 2018 16:59:16 GMT
+      - Mon, 24 Sep 2018 20:29:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8176,7 +7957,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8191,7 +7972,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8202,9 +7983,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d9409d0f-a41e-402b-bdde-d64fdd97470c
+      - req-029a71f5-ee1c-44bf-a131-6932b31fc48e
       Date:
-      - Mon, 06 Aug 2018 16:59:16 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8236,7 +8017,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -8251,7 +8032,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8262,9 +8043,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f3de9f74-27ac-4139-a5c0-3d782ee98750
+      - req-b8d640e5-d453-4120-9c86-9191ef9165dc
       Date:
-      - Mon, 06 Aug 2018 16:59:16 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8296,7 +8077,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -8311,7 +8092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8322,9 +8103,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-40846e1d-8375-4d70-b544-2a297ad2603c
+      - req-254d1296-cd6d-4328-887a-a40a624dad2a
       Date:
-      - Mon, 06 Aug 2018 16:59:18 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -8366,7 +8147,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -8381,7 +8162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8392,9 +8173,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-43a02090-5e05-41dd-b260-018d6a878b19
+      - req-7f030391-e430-437e-bf99-62c93145a2ae
       Date:
-      - Mon, 06 Aug 2018 16:59:18 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -8437,7 +8218,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -8452,7 +8233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8463,9 +8244,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-6e250d2e-3fa8-40b9-9a2e-f856bcf55496
+      - req-435ac057-8a3b-46d6-8d1c-00e5d2417bde
       Date:
-      - Mon, 06 Aug 2018 16:59:18 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -8500,7 +8281,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -8515,7 +8296,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d88b45aa6a6545f2ba07d009de85ad0a
+      - a2e9b72b92a443f4b4541c478ba2e127
   response:
     status:
       code: 200
@@ -8526,9 +8307,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-ad66afa1-6721-4c23-a746-51198e8e3ad7
+      - req-4248b95a-9b9d-4ea8-b3de-933bb63b7ec5
       Date:
-      - Mon, 06 Aug 2018 16:59:18 GMT
+      - Mon, 24 Sep 2018 20:29:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -8615,7 +8396,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8633,13 +8414,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:19 GMT
+      - Mon, 24 Sep 2018 20:29:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4e9bfa65-42b2-4ce4-b22c-507111905e1c
+      - req-016bd9ad-e47a-4972-be7e-259140e2c643
       Content-Length:
       - '4170'
       Connection:
@@ -8648,10 +8429,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.519386", "expires":
-        "2018-08-06T17:59:19Z", "id": "68b742dc9c1e450fb199eb9ec23ffdce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:39.651861", "expires":
+        "2018-09-24T21:29:39Z", "id": "375fd8aa90054de3a0b92325769129f6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ykZULkUJRUG_kZzabtsAxw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Dmb4GY9bQeCTNJZ7wNXn2w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8696,7 +8477,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8714,13 +8495,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:19 GMT
+      - Mon, 24 Sep 2018 20:29:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee2d54ec-8e25-4580-a023-26a045846c7f
+      - req-aec8d185-943b-43a5-b529-79c214b36e59
       Content-Length:
       - '4170'
       Connection:
@@ -8729,10 +8510,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.767325", "expires":
-        "2018-08-06T17:59:19Z", "id": "be1b0e4a3b094df8899c595fde3b3191", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:39.839940", "expires":
+        "2018-09-24T21:29:39Z", "id": "0d9f248640c44f16a54ae1c3d10d74a1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ffPYt2dXRje0GxKSyXTuqQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Q5LxYcNoRxq0u_KkxW5BZA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8777,7 +8558,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8795,13 +8576,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:19 GMT
+      - Mon, 24 Sep 2018 20:29:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-438dbed8-9fa5-4dfc-9505-39adec04e289
+      - req-f8dd9a2b-bf49-43e7-8de8-7e7b8ccd57e5
       Content-Length:
       - '370'
       Connection:
@@ -8810,13 +8591,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:19.916954", "expires":
-        "2018-08-06T17:59:19Z", "id": "19c7b0653dc54a1fb9cfc82c7098e272", "audit_ids":
-        ["ZVmiBOYtS0urU8XTrim-3w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:39.992277", "expires":
+        "2018-09-24T21:29:39Z", "id": "914e57a46c524366a2365e990021c62f", "audit_ids":
+        ["Ub9ocj9QTWKMiIngLpuTFQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8831,20 +8612,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19c7b0653dc54a1fb9cfc82c7098e272
+      - 914e57a46c524366a2365e990021c62f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:20 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d2f7ea21-769e-4ae7-82cc-d4717cfd3f60
+      - req-8ad3c27d-61c0-4cbf-83b9-87436f2ac1b5
       Content-Length:
       - '500'
       Connection:
@@ -8861,13 +8642,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"19c7b0653dc54a1fb9cfc82c7098e272"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"914e57a46c524366a2365e990021c62f"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8879,13 +8660,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:20 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-91c0b0a8-e9a4-4d3c-a7fb-e5ede13a624f
+      - req-22e8ee07-6cf0-453b-bd7c-48e8d6de9af1
       Content-Length:
       - '4143'
       Connection:
@@ -8894,11 +8675,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:20.223429", "expires":
-        "2018-08-06T17:59:19Z", "id": "8584c37590f84628a374e22d249e8307", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:40.288397", "expires":
+        "2018-09-24T21:29:39Z", "id": "f05c676b09ba46dea8d988a9e7680ff5", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5ajzjj_vQBqfuMGjPFaHvw",
-        "ZVmiBOYtS0urU8XTrim-3w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["pSJDmDK2S_-rNq3AzchZfA",
+        "Ub9ocj9QTWKMiIngLpuTFQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8942,7 +8723,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8957,20 +8738,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 19c7b0653dc54a1fb9cfc82c7098e272
+      - 914e57a46c524366a2365e990021c62f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:20 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e7320054-920c-447b-8899-a84602e51ea6
+      - req-0ec6b016-83f4-457f-9ff7-a8f00bce9ac1
       Content-Length:
       - '500'
       Connection:
@@ -8987,7 +8768,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9005,13 +8786,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:20 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-545dbe38-b07b-49f1-9309-c9faab1ae392
+      - req-705619cb-875f-49c4-bea0-b548e2b4bf84
       Content-Length:
       - '4117'
       Connection:
@@ -9020,10 +8801,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:20.641306", "expires":
-        "2018-08-06T17:59:20Z", "id": "d2da814bd13c47cb9d8436089a51dd2b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:40.599903", "expires":
+        "2018-09-24T21:29:40Z", "id": "a8b6ca2e67f54b369232f815d0cbbc03", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jHrnXa4DTSG5xvHHISdKVA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8nGI6JOZQfmlkb91QjUr1A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9067,7 +8848,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9085,13 +8866,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:20 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-04d7d6e7-fc96-438e-80ad-4a490929d58f
+      - req-b9be9410-d97f-47fd-80e0-6242d9915853
       Content-Length:
       - '4131'
       Connection:
@@ -9100,10 +8881,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.020195", "expires":
-        "2018-08-06T17:59:20Z", "id": "e2de1187c0184808a29675d57710ac8f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:40.776847", "expires":
+        "2018-09-24T21:29:40Z", "id": "c9408e61e80846afb31cfd17e0d76924", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["PXy2QaNUR3-lOUCJbxNVEw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["M_YdCz4XRI6K0RbHRg-V-A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9147,7 +8928,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9165,13 +8946,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:21 GMT
+      - Mon, 24 Sep 2018 20:29:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9058a710-9e07-4c54-b516-e0bae9b8f26f
+      - req-70037144-36ac-4257-a210-a9d5a21028b5
       Content-Length:
       - '4118'
       Connection:
@@ -9180,10 +8961,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.317147", "expires":
-        "2018-08-06T17:59:21Z", "id": "061e7aaa56e942ddbb7fdb1b1531f3fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:40.957717", "expires":
+        "2018-09-24T21:29:40Z", "id": "ba9adf887a9a4335a8b48c63c34fe9bd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MN72ZUc_Q8O5z4tEDxpgEg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["RMbK22jEQ2K43Sb9vrg3jQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9227,7 +9008,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9245,13 +9026,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:21 GMT
+      - Mon, 24 Sep 2018 20:29:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-30d54df0-e1dd-4d1e-82b1-0feb6c8310a5
+      - req-f74fb757-a94e-460b-8502-82531e99dff9
       Content-Length:
       - '4117'
       Connection:
@@ -9260,10 +9041,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:21.587395", "expires":
-        "2018-08-06T17:59:21Z", "id": "5f0d46b46ad04e69903dc564100ec9a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:41.146628", "expires":
+        "2018-09-24T21:29:41Z", "id": "271e9c7de7f84444b549941a6fd4c357", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LF82K4J2RKmm6h6vkM-2KQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["eCllVoN0Rl-WofymUYaZ_A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9307,7 +9088,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -9322,22 +9103,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4301b9c6-1ed2-43e9-9185-8263d5f5088b
+      - req-58c4184b-8366-4568-b443-48e1edf48ba5
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-4301b9c6-1ed2-43e9-9185-8263d5f5088b
+      - req-58c4184b-8366-4568-b443-48e1edf48ba5
       Date:
-      - Mon, 06 Aug 2018 16:59:22 GMT
+      - Mon, 24 Sep 2018 20:29:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -9370,7 +9151,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -9385,22 +9166,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-62e652d2-ab56-4aca-9641-2bb06704b66c
+      - req-b56a698a-b63b-40fe-9c7d-8f8c67832c38
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-62e652d2-ab56-4aca-9641-2bb06704b66c
+      - req-b56a698a-b63b-40fe-9c7d-8f8c67832c38
       Date:
-      - Mon, 06 Aug 2018 16:59:22 GMT
+      - Mon, 24 Sep 2018 20:29:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -9441,7 +9222,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -9456,22 +9237,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-76c99b70-1eab-4b30-b959-b504432956f7
+      - req-6bc0ad84-7f72-4453-89b8-5f70bac14d7c
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-76c99b70-1eab-4b30-b959-b504432956f7
+      - req-6bc0ad84-7f72-4453-89b8-5f70bac14d7c
       Date:
-      - Mon, 06 Aug 2018 16:59:22 GMT
+      - Mon, 24 Sep 2018 20:29:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -9505,7 +9286,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -9520,27 +9301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c345ce99-c83f-4f96-ad6b-90c5f9dcaec2
+      - req-534e4e04-b719-4d60-a649-076e5ab0df16
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c345ce99-c83f-4f96-ad6b-90c5f9dcaec2
+      - req-534e4e04-b719-4d60-a649-076e5ab0df16
       Date:
-      - Mon, 06 Aug 2018 16:59:23 GMT
+      - Mon, 24 Sep 2018 20:29:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9558,13 +9339,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:23 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5558ea28-4c00-484d-b379-c73734f5cac0
+      - req-3fc1bd71-0222-4b58-b940-0db072ccaa64
       Content-Length:
       - '4131'
       Connection:
@@ -9573,10 +9354,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:23.526106", "expires":
-        "2018-08-06T17:59:23Z", "id": "c7c4928b6d44499e8d874dbad8b15386", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:42.058157", "expires":
+        "2018-09-24T21:29:42Z", "id": "45a5d421e338426d86e61ac6659db4e8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["YufTPl9qSt6G17x1sRpgMQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ORauHaPFTSu584fYMHMGPA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9620,7 +9401,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -9635,27 +9416,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c9eede0b-edef-47ae-b78f-2a1c1cacff04
+      - req-4a1e2e93-d932-498c-a73b-3b0769fa80d8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c9eede0b-edef-47ae-b78f-2a1c1cacff04
+      - req-4a1e2e93-d932-498c-a73b-3b0769fa80d8
       Date:
-      - Mon, 06 Aug 2018 16:59:23 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -9670,27 +9451,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f9246ebd-c085-4427-b6f8-000d45d9f8bb
+      - req-18e272a8-1f09-4445-ac2b-829f1661b936
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f9246ebd-c085-4427-b6f8-000d45d9f8bb
+      - req-18e272a8-1f09-4445-ac2b-829f1661b936
       Date:
-      - Mon, 06 Aug 2018 16:59:24 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9708,13 +9489,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:24 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-92b3cc63-c0b1-43ef-a233-e209ae439544
+      - req-7ba22ee3-9655-4cc9-8235-06964bb1487f
       Content-Length:
       - '4118'
       Connection:
@@ -9723,10 +9504,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:24.754751", "expires":
-        "2018-08-06T17:59:24Z", "id": "bec5445947df455a8e17059515395e53", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:42.600290", "expires":
+        "2018-09-24T21:29:42Z", "id": "d809165fe19841bc85c39e9c38d58a38", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KbRJItYbSTmFXXCLo3zJBQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["f6WiBkC0QfieHrUSl_pmCg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9770,7 +9551,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -9785,27 +9566,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9fa47910-ff90-43d8-990b-f6e031c0d292
+      - req-93303f2e-ca36-41e3-a6cb-343b8686c864
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9fa47910-ff90-43d8-990b-f6e031c0d292
+      - req-93303f2e-ca36-41e3-a6cb-343b8686c864
       Date:
-      - Mon, 06 Aug 2018 16:59:25 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -9820,22 +9601,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c65d8a5d-42f0-4258-8963-9a5e7eebb102
+      - req-7997f40a-afd6-4e16-a736-91ebfb6327f8
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-c65d8a5d-42f0-4258-8963-9a5e7eebb102
+      - req-7997f40a-afd6-4e16-a736-91ebfb6327f8
       Date:
-      - Mon, 06 Aug 2018 16:59:25 GMT
+      - Mon, 24 Sep 2018 20:29:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9850,7 +9631,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -9865,22 +9646,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbc6c9c7-650f-41da-8a9d-c6cfc0fe0d76
+      - req-fd00f7c4-7541-4d8c-8157-17a1cad6018e
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-dbc6c9c7-650f-41da-8a9d-c6cfc0fe0d76
+      - req-fd00f7c4-7541-4d8c-8157-17a1cad6018e
       Date:
-      - Mon, 06 Aug 2018 16:59:25 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -9895,7 +9676,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -9910,27 +9691,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5012f771-29ea-4868-ab83-09d3486092ef
+      - req-7d8cd500-5c6c-493b-af31-0414ae1350cc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5012f771-29ea-4868-ab83-09d3486092ef
+      - req-7d8cd500-5c6c-493b-af31-0414ae1350cc
       Date:
-      - Mon, 06 Aug 2018 16:59:25 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -9945,27 +9726,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e845be26-9dab-43ad-bd92-7fcf7fb1af86
+      - req-6f2dac2a-3515-4d36-ac3d-693939fb9a38
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e845be26-9dab-43ad-bd92-7fcf7fb1af86
+      - req-6f2dac2a-3515-4d36-ac3d-693939fb9a38
       Date:
-      - Mon, 06 Aug 2018 16:59:25 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -9980,27 +9761,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2bc7a47-7fe1-4b16-bd04-50f7a8e344b2
+      - req-22b5798e-cb6a-4be4-846e-aa864e675861
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b2bc7a47-7fe1-4b16-bd04-50f7a8e344b2
+      - req-22b5798e-cb6a-4be4-846e-aa864e675861
       Date:
-      - Mon, 06 Aug 2018 16:59:26 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -10015,27 +9796,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-398f8111-9eae-43a5-a36c-eae81928f143
+      - req-993ca027-b109-48fb-b716-5ac41021421c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-398f8111-9eae-43a5-a36c-eae81928f143
+      - req-993ca027-b109-48fb-b716-5ac41021421c
       Date:
-      - Mon, 06 Aug 2018 16:59:26 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -10050,27 +9831,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1eb08e3d-a431-4de1-9738-32912ea6a8ed
+      - req-31240d49-a6be-4e97-949c-f618ff799b8c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1eb08e3d-a431-4de1-9738-32912ea6a8ed
+      - req-31240d49-a6be-4e97-949c-f618ff799b8c
       Date:
-      - Mon, 06 Aug 2018 16:59:26 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -10085,27 +9866,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf5df789-c985-4cdd-8475-401692a6624d
+      - req-0f92e3ae-6041-496b-98c3-d0783d6744e9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bf5df789-c985-4cdd-8475-401692a6624d
+      - req-0f92e3ae-6041-496b-98c3-d0783d6744e9
       Date:
-      - Mon, 06 Aug 2018 16:59:26 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -10120,27 +9901,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ef163e07-329c-4d87-8878-5f9e73a94637
+      - req-ebc28a81-1f03-4f33-9d28-72538a579097
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ef163e07-329c-4d87-8878-5f9e73a94637
+      - req-ebc28a81-1f03-4f33-9d28-72538a579097
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -10155,27 +9936,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ecb97b6-9236-4864-a639-1161d5828b33
+      - req-6ca57f09-7003-4124-b0eb-a6e71dcb9cbb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ecb97b6-9236-4864-a639-1161d5828b33
+      - req-6ca57f09-7003-4124-b0eb-a6e71dcb9cbb
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -10190,27 +9971,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f65a5e7-f525-474d-81a4-8d8892b7f056
+      - req-ea27dba1-3116-4d67-9245-66f9c7c78306
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0f65a5e7-f525-474d-81a4-8d8892b7f056
+      - req-ea27dba1-3116-4d67-9245-66f9c7c78306
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -10225,27 +10006,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e3a24031-234b-43c3-bb1d-f46ad4707409
+      - req-c9209843-074a-4a3d-8ffb-20cec8ab3c90
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e3a24031-234b-43c3-bb1d-f46ad4707409
+      - req-c9209843-074a-4a3d-8ffb-20cec8ab3c90
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -10260,27 +10041,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d5fbfc35-773a-497e-9c87-d28b1e7ced99
+      - req-c5045350-cca2-4d59-9ea8-5fb318c316dd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d5fbfc35-773a-497e-9c87-d28b1e7ced99
+      - req-c5045350-cca2-4d59-9ea8-5fb318c316dd
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -10295,27 +10076,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f2e783e4-486b-4b27-8e1c-30761ce133ab
+      - req-361154cf-ecaa-4529-8a6e-5b65d5620ff6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f2e783e4-486b-4b27-8e1c-30761ce133ab
+      - req-361154cf-ecaa-4529-8a6e-5b65d5620ff6
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -10330,27 +10111,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3d58a50-6510-4aac-be18-a7662385c0fd
+      - req-c83f1668-edd0-4c98-933a-2703ac591adb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b3d58a50-6510-4aac-be18-a7662385c0fd
+      - req-c83f1668-edd0-4c98-933a-2703ac591adb
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -10365,27 +10146,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e641a975-6fee-4709-809d-4af89f07cfa7
+      - req-1ed0e3f1-56d7-4036-8ad4-e2850451a3cb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e641a975-6fee-4709-809d-4af89f07cfa7
+      - req-1ed0e3f1-56d7-4036-8ad4-e2850451a3cb
       Date:
-      - Mon, 06 Aug 2018 16:59:27 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -10400,22 +10181,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d30e0c7e-0c59-41f7-be20-13ccbcf19559
+      - req-8fd63ddf-eae0-47d6-9e29-e4b68ee3e451
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d30e0c7e-0c59-41f7-be20-13ccbcf19559
+      - req-8fd63ddf-eae0-47d6-9e29-e4b68ee3e451
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10427,7 +10208,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10442,22 +10223,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f0d46b46ad04e69903dc564100ec9a1
+      - 271e9c7de7f84444b549941a6fd4c357
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1ae576ea-57d6-4336-80c9-780d546c10e7
+      - req-d95adfe4-c4fc-4d3d-b030-5e54d2077287
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1ae576ea-57d6-4336-80c9-780d546c10e7
+      - req-d95adfe4-c4fc-4d3d-b030-5e54d2077287
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10469,7 +10250,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -10484,22 +10265,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd373a9a-bdfe-4643-8183-1644d7e1459b
+      - req-bf4a5a3a-ad41-420b-b8a9-054a57e7e545
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fd373a9a-bdfe-4643-8183-1644d7e1459b
+      - req-bf4a5a3a-ad41-420b-b8a9-054a57e7e545
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10511,7 +10292,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10526,22 +10307,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7c4928b6d44499e8d874dbad8b15386
+      - 45a5d421e338426d86e61ac6659db4e8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f48eeed2-27b3-4979-bee4-4cc8f9840efe
+      - req-9214a455-1f31-469a-bfb2-d257960a566f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f48eeed2-27b3-4979-bee4-4cc8f9840efe
+      - req-9214a455-1f31-469a-bfb2-d257960a566f
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10553,7 +10334,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -10568,22 +10349,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ce621c95-198d-4b11-a33e-bced0ecae254
+      - req-3e7495b2-686e-40e2-baf9-b8be94976b52
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ce621c95-198d-4b11-a33e-bced0ecae254
+      - req-3e7495b2-686e-40e2-baf9-b8be94976b52
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10595,7 +10376,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10610,22 +10391,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be1b0e4a3b094df8899c595fde3b3191
+      - 0d9f248640c44f16a54ae1c3d10d74a1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5eb2659a-61d1-4a17-8ec6-7d2e18ebaee8
+      - req-ab24c109-7b82-43f4-b9e1-5971f95e57e4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5eb2659a-61d1-4a17-8ec6-7d2e18ebaee8
+      - req-ab24c109-7b82-43f4-b9e1-5971f95e57e4
       Date:
-      - Mon, 06 Aug 2018 16:59:28 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10637,7 +10418,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -10652,22 +10433,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8f1afd8-c9b9-44ca-b55b-dda3961662a7
+      - req-5fe58314-2157-4126-a312-f655d67f5fd0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b8f1afd8-c9b9-44ca-b55b-dda3961662a7
+      - req-5fe58314-2157-4126-a312-f655d67f5fd0
       Date:
-      - Mon, 06 Aug 2018 16:59:29 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10679,7 +10460,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -10694,22 +10475,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bec5445947df455a8e17059515395e53
+      - d809165fe19841bc85c39e9c38d58a38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f1efd27c-de4c-429f-8220-56514b2a40a7
+      - req-84711c3a-0729-4f70-8642-c5ac525a6753
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f1efd27c-de4c-429f-8220-56514b2a40a7
+      - req-84711c3a-0729-4f70-8642-c5ac525a6753
       Date:
-      - Mon, 06 Aug 2018 16:59:29 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -10721,7 +10502,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10739,13 +10520,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:29 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e7e6b45e-9382-4ca1-9935-1b0c5693b8a5
+      - req-95ab8624-08cd-4217-87dc-ac3f9cf0aecc
       Content-Length:
       - '4170'
       Connection:
@@ -10754,10 +10535,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:29.580676", "expires":
-        "2018-08-06T17:59:29Z", "id": "3a61c4d7b6f74774a0d2ad933e1c6435", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:45.543173", "expires":
+        "2018-09-24T21:29:45Z", "id": "65e8773705a34aceba256a24eaf2749d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["FVSdFB0LQFG0tpAbWFrKxw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["d6k8IZnwRdm3KhV_59p2iw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10802,7 +10583,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10820,13 +10601,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:29 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-753614ef-fd42-48b9-be80-b820f53d2ee1
+      - req-720d34d1-ac72-42d2-bfc0-61a4094f607d
       Content-Length:
       - '4170'
       Connection:
@@ -10835,10 +10616,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:29.896937", "expires":
-        "2018-08-06T17:59:29Z", "id": "5748222f76a742bf9150654229b08b2d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:45.733970", "expires":
+        "2018-09-24T21:29:45Z", "id": "e77e63b5d8d74582aa05b28abf596319", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["LQtXciQZQW23W35IseCs5Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EQhArWTGQuuPNKDqbDv2ig"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -10883,7 +10664,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -10901,13 +10682,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:30 GMT
+      - Mon, 24 Sep 2018 20:29:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ad5cb464-5dba-42e3-9020-375ddfac2e66
+      - req-9df4e59c-7128-4513-b359-480ac296d0dc
       Content-Length:
       - '370'
       Connection:
@@ -10916,13 +10697,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:30.089513", "expires":
-        "2018-08-06T17:59:30Z", "id": "1bc2e95a2abf4cf5a354fa2f41f184ac", "audit_ids":
-        ["fhIFJA40SDaJzOAyaaJL4Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:45.886325", "expires":
+        "2018-09-24T21:29:45Z", "id": "70af7cae240548cab3d07c0f0932bbb5", "audit_ids":
+        ["9jm0we1oSVW8iT_8NIfTYA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:45 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -10937,20 +10718,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bc2e95a2abf4cf5a354fa2f41f184ac
+      - 70af7cae240548cab3d07c0f0932bbb5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:30 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e395ab02-bb10-4df8-936a-939118fbc315
+      - req-ccdc5ba1-2c5d-430b-a8ee-2c3dfabcb03d
       Content-Length:
       - '500'
       Connection:
@@ -10967,13 +10748,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"1bc2e95a2abf4cf5a354fa2f41f184ac"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"70af7cae240548cab3d07c0f0932bbb5"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10985,13 +10766,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:30 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-db6acb8d-bf71-493d-97cc-22575807f2f1
+      - req-957c6968-8490-46e1-aff4-57889631ed39
       Content-Length:
       - '4143'
       Connection:
@@ -11000,11 +10781,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:30.561806", "expires":
-        "2018-08-06T17:59:30Z", "id": "c5a93a05339a46978a244b0e9571c75f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:46.192147", "expires":
+        "2018-09-24T21:29:45Z", "id": "66c19643213148f9aef8c1bfdc2fa856", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YqZek5xyRxygtja9Yvx-vQ",
-        "fhIFJA40SDaJzOAyaaJL4Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5oYFJhOoSHOkPvThl0p8ng",
+        "9jm0we1oSVW8iT_8NIfTYA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11048,7 +10829,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -11063,20 +10844,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bc2e95a2abf4cf5a354fa2f41f184ac
+      - 70af7cae240548cab3d07c0f0932bbb5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:30 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a08017d1-d686-44ce-8b38-845626c80c67
+      - req-6d359695-aa92-4131-a6ca-a4f96ea94b33
       Content-Length:
       - '500'
       Connection:
@@ -11093,7 +10874,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11111,13 +10892,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:30 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cbd5973a-8dbd-4ea1-a5eb-552e4e71dbd8
+      - req-cc5772cf-a6a0-488a-8fa1-4344ed9c91e5
       Content-Length:
       - '4117'
       Connection:
@@ -11126,10 +10907,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.231944", "expires":
-        "2018-08-06T17:59:31Z", "id": "63528c43735f4c589a3e70a98f6541e7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:46.507405", "expires":
+        "2018-09-24T21:29:46Z", "id": "7490500fd96c4521afce059e00c5279b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["CgTO8Y4CQk-cUD3tGGxHAA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0PZsNciPSEmTAF_HfGS-mA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11173,7 +10954,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11191,13 +10972,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:31 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f5b10ea4-3780-4443-9989-0aadde0f2469
+      - req-c9342a38-c7b9-492e-a539-e6e53b7a840a
       Content-Length:
       - '4131'
       Connection:
@@ -11206,10 +10987,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.555502", "expires":
-        "2018-08-06T17:59:31Z", "id": "fa8ab7986f6844c297d1c2e2b73b3539", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:46.699709", "expires":
+        "2018-09-24T21:29:46Z", "id": "238d6ce87d7f4532be6a3f478f7fd09d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dQqIMiOoQziN_C_1YCqOxg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1Aa0dDNCQaGDiUEnaF0dTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11253,7 +11034,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11271,13 +11052,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:31 GMT
+      - Mon, 24 Sep 2018 20:29:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dd18a0c6-e290-4366-bdd8-64d41221d440
+      - req-260c08fd-a377-4690-b29c-c765da7db142
       Content-Length:
       - '4118'
       Connection:
@@ -11286,10 +11067,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:31.862409", "expires":
-        "2018-08-06T17:59:31Z", "id": "c86dd302cb8845bbac3f0684152e4d89", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:46.882075", "expires":
+        "2018-09-24T21:29:46Z", "id": "a982570b907d495198821bab61819c17", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NoogcbC_Tk-T3oGgW2kREg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3omsi0fpRlG6eI1ZA5xRWQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11333,7 +11114,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11351,13 +11132,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:31 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-283ccace-faf0-402f-a09c-b07cc6950acd
+      - req-8e761bb7-d885-42e2-bd1d-b4f9f52019f6
       Content-Length:
       - '4117'
       Connection:
@@ -11366,10 +11147,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:32.160678", "expires":
-        "2018-08-06T17:59:32Z", "id": "76f8237daac748dc9cb8c9d27b7b67b3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:47.065402", "expires":
+        "2018-09-24T21:29:47Z", "id": "2f07b72040d147c78251a45a84a469d1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["SkdWdT86TueNkWOcpkwtcg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EHbhx9oOTJC8V-OA-4TpKg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -11413,7 +11194,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -11428,7 +11209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76f8237daac748dc9cb8c9d27b7b67b3
+      - 2f07b72040d147c78251a45a84a469d1
   response:
     status:
       code: 200
@@ -11457,15 +11238,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx9643b989eac64731b10d6-005b687e74
+      - tx90c8471092ce4be0a4b17-005ba9493b
       Date:
-      - Mon, 06 Aug 2018 16:59:32 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -11480,7 +11261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76f8237daac748dc9cb8c9d27b7b67b3
+      - 2f07b72040d147c78251a45a84a469d1
   response:
     status:
       code: 200
@@ -11509,14 +11290,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx6dc66264a7eb4cb4be8b2-005b687e74
+      - tx2d7ceaeb9dbf42a99ad2d-005ba9493b
       Date:
-      - Mon, 06 Aug 2018 16:59:32 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11534,13 +11315,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:32 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e298d04-c7a5-40ef-b845-2a3075c92857
+      - req-c3634ea9-7de7-4984-9525-eabb1f588954
       Content-Length:
       - '4131'
       Connection:
@@ -11549,10 +11330,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:33.292117", "expires":
-        "2018-08-06T17:59:33Z", "id": "bfbc6b562b5b48bc99ec85e9ac03a374", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:47.519498", "expires":
+        "2018-09-24T21:29:47Z", "id": "134d2282503243598db0202eb9ff6b7f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0YnI4vF_S-WRr9NoGitb8Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["c4EgUrqBQTChn-oy9OqrmQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -11596,7 +11377,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -11611,7 +11392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bfbc6b562b5b48bc99ec85e9ac03a374
+      - 134d2282503243598db0202eb9ff6b7f
   response:
     status:
       code: 200
@@ -11624,22 +11405,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574773.62254'
+      - '1537820987.68514'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574773.62254'
+      - '1537820987.68514'
       X-Trans-Id:
-      - txb56db25c175b4c588b6de-005b687e75
+      - tx1e596ffe00914f049c859-005ba9493b
       Date:
-      - Mon, 06 Aug 2018 16:59:33 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -11654,7 +11435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5748222f76a742bf9150654229b08b2d
+      - e77e63b5d8d74582aa05b28abf596319
   response:
     status:
       code: 200
@@ -11667,22 +11448,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574773.91746'
+      - '1537820987.83499'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574773.91746'
+      - '1537820987.83499'
       X-Trans-Id:
-      - tx50080720bb4d4c599567e-005b687e75
+      - tx6504ed1184ee49a4a4bbe-005ba9493b
       Date:
-      - Mon, 06 Aug 2018 16:59:33 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -11700,13 +11481,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:34 GMT
+      - Mon, 24 Sep 2018 20:29:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b82742e4-cd6e-4a9d-b838-0e76e035f813
+      - req-43d0d939-0378-488a-a2cd-cfb95d4b0646
       Content-Length:
       - '4118'
       Connection:
@@ -11715,10 +11496,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:34.170978", "expires":
-        "2018-08-06T17:59:34Z", "id": "29c4288d22c6477d8606395d7168e29b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:48.010785", "expires":
+        "2018-09-24T21:29:47Z", "id": "5ed9b3e895094c209f7597c2fed6098e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DMZ5PglkRgOUnO6gwWSC6Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["8iD4q3OVQOaqu4z8MMy75A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -11762,7 +11543,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -11777,7 +11558,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 29c4288d22c6477d8606395d7168e29b
+      - 5ed9b3e895094c209f7597c2fed6098e
   response:
     status:
       code: 200
@@ -11790,22 +11571,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574774.48208'
+      - '1537820988.17243'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574774.48208'
+      - '1537820988.17243'
       X-Trans-Id:
-      - txae0ccf6d94084d878d830-005b687e76
+      - tx201bdb92150d444e9305b-005ba9493c
       Date:
-      - Mon, 06 Aug 2018 16:59:34 GMT
+      - Mon, 24 Sep 2018 20:29:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -11820,7 +11601,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76f8237daac748dc9cb8c9d27b7b67b3
+      - 2f07b72040d147c78251a45a84a469d1
   response:
     status:
       code: 200
@@ -11841,9 +11622,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx266458fd1be741b6bf80b-005b687e76
+      - tx983bd8d474f5439588126-005ba9493c
       Date:
-      - Mon, 06 Aug 2018 16:59:34 GMT
+      - Mon, 24 Sep 2018 20:29:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -11853,7 +11634,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -11868,7 +11649,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76f8237daac748dc9cb8c9d27b7b67b3
+      - 2f07b72040d147c78251a45a84a469d1
   response:
     status:
       code: 200
@@ -11889,14 +11670,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx8bd1b193b4b1456186b0c-005b687e76
+      - txbe1b5e88ca36494c9dd62-005ba9493c
       Date:
-      - Mon, 06 Aug 2018 16:59:34 GMT
+      - Mon, 24 Sep 2018 20:29:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -11911,7 +11692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 76f8237daac748dc9cb8c9d27b7b67b3
+      - 2f07b72040d147c78251a45a84a469d1
   response:
     status:
       code: 200
@@ -11932,12 +11713,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1cb9c4f3c1fa434494a5a-005b687e76
+      - txaa85c818386a4fb3a6a18-005ba9493c
       Date:
-      - Mon, 06 Aug 2018 16:59:34 GMT
+      - Mon, 24 Sep 2018 20:29:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:38 GMT
+      - Mon, 24 Sep 2018 20:31:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d07290e-74fc-4125-9896-97a0cce49a42
+      - req-dcf93603-d475-4066-b44b-a3a02968ec57
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:38.589467Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:22.424433Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h-O1Nd7XRwSIUswx3BAs7A"],
-        "issued_at": "2018-08-06T16:52:38.589550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HQbLoAhnRvqbsBTw-gY1FA"],
+        "issued_at": "2018-09-24T20:31:22.424453Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:38 GMT
+      - Mon, 24 Sep 2018 20:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-fb672a8d-2084-41a9-ade9-76b8755d543f
+      - req-8e2ef338-6ad4-4552-ae6e-b351d00bdf80
       Date:
-      - Mon, 06 Aug 2018 16:52:38 GMT
+      - Mon, 24 Sep 2018 20:31:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:39 GMT
+      - Mon, 24 Sep 2018 20:31:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b2f75fbb-606d-4372-8582-8410620157ea
+      - req-7c7bb1c3-86db-435d-ae39-27aa4360ce53
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:39.286345Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:22.876741Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIDlV7bER0yyZIl10S-LJg"],
-        "issued_at": "2018-08-06T16:52:39.286412Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZbNeY8g9TfyBwrN46dOndA"],
+        "issued_at": "2018-09-24T20:31:22.876760Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-15bbc64f-b0ad-4382-96af-61ef4970a63b
+      - req-36c19562-4e02-4df4-a418-badb34ab1648
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-15bbc64f-b0ad-4382-96af-61ef4970a63b
+      - req-36c19562-4e02-4df4-a418-badb34ab1648
       Date:
-      - Mon, 06 Aug 2018 16:52:39 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +364,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:39 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c8f530ab110446e093f91a8bf1479483
+      - 30c7bd166294429d8817141a0ad1c623
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb43493f-95d4-4d3a-b15d-ebc1f77f7776
+      - req-22ae701d-acb2-4430-ab6e-98e70435fbb5
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +381,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:39.735964Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:31:23.344578Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fr_uUYXIShWj4W3M5GqfCA"],
-        "issued_at": "2018-08-06T16:52:39.736062Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7ExMyXB0R0GTI_Rl9hoQHA"],
+        "issued_at": "2018-09-24T20:31:23.344598Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -401,20 +401,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c8f530ab110446e093f91a8bf1479483
+      - 30c7bd166294429d8817141a0ad1c623
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:39 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e007cad8-3988-4626-82fb-d05accaeeed5
+      - req-9f41222c-cdcb-4982-9a5b-894e9a3c88c7
       Content-Length:
       - '2457'
       Connection:
@@ -447,13 +447,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"c8f530ab110446e093f91a8bf1479483"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"30c7bd166294429d8817141a0ad1c623"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -465,15 +465,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:40 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a80481f2ddef491b88f7655e54259581
+      - cddb21d450284d37b70d23c61a2e6b69
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da1cc156-4549-4a0c-9acc-132131c48361
+      - req-7eb67f8b-eb48-42f3-a7fe-9b58dc729f61
       Content-Length:
       - '7313'
       Connection:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:39.735964Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:23.344578Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +564,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xlSadgQyQtqW0_JK_SDCdw",
-        "fr_uUYXIShWj4W3M5GqfCA"], "issued_at": "2018-08-06T16:52:40.185016Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p62LqTInQTqjkJkumvxbjw",
+        "7ExMyXB0R0GTI_Rl9hoQHA"], "issued_at": "2018-09-24T20:31:23.657968Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -582,20 +582,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a80481f2ddef491b88f7655e54259581
+      - cddb21d450284d37b70d23c61a2e6b69
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:40 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bed535d6-eaf4-4f13-813b-41e55cfca355
+      - req-024771a9-1796-46fc-9cf5-e6a4c92cc9dd
       Content-Length:
       - '2179'
       Connection:
@@ -628,7 +628,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -646,15 +646,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:40 GMT
+      - Mon, 24 Sep 2018 20:31:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ecdcb143-d1c1-4144-80b0-ae549111e99e
+      - req-a11b2178-8d05-4224-999e-7da36064253a
       Content-Length:
       - '7278'
       Connection:
@@ -666,7 +666,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:40.767860Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:23.956634Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -745,10 +745,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L3y3ssfvQ32RFO4JaggdeA"],
-        "issued_at": "2018-08-06T16:52:40.767942Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-lxUNWg3TKyUzjBuuP16fg"],
+        "issued_at": "2018-09-24T20:31:23.956652Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:40 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -801,15 +801,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:40 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dfbb0c31-fcc6-49df-999b-e5d5e4cd60d5
+      - req-19727ed0-692d-4eac-a59d-2025dfa97e81
       Content-Length:
       - '7278'
       Connection:
@@ -821,7 +821,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:41.184434Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:24.226917Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -900,10 +900,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["89HDEpJkST2OV_rFJbB04w"],
-        "issued_at": "2018-08-06T16:52:41.184523Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["n22DDME1QI-zMMS-jNDHzQ"],
+        "issued_at": "2018-09-24T20:31:24.226937Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -918,7 +918,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
   response:
     status:
       code: 200
@@ -929,7 +929,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:41 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -938,7 +938,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -956,15 +956,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:41 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-31b5a559-8352-4482-a4e6-054ae7517a9b
+      - req-f7c16775-9755-4216-87fd-7d37b9a1112d
       Content-Length:
       - '7264'
       Connection:
@@ -976,7 +976,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:41.602988Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:24.514066Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1055,10 +1055,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LNYmP48kR82cleIMmIAcJg"],
-        "issued_at": "2018-08-06T16:52:41.603090Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CInZAO9lTC2Ic2-OuBpk6g"],
+        "issued_at": "2018-09-24T20:31:24.514088Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
   response:
     status:
       code: 200
@@ -1084,7 +1084,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:41 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1093,7 +1093,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1111,15 +1111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:42 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3a424a15-4d95-4713-9ba5-142a29df2bdc
+      - req-f94f8412-baea-48eb-9a22-d6c4ead5ba5d
       Content-Length:
       - '7278'
       Connection:
@@ -1131,7 +1131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:42.275227Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:24.787885Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1210,10 +1210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["I3PV587YR-SmY53Q8D0A8w"],
-        "issued_at": "2018-08-06T16:52:42.275298Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DLJRv6CRReaQNvf6t1Ur1A"],
+        "issued_at": "2018-09-24T20:31:24.787905Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1228,7 +1228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
   response:
     status:
       code: 200
@@ -1239,7 +1239,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:42 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1248,7 +1248,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1266,15 +1266,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:42 GMT
+      - Mon, 24 Sep 2018 20:31:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e109d28b-d06b-4199-9789-b0f7a688d3a6
+      - req-815468c6-f32c-4ef4-9a90-eb70b4a9f802
       Content-Length:
       - '7265'
       Connection:
@@ -1286,7 +1286,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:42.811365Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:25.069516Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1365,10 +1365,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vLQdIbquQCaYiRMEEW_MbA"],
-        "issued_at": "2018-08-06T16:52:42.811445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GCTUbwGFTrS1QDmZw7URcQ"],
+        "issued_at": "2018-09-24T20:31:25.069555Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1383,7 +1383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
   response:
     status:
       code: 200
@@ -1394,7 +1394,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:42 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1403,7 +1403,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1421,15 +1421,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:43 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-773d374e-def9-456c-811f-bb0bd144f96d
+      - req-28b3b3da-a93a-47fe-891c-c13ff513819d
       Content-Length:
       - '7278'
       Connection:
@@ -1441,7 +1441,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:43.205474Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:25.359589Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1520,10 +1520,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jwqa7qe3TQaozli8tB7_Fg"],
-        "issued_at": "2018-08-06T16:52:43.205538Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bW5pAgLISxWhojNARuk5Og"],
+        "issued_at": "2018-09-24T20:31:25.359622Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1538,7 +1538,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
   response:
     status:
       code: 200
@@ -1549,7 +1549,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:52:43 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1558,7 +1558,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1573,7 +1573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1586,26 +1586,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-cc998ef2-c624-4651-b834-7d7493c267ff
+      - req-f818a31e-9815-47fc-9824-8433981e1e3d
       Date:
-      - Mon, 06 Aug 2018 16:52:43 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1620,7 +1620,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1633,26 +1633,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-36251c9d-c533-4cb3-8ab9-85e19e97b07a
+      - req-17259628-8fda-4592-a2a3-f4160cc95969
       Date:
-      - Mon, 06 Aug 2018 16:52:43 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1667,7 +1667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1680,26 +1680,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f1fe8dce-532e-416e-940b-493ddca98fb5
+      - req-7eec801f-5baa-49c0-857e-2caa46ccce10
       Date:
-      - Mon, 06 Aug 2018 16:52:43 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1714,7 +1714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1727,26 +1727,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-29faa091-0e58-4f46-b867-e6a557a92ef8
+      - req-7c8ef2a9-8a85-42ab-b741-1590471b2682
       Date:
-      - Mon, 06 Aug 2018 16:52:44 GMT
+      - Mon, 24 Sep 2018 20:31:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1761,7 +1761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1774,26 +1774,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-cd54d602-d3d8-48e7-af72-b9af56c80101
+      - req-2cd6021c-497a-4026-a440-5ceffd682bf8
       Date:
-      - Mon, 06 Aug 2018 16:52:44 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1808,7 +1808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1821,26 +1821,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-af286552-37d5-4e9c-a403-af307066390f
+      - req-bd87fd6d-2127-4b9b-a2d3-34f8b1e2bb52
       Date:
-      - Mon, 06 Aug 2018 16:52:44 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1855,7 +1855,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1868,26 +1868,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e29f7485-86e8-4a10-bacb-e9007d0d023e
+      - req-5d101a71-457c-4b8a-8b36-f9b315c3b99a
       Date:
-      - Mon, 06 Aug 2018 16:52:44 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1902,7 +1902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1915,26 +1915,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e244a05a-2f19-458c-9a80-48083a5e233e
+      - req-b3981709-720d-4778-949f-da9b873223d8
       Date:
-      - Mon, 06 Aug 2018 16:52:44 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1949,7 +1949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1962,26 +1962,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3b411cf7-98c7-49db-9332-03ea788bfa75
+      - req-2c156493-ebf5-4b23-9ea3-ddbe3a6ab5ee
       Date:
-      - Mon, 06 Aug 2018 16:52:45 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1996,7 +1996,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2009,26 +2009,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3caa2b22-ed52-471c-9fb0-889344e67cc8
+      - req-af66a268-d750-4490-bd05-daaba7293cd1
       Date:
-      - Mon, 06 Aug 2018 16:52:45 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -2043,7 +2043,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2056,26 +2056,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-ef9b404c-59f0-41d8-a333-63a89e1eb4e8
+      - req-763c929f-81fc-400c-a063-00f0464d4975
       Date:
-      - Mon, 06 Aug 2018 16:52:45 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -2090,7 +2090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2103,26 +2103,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d1519d20-d6fe-4066-8fb6-09065f103091
+      - req-ef4e165b-d1f6-408e-87a7-726dea141ae5
       Date:
-      - Mon, 06 Aug 2018 16:52:45 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:35.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -2137,7 +2137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2150,26 +2150,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-68e40470-d95c-4a2f-86bb-722a89fd711e
+      - req-e1aa6eaa-2ded-4507-9567-2c5951c133ce
       Date:
-      - Mon, 06 Aug 2018 16:52:45 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2184,7 +2184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2197,26 +2197,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a97ca6b5-230d-4884-911a-827a68bd27fa
+      - req-5278f803-6879-45df-98c5-422579be3a8a
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:52:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:52:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:52:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:31:24.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:52:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:31:24.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:52:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:31:24.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2231,7 +2231,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2244,9 +2244,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-6fccb537-61f1-4ced-acad-e8fb660b4dad
+      - req-173bed24-58f7-40de-8387-aed639ab4b60
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2260,7 +2260,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-3674c6e8-5545-4cb4-861d-42825c0df93a
+      - req-755c4d3a-cb31-4051-bead-03de7ac0108f
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2304,7 +2304,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2319,7 +2319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2332,9 +2332,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-4ae770a9-8287-45b8-81d7-9d6ef8e1b0f9
+      - req-ca7b2d4a-51d9-432f-ae93-16601edf83c4
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2349,7 +2349,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2364,7 +2364,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2377,9 +2377,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-723fb82e-289c-4a05-b65e-388f3415dd27
+      - req-e6161254-b729-44c6-bfb8-64596f6be097
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2389,7 +2389,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2404,7 +2404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2417,15 +2417,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-9bf655a5-6e50-48b9-bbe4-e4036812b847
+      - req-cb335fc0-3c85-4032-8d2d-436978463007
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2443,15 +2443,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:46 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e0255fc0aa294babb280279aca329cbf
+      - 398bef20111d4096a3d8a8db814021e4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a9f01416-29cb-4579-ac16-29b8cfbc6415
+      - req-138ba3bc-d308-4fb7-af26-73551aebedaf
       Content-Length:
       - '7311'
       Connection:
@@ -2463,7 +2463,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:47.116655Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:27.723446Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2542,10 +2542,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y6nKBSC2Rk2EwEpbR0A6Bw"],
-        "issued_at": "2018-08-06T16:52:47.116727Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qk-bRgvjQSOxDbIvn7t6Iw"],
+        "issued_at": "2018-09-24T20:31:27.723466Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -2560,7 +2560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0255fc0aa294babb280279aca329cbf
+      - 398bef20111d4096a3d8a8db814021e4
   response:
     status:
       code: 300
@@ -2571,7 +2571,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:52:47 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -2584,7 +2584,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2602,15 +2602,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:47 GMT
+      - Mon, 24 Sep 2018 20:31:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6b2a80456bc941eaaae5cf6e479b6010
+      - 6ddb6a8d919f4e0f84b439c9c761e36c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa9582a3-99af-4f5d-8392-0d7ab05cc2dc
+      - req-d7d6f48c-b3eb-4bd5-bb91-daed350e1bcc
       Content-Length:
       - '7278'
       Connection:
@@ -2622,7 +2622,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:47.524291Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:28.024856Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2701,10 +2701,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zEvt1LvlT6epY86Y_YroGQ"],
-        "issued_at": "2018-08-06T16:52:47.524355Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G-sDi56JTHerSOWygh1BZQ"],
+        "issued_at": "2018-09-24T20:31:28.024879Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2719,7 +2719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b2a80456bc941eaaae5cf6e479b6010
+      - 6ddb6a8d919f4e0f84b439c9c761e36c
   response:
     status:
       code: 200
@@ -2730,9 +2730,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-565e993e-bcae-4595-b868-34f47d4e14f7
+      - req-58d8b29f-071d-488b-b62c-2e55da923f5a
       Date:
-      - Mon, 06 Aug 2018 16:52:47 GMT
+      - Mon, 24 Sep 2018 20:31:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2774,7 +2774,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -2789,7 +2789,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b2a80456bc941eaaae5cf6e479b6010
+      - 6ddb6a8d919f4e0f84b439c9c761e36c
   response:
     status:
       code: 200
@@ -2800,14 +2800,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-547cbf1c-a3c3-4faa-9d58-b918c62742b7
+      - req-203f458e-7ace-4d22-8c09-3707d52686b3
       Date:
-      - Mon, 06 Aug 2018 16:52:48 GMT
+      - Mon, 24 Sep 2018 20:31:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2825,15 +2825,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:48 GMT
+      - Mon, 24 Sep 2018 20:31:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e08c7d86bb46470fb21d8583bcc1c547
+      - e6f7cfde597e47b88f6ae42e078e74f1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1493b0b2-45d2-489e-93aa-c019742d4f36
+      - req-4ce467cd-91a0-46f5-89f4-49c680c03b0e
       Content-Length:
       - '7278'
       Connection:
@@ -2845,7 +2845,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:48.357818Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:28.853548Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2924,10 +2924,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q5r3DhCaRqm907y0zS7O-w"],
-        "issued_at": "2018-08-06T16:52:48.357889Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D3XaXjcIS-q283Bpxhdi5w"],
+        "issued_at": "2018-09-24T20:31:28.853569Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -2942,7 +2942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e08c7d86bb46470fb21d8583bcc1c547
+      - e6f7cfde597e47b88f6ae42e078e74f1
   response:
     status:
       code: 200
@@ -2953,9 +2953,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a18a56f4-031b-458f-bb49-1315bbb53df7
+      - req-cc6b969e-c6a5-4a9c-af91-e175b8204846
       Date:
-      - Mon, 06 Aug 2018 16:52:48 GMT
+      - Mon, 24 Sep 2018 20:31:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2997,7 +2997,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3012,7 +3012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e08c7d86bb46470fb21d8583bcc1c547
+      - e6f7cfde597e47b88f6ae42e078e74f1
   response:
     status:
       code: 200
@@ -3023,14 +3023,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2a99b798-6070-4892-90f0-9f13994260bb
+      - req-99bdeb81-bc98-4ebb-b2b3-adf939afa558
       Date:
-      - Mon, 06 Aug 2018 16:52:48 GMT
+      - Mon, 24 Sep 2018 20:31:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3048,15 +3048,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:49 GMT
+      - Mon, 24 Sep 2018 20:31:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d94d85ae28f345c6a4abdc0a79aa5f29
+      - d55dcf1c6be14bac86949605815e1f4b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6539bf3f-b8e3-43ff-9671-21d9157cc0d4
+      - req-75e1c040-3a72-4ba9-9366-4fb4bd4b4de8
       Content-Length:
       - '7264'
       Connection:
@@ -3068,7 +3068,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:49.264408Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:29.354205Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3147,10 +3147,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0-jmVHbQTl2Dxd3DBrgwUw"],
-        "issued_at": "2018-08-06T16:52:49.264480Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N1hhmaGkRiWwVty2QjhoXA"],
+        "issued_at": "2018-09-24T20:31:29.354227Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3165,7 +3165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d94d85ae28f345c6a4abdc0a79aa5f29
+      - d55dcf1c6be14bac86949605815e1f4b
   response:
     status:
       code: 200
@@ -3176,9 +3176,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-be63f8e4-e004-4d5c-81a0-d3426dff792a
+      - req-efaf93a8-6fe5-496b-8fb2-d291018d4488
       Date:
-      - Mon, 06 Aug 2018 16:52:49 GMT
+      - Mon, 24 Sep 2018 20:31:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3220,7 +3220,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3235,7 +3235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d94d85ae28f345c6a4abdc0a79aa5f29
+      - d55dcf1c6be14bac86949605815e1f4b
   response:
     status:
       code: 200
@@ -3246,14 +3246,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c5b1faa0-99f0-42ef-b6a7-1fb0bdde029f
+      - req-d04c6361-6123-413f-8ec9-8d954716bff8
       Date:
-      - Mon, 06 Aug 2018 16:52:49 GMT
+      - Mon, 24 Sep 2018 20:31:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3271,15 +3271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:49 GMT
+      - Mon, 24 Sep 2018 20:31:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63828c7f088e450fbb3a18a495f6d723
+      - dbb7dce8373948f3a90efb5c268cf326
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a004f139-a355-435c-80d2-f155ec3354e4
+      - req-cd00a698-dc9f-4f23-a1fa-519950bddd18
       Content-Length:
       - '7278'
       Connection:
@@ -3291,7 +3291,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:50.082257Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:30.841478Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3370,10 +3370,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5yJ8qLbQSMCYFeTyPyYGbQ"],
-        "issued_at": "2018-08-06T16:52:50.082320Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VLQz51CIRMGaufY0fDBCaQ"],
+        "issued_at": "2018-09-24T20:31:30.841498Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3388,7 +3388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63828c7f088e450fbb3a18a495f6d723
+      - dbb7dce8373948f3a90efb5c268cf326
   response:
     status:
       code: 200
@@ -3399,9 +3399,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8d3b761a-91c5-4a5f-8aa2-259e5f1481c5
+      - req-4d0c3fb9-24f1-45bf-86e7-dd192c1d417f
       Date:
-      - Mon, 06 Aug 2018 16:52:50 GMT
+      - Mon, 24 Sep 2018 20:31:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3443,7 +3443,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3458,7 +3458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63828c7f088e450fbb3a18a495f6d723
+      - dbb7dce8373948f3a90efb5c268cf326
   response:
     status:
       code: 200
@@ -3469,14 +3469,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-09484f92-d968-4d79-a28f-1e551c7d1b49
+      - req-73bb797a-0413-4be2-9cb0-35cbafccd9a3
       Date:
-      - Mon, 06 Aug 2018 16:52:50 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3491,7 +3491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0255fc0aa294babb280279aca329cbf
+      - 398bef20111d4096a3d8a8db814021e4
   response:
     status:
       code: 200
@@ -3502,9 +3502,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3966a763-f1ed-48ee-b938-4b90d6e9699f
+      - req-e9181a43-6cfe-4545-9986-7f098fc45e48
       Date:
-      - Mon, 06 Aug 2018 16:52:50 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3546,7 +3546,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3561,7 +3561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0255fc0aa294babb280279aca329cbf
+      - 398bef20111d4096a3d8a8db814021e4
   response:
     status:
       code: 200
@@ -3572,14 +3572,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1e29afd5-5d64-4405-8003-bbb0be355a55
+      - req-39ca08a3-bac4-4073-a422-903dcd13a573
       Date:
-      - Mon, 06 Aug 2018 16:52:51 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3597,15 +3597,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:51 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d242693e8d344bc4a3b968d514136dc8
+      - eb36876c3cef4a31b9743d75978a278b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b971a73-0069-4f59-a844-cf11d26a9e18
+      - req-b5bc1b56-6d41-4064-b323-a230b4f5ea9a
       Content-Length:
       - '7265'
       Connection:
@@ -3617,7 +3617,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:51.348687Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:31.621837Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3696,10 +3696,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rqYl1q4PQ2OZUUW6rH2LfA"],
-        "issued_at": "2018-08-06T16:52:51.348758Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XSiSYKZ2SsG-4X31--Cf4w"],
+        "issued_at": "2018-09-24T20:31:31.621859Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3714,7 +3714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d242693e8d344bc4a3b968d514136dc8
+      - eb36876c3cef4a31b9743d75978a278b
   response:
     status:
       code: 200
@@ -3725,9 +3725,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a0db113a-7616-424a-8689-fe740d6a307b
+      - req-60ee102a-d28d-44f5-b452-0829316628fc
       Date:
-      - Mon, 06 Aug 2018 16:52:51 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3769,7 +3769,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3784,7 +3784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d242693e8d344bc4a3b968d514136dc8
+      - eb36876c3cef4a31b9743d75978a278b
   response:
     status:
       code: 200
@@ -3795,14 +3795,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c2ca3315-bc11-4535-8f61-7128c3c2da78
+      - req-09d4c56c-eafe-47df-a71a-e16e195f64df
       Date:
-      - Mon, 06 Aug 2018 16:52:51 GMT
+      - Mon, 24 Sep 2018 20:31:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3820,15 +3820,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:52 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3fd8d08be5694ed6971260dab1201cdf
+      - 1f68705e98b9464098eae5201574939e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e5b2f3b8-0421-4c8a-b405-21f219edb778
+      - req-c1c820fb-ee10-4ac3-ae58-862d38876513
       Content-Length:
       - '7278'
       Connection:
@@ -3840,7 +3840,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:52.244069Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:32.078442Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3919,10 +3919,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mavmut0ATNGNNRc5nyMOSg"],
-        "issued_at": "2018-08-06T16:52:52.244184Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aRGF8jstRdeQsbXFLS2YKA"],
+        "issued_at": "2018-09-24T20:31:32.078476Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3937,7 +3937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3fd8d08be5694ed6971260dab1201cdf
+      - 1f68705e98b9464098eae5201574939e
   response:
     status:
       code: 200
@@ -3948,9 +3948,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ebf99b7c-6c55-4140-8473-897bc4401b9b
+      - req-8a3b5bd0-b492-4be9-9489-fab4823610aa
       Date:
-      - Mon, 06 Aug 2018 16:52:52 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3992,7 +3992,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -4007,7 +4007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3fd8d08be5694ed6971260dab1201cdf
+      - 1f68705e98b9464098eae5201574939e
   response:
     status:
       code: 200
@@ -4018,14 +4018,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0cf4518c-d633-4815-a9a9-2a0c1023514d
+      - req-77203bdc-6cce-4bd0-8d0e-a6ac2e4d6af7
       Date:
-      - Mon, 06 Aug 2018 16:52:52 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -4040,7 +4040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4053,9 +4053,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ff2ad657-8787-4537-b18b-4c73af28d9ee
+      - req-8b6e8c60-767e-4e55-83d5-cbb30d1b83df
       Date:
-      - Mon, 06 Aug 2018 16:52:52 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4065,7 +4065,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4080,7 +4080,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4093,9 +4093,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-9c69e1fe-4cd4-43b5-a731-0d78b9c0991e
+      - req-c715140e-fc30-4271-8a3c-e4006e4071b9
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4105,7 +4105,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -4120,7 +4120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4133,9 +4133,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-c6aed6d9-41ef-4993-be29-c21fdbcf0b40
+      - req-e68fed5e-a0c4-49b2-affb-0b4239494ee3
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4145,7 +4145,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4160,7 +4160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4173,9 +4173,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-eaacafc8-01eb-4dd7-9081-8364b9584525
+      - req-851f5a2d-cf41-44c9-82da-c9a15273fb44
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4185,7 +4185,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -4200,7 +4200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4213,9 +4213,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-126938d7-0f15-4249-b0fe-3decfaf7199b
+      - req-968851ad-c389-4f87-a2ed-ded29168d6c5
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4225,7 +4225,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4240,7 +4240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4253,9 +4253,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-c14edb40-8d0c-49e4-8f88-8d0e58984613
+      - req-09d24301-117f-4283-9f21-d2033386c541
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4265,7 +4265,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4280,7 +4280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4293,9 +4293,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-d11a6e65-1099-4225-8f9c-e2986229fe57
+      - req-61b6c90d-cc6e-43a8-bb04-de9206b26974
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4305,7 +4305,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4320,7 +4320,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4333,9 +4333,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-87682d57-d6bd-4f74-9793-58f52ff14644
+      - req-360c39ed-6822-4181-9647-9c5f6f3cceec
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4345,7 +4345,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4360,7 +4360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4373,9 +4373,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-b50e9765-7a37-4fb1-a50a-bdf201c7e1db
+      - req-314f5925-60f0-4c55-9038-3817facba4ce
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4385,7 +4385,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4400,7 +4400,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4413,9 +4413,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-5149f29f-470a-4950-a3e9-3e35dcf3289a
+      - req-ffce56b9-f7ca-40ba-8584-78a9befcd1d7
       Date:
-      - Mon, 06 Aug 2018 16:52:53 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4425,7 +4425,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4440,7 +4440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4453,9 +4453,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-eea393d7-4972-4f81-ae8c-0428bc617f89
+      - req-1a020ff9-6a70-482a-b351-52641f1578a6
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4465,7 +4465,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4480,7 +4480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4493,9 +4493,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-42e07569-08b9-4fc1-8673-181894d8459b
+      - req-97d2328d-d66f-47c7-aa80-188c64b57026
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4505,7 +4505,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4520,7 +4520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4533,9 +4533,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-63c1abd7-0dd8-4a92-9e70-28304374cf84
+      - req-745ba6b9-d87c-4069-a239-0323872f4ef9
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4545,7 +4545,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4560,7 +4560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4573,9 +4573,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-da49120e-d605-4b64-9658-ce362a6093cb
+      - req-4c79e318-7626-440c-a08a-0950619d11d1
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4585,7 +4585,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4603,15 +4603,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c2978f9f41d4f4092f5b157f5bc9559
+      - 4f080b8466da4a198a17fd4150c59c9d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-00412d16-d80a-4c86-9257-d349505d59b7
+      - req-144568ba-e5e3-449a-a85e-2b23c13c00f1
       Content-Length:
       - '7311'
       Connection:
@@ -4623,7 +4623,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:54.785531Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:33.843046Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4702,10 +4702,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7OLy8fs2Q-WAzNP50kM_tw"],
-        "issued_at": "2018-08-06T16:52:54.785606Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GbOd3PwhQZ2S1P3O_bTe5g"],
+        "issued_at": "2018-09-24T20:31:33.843067Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4723,15 +4723,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:54 GMT
+      - Mon, 24 Sep 2018 20:31:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d0c452aad88e4242bf637b03a2904903
+      - 290775f219e2465796de2c20874ec28e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ddbaf8f9-cdd9-43b0-bd97-878b27b54a70
+      - req-f23174f5-5ca7-429d-8c62-23f4992917dd
       Content-Length:
       - '7278'
       Connection:
@@ -4743,7 +4743,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:55.121719Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:34.043936Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4822,10 +4822,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2EaUwMHBSZyW98IXrm4ylA"],
-        "issued_at": "2018-08-06T16:52:55.121789Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qdlw61I1SriXJqS0YVDwZg"],
+        "issued_at": "2018-09-24T20:31:34.043955Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -4840,7 +4840,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0c452aad88e4242bf637b03a2904903
+      - 290775f219e2465796de2c20874ec28e
   response:
     status:
       code: 200
@@ -4851,14 +4851,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-34ade597-9452-42b6-b912-9802c85a3ae8
+      - req-6bb5a2c9-6c5d-4a16-acce-1fc539737ea5
       Date:
-      - Mon, 06 Aug 2018 16:52:55 GMT
+      - Mon, 24 Sep 2018 20:31:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4876,15 +4876,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:55 GMT
+      - Mon, 24 Sep 2018 20:31:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 31a0d57a36ca4c02898433445435548a
+      - b23df72be2944e08acf83ba3c26384d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1308f761-0258-4abe-a952-0b02dc22b381
+      - req-cd5d0102-c47a-497f-93cc-4dc1d4a392a0
       Content-Length:
       - '7278'
       Connection:
@@ -4896,7 +4896,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:55.673026Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:34.526882Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4975,10 +4975,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jo2kK6nlT9y2xn4UaTbExA"],
-        "issued_at": "2018-08-06T16:52:55.673095Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r6blfKcoRTeofWu3LQFZfg"],
+        "issued_at": "2018-09-24T20:31:34.526903Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -4993,7 +4993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31a0d57a36ca4c02898433445435548a
+      - b23df72be2944e08acf83ba3c26384d8
   response:
     status:
       code: 200
@@ -5004,14 +5004,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2bd0c15a-37a3-479d-9da7-4167b25d2570
+      - req-7789b50c-fb30-4433-b147-050e508d3fc2
       Date:
-      - Mon, 06 Aug 2018 16:52:55 GMT
+      - Mon, 24 Sep 2018 20:31:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5029,15 +5029,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:56 GMT
+      - Mon, 24 Sep 2018 20:31:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-480a9782-4a4f-4eba-8ef5-86a228cdf3ea
+      - req-22dd43ea-5d41-4e68-b65e-70c28bd56de7
       Content-Length:
       - '7264'
       Connection:
@@ -5049,7 +5049,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:56.227459Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:34.850373Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5128,10 +5128,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k2wkQZqLQ8-en49fVRWB5w"],
-        "issued_at": "2018-08-06T16:52:56.227526Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fT8kRFi8RRy255J-zmY1YA"],
+        "issued_at": "2018-09-24T20:31:34.850419Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5146,7 +5146,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5157,9 +5157,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-41b143e8-6cfc-414c-a350-b60e3b7d4382
+      - req-337598a1-4d40-440c-a1fe-ecf0b53df65b
       Date:
-      - Mon, 06 Aug 2018 16:52:56 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5193,7 +5193,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5208,7 +5208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5219,14 +5219,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3b104c59-5fc8-40e7-939e-d80bedc323d5
+      - req-5937f1a9-548e-43ce-b985-bba5dd96455f
       Date:
-      - Mon, 06 Aug 2018 16:52:56 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5244,15 +5244,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:56 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dee8366863ab435a968168c9c439234e
+      - ae5d133cc1e04bfcab95d4afa11e5ada
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da5d954b-097d-4618-ab95-ac15a5cb506c
+      - req-b09c2379-6e54-430f-ad69-8caab8de8079
       Content-Length:
       - '7278'
       Connection:
@@ -5264,7 +5264,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:57.141571Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:35.326629Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5343,10 +5343,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RiWr8L3CQzGYrPTGpZ75Yw"],
-        "issued_at": "2018-08-06T16:52:57.141653Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jUFlnHPtSA6aKbfOZQetNw"],
+        "issued_at": "2018-09-24T20:31:35.326666Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5361,7 +5361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dee8366863ab435a968168c9c439234e
+      - ae5d133cc1e04bfcab95d4afa11e5ada
   response:
     status:
       code: 200
@@ -5372,14 +5372,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d6e8ba25-506e-4504-bbbb-eaff5a08bebb
+      - req-499034d4-2c1f-49f5-adf7-f6326483cc52
       Date:
-      - Mon, 06 Aug 2018 16:52:57 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5394,7 +5394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c2978f9f41d4f4092f5b157f5bc9559
+      - 4f080b8466da4a198a17fd4150c59c9d
   response:
     status:
       code: 200
@@ -5405,14 +5405,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8dc48d3e-db9d-468a-b94c-913dd0906247
+      - req-3cf674cc-4ab3-4e24-bc19-00074eda4d43
       Date:
-      - Mon, 06 Aug 2018 16:52:57 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5430,15 +5430,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:57 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 109146320f07436d9ba2e121784cd817
+      - 583a65214aa34bc68a5e42e8bf6b4111
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-909ecce8-5582-4db5-b784-ee59e4f50d7c
+      - req-4a9b7fc2-a4b7-44e6-b73f-4b207a32f8b7
       Content-Length:
       - '7265'
       Connection:
@@ -5450,7 +5450,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:57.901678Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:35.810014Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5529,10 +5529,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tVSntgbjR4mVhEjXCFguxw"],
-        "issued_at": "2018-08-06T16:52:57.901749Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qeG24h3YTu2nwWVoGJqr7g"],
+        "issued_at": "2018-09-24T20:31:35.810035Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5547,7 +5547,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 109146320f07436d9ba2e121784cd817
+      - 583a65214aa34bc68a5e42e8bf6b4111
   response:
     status:
       code: 200
@@ -5558,14 +5558,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-99d56488-9c04-4dbe-a871-391d1d414276
+      - req-3df0e351-cace-4769-ab71-bb8e84a82851
       Date:
-      - Mon, 06 Aug 2018 16:52:58 GMT
+      - Mon, 24 Sep 2018 20:31:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5583,15 +5583,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:58 GMT
+      - Mon, 24 Sep 2018 20:31:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b1e177b7e02d4dddb686d3f0c566f620
+      - 65f28461479e47339aff92ad96081dc5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01f89233-4aab-48b0-832e-cd4757922a56
+      - req-c2e169d9-7ca0-4638-9b2b-c046e74ed4d2
       Content-Length:
       - '7278'
       Connection:
@@ -5603,7 +5603,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:58.544698Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:36.140511Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5682,10 +5682,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kVrvmzwvRX2o33nT1__3dg"],
-        "issued_at": "2018-08-06T16:52:58.544798Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tEGBrSQtSNS-InCculQraQ"],
+        "issued_at": "2018-09-24T20:31:36.140531Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5700,7 +5700,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1e177b7e02d4dddb686d3f0c566f620
+      - 65f28461479e47339aff92ad96081dc5
   response:
     status:
       code: 200
@@ -5711,14 +5711,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-38a43eda-b696-42f8-9bca-84fbdc6bff2a
+      - req-415b678b-8967-4c9e-83a5-8618514bf342
       Date:
-      - Mon, 06 Aug 2018 16:52:58 GMT
+      - Mon, 24 Sep 2018 20:31:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5733,7 +5733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5744,9 +5744,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d8a28338-cb30-4099-be84-bab7a824d61a
+      - req-71d83e10-940f-4914-bdff-e4eb9f136ccb
       Date:
-      - Mon, 06 Aug 2018 16:52:59 GMT
+      - Mon, 24 Sep 2018 20:31:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5773,7 +5773,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5788,7 +5788,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5799,9 +5799,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-cd758996-b86d-4d4f-9dbb-9865e0d72bf3
+      - req-e5aeb459-c2db-4439-9b6b-a02b84c1eba2
       Date:
-      - Mon, 06 Aug 2018 16:53:00 GMT
+      - Mon, 24 Sep 2018 20:31:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5828,7 +5828,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5843,7 +5843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5854,9 +5854,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c1748a00-f9e7-4952-abc4-2b5ee6782b09
+      - req-08006965-61e8-40fb-ab3e-e436e3b5f28e
       Date:
-      - Mon, 06 Aug 2018 16:53:01 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5883,7 +5883,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5898,7 +5898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5909,9 +5909,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-057dce27-9c52-423e-aba9-307352a93ba8
+      - req-91891e6b-03b1-41bf-9216-f63f1b1dd346
       Date:
-      - Mon, 06 Aug 2018 16:53:01 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5967,7 +5967,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5982,7 +5982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -5993,9 +5993,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3e7b5de9-7a72-4c8f-92c7-230ae7cca305
+      - req-dc8735bd-d241-43e5-953d-59f10ee220f1
       Date:
-      - Mon, 06 Aug 2018 16:53:01 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6007,7 +6007,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -6022,7 +6022,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6035,14 +6035,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-be00c2f7-0b85-453a-8159-e3f4f0ef1be4
+      - req-814dd816-8fda-4d52-9fce-2b39a08a5944
       Date:
-      - Mon, 06 Aug 2018 16:53:01 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -6057,7 +6057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6070,14 +6070,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-ff48b394-7e7f-40b6-88d5-65bccabc4438
+      - req-8450587a-aff7-4bc4-9ca2-f985e131bf00
       Date:
-      - Mon, 06 Aug 2018 16:53:02 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -6092,7 +6092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6105,13 +6105,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-f4292a65-29ca-40e0-9ebd-d4dda74b550e
+      - req-55b5a78e-6b73-4f0e-9d95-7d5468e2de7a
       Date:
-      - Mon, 06 Aug 2018 16:53:02 GMT
+      - Mon, 24 Sep 2018 20:31:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:23Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -6153,7 +6153,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6168,7 +6168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6181,9 +6181,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-9f59117b-b80e-4c8e-bfcf-c0cdb5cfbe46
+      - req-0519bc3c-647d-491b-ba7b-4d0aaa9c0740
       Date:
-      - Mon, 06 Aug 2018 16:53:03 GMT
+      - Mon, 24 Sep 2018 20:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6207,7 +6207,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:57:56Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -6229,7 +6229,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6244,7 +6244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6257,13 +6257,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-ad3a735f-b51d-4fd4-b9f6-69eb8573f6c9
+      - req-d3699ab1-13ef-4a55-8ffe-a4bc0c12caa1
       Date:
-      - Mon, 06 Aug 2018 16:53:04 GMT
+      - Mon, 24 Sep 2018 20:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:19Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -6284,7 +6284,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:46:48Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -6307,7 +6307,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6322,7 +6322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6335,9 +6335,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-c17c8f25-08ad-4120-aec0-84e6d31c5c67
+      - req-0d159a02-a9fe-4db5-8bdb-5e8becc3884f
       Date:
-      - Mon, 06 Aug 2018 16:53:04 GMT
+      - Mon, 24 Sep 2018 20:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6379,7 +6379,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6394,7 +6394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6407,9 +6407,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-b8be4714-a8d9-4956-91d4-2012ff42a891
+      - req-f7cb71fd-657d-4f86-aa9d-7b99e1a159cc
       Date:
-      - Mon, 06 Aug 2018 16:53:05 GMT
+      - Mon, 24 Sep 2018 20:31:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6432,7 +6432,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6447,7 +6447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6460,14 +6460,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-b73ad868-377c-4bbe-b18d-68fb4793f542
+      - req-10e41d1a-1895-412a-b3a9-c62e4eb779b7
       Date:
-      - Mon, 06 Aug 2018 16:53:05 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6482,7 +6482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6495,14 +6495,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-46866397-24fa-4198-a165-77dc4f18c559
+      - req-13169bc4-f32f-43ea-84d7-efeffd3d0a92
       Date:
-      - Mon, 06 Aug 2018 16:53:05 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6517,7 +6517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6530,14 +6530,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-16010f25-282a-4d58-9878-d645d7bea724
+      - req-5e6c63c8-fc48-4b19-914e-abe2bb42477f
       Date:
-      - Mon, 06 Aug 2018 16:53:05 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6552,7 +6552,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6565,14 +6565,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-a6fb132f-bdde-4fcf-87ad-1b4f0a1433b8
+      - req-ba63e374-90b1-4681-af98-6743b5eb8b6b
       Date:
-      - Mon, 06 Aug 2018 16:53:06 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6587,7 +6587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -6598,9 +6598,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-cce2ea96-be76-425a-93bb-1226f74928e9
+      - req-7b5b8283-9759-4819-a868-451b314f4b1e
       Date:
-      - Mon, 06 Aug 2018 16:53:06 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6656,7 +6656,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6671,7 +6671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -6682,9 +6682,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a53cfa1b-56fd-4a7e-a304-3a19b97019dd
+      - req-3a8d0dc8-f15f-4249-b80e-85cf7875c3b3
       Date:
-      - Mon, 06 Aug 2018 16:53:06 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6696,7 +6696,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6711,7 +6711,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -6722,9 +6722,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-489899d2-1308-43d4-8b65-c85362e9bdbd
+      - req-8e3dde1e-e82c-4e73-9619-436f60c54b11
       Date:
-      - Mon, 06 Aug 2018 16:53:06 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6780,7 +6780,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6795,7 +6795,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b77edbdc5ef544b2aea248f2c2aaa45e
+      - cc7b8db6ccdf403d951d4b52d346b4c8
   response:
     status:
       code: 200
@@ -6806,9 +6806,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e97d5726-1f49-4d77-af9d-598ba7a74f0f
+      - req-ef8d174b-3bec-4e59-b4a4-e1322353247e
       Date:
-      - Mon, 06 Aug 2018 16:53:06 GMT
+      - Mon, 24 Sep 2018 20:31:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6820,7 +6820,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6835,7 +6835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a42803d75e874942aad55838bcdbdb57
+      - a18d3587e37d44bdb283253ff80055b3
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6848,9 +6848,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-253aca03-644b-4bb1-b7e8-16cae6274f8a
+      - req-43cff134-4f40-48f1-9a0e-d73595a7166a
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6859,7 +6859,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6874,7 +6874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6261347ce294158801fcd7ae46c28b5
+      - aa9436ca7a5b4189a32b4504bb7d205b
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6887,9 +6887,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-759f0075-f3c0-4515-859e-07c910e3741c
+      - req-f7e7b718-aa62-4aaf-9469-bf0085bf26db
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6898,7 +6898,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6913,7 +6913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6926,9 +6926,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2a5ca4c7-8b71-4d49-9bac-a5eab66e0935
+      - req-83b26346-ea4b-4419-838f-63e3cb5d25fb
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6937,7 +6937,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6952,7 +6952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e467dc0da3a488fa7febc7960ef0c57
+      - ce91c2ce87d34994b20f56e1dc3a2344
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6965,9 +6965,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3df399bb-2178-4d8a-b5f2-70a0e8a8faf0
+      - req-c2f7ca1c-57fc-4e9c-a194-4db9478c6bb4
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6976,7 +6976,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6991,7 +6991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7004,9 +7004,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-120c4d26-c41e-457c-be6b-ade3e9389cc6
+      - req-f6bd5e23-2139-4683-8d65-af29d90b94f4
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7015,7 +7015,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7030,7 +7030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 886f1fde8f83488597be3fad95c8cb04
+      - cd1aeaed27f14d26af48fce4c5c18780
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7043,9 +7043,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d497a84f-3c82-4b19-9d7f-5c214434c148
+      - req-942bf93b-ecc1-45f7-a3e0-2323c019aeb2
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7054,7 +7054,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7069,7 +7069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 154f676ec5da4c0da8039638bb2147fa
+      - 8e947d6e8e18431caa701e381dda7176
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7082,9 +7082,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-698a31bc-cfe4-46c8-983d-cc7e7fd7f53b
+      - req-776e5df9-e17b-43c2-9f2f-17648a478594
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -7093,7 +7093,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7111,15 +7111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:07 GMT
+      - Mon, 24 Sep 2018 20:31:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-10c3fa80-f773-4542-958c-93278e3071d7
+      - req-9201bfad-6e32-4fa6-9556-64a56b017a4e
       Content-Length:
       - '7278'
       Connection:
@@ -7131,7 +7131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:07.983736Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:43.762076Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7210,10 +7210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2x2sJPqnT2GhKKJ4L0QabA"],
-        "issued_at": "2018-08-06T16:53:07.983802Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["moyWZl15S-CZRjgcICSzXA"],
+        "issued_at": "2018-09-24T20:31:43.762096Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7228,22 +7228,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9dd3364-99ba-46bd-bffe-a0167b256954
+      - req-5997135a-f4d7-412e-80f6-e0e78f51f068
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a9dd3364-99ba-46bd-bffe-a0167b256954
+      - req-5997135a-f4d7-412e-80f6-e0e78f51f068
       Date:
-      - Mon, 06 Aug 2018 16:53:08 GMT
+      - Mon, 24 Sep 2018 20:31:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7253,7 +7253,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7271,15 +7271,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:08 GMT
+      - Mon, 24 Sep 2018 20:31:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9a0dea54-28bc-428f-9e3f-9d9453f4353e
+      - req-533ebf3a-aee5-4f7e-8597-0ebe435177d2
       Content-Length:
       - '7278'
       Connection:
@@ -7291,7 +7291,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:09.144330Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:44.226348Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7370,10 +7370,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RxKnFFoXST6xgSfQmskNpA"],
-        "issued_at": "2018-08-06T16:53:09.144394Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["euCHg6WVRTSLs5ATRKACDA"],
+        "issued_at": "2018-09-24T20:31:44.226369Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7388,22 +7388,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f99b9f8-6f9f-4f2c-af82-d146da142a9e
+      - req-2fb430e6-de28-46a9-9ebc-564461bd3234
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5f99b9f8-6f9f-4f2c-af82-d146da142a9e
+      - req-2fb430e6-de28-46a9-9ebc-564461bd3234
       Date:
-      - Mon, 06 Aug 2018 16:53:09 GMT
+      - Mon, 24 Sep 2018 20:31:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7413,7 +7413,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7431,15 +7431,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:09 GMT
+      - Mon, 24 Sep 2018 20:31:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdb2279f-74a5-45ee-9d68-055ed553c446
+      - req-cfff5ec8-df12-4457-b9d7-c877800451bd
       Content-Length:
       - '7264'
       Connection:
@@ -7451,7 +7451,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:10.138274Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:44.756751Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7530,10 +7530,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eSPzD5EJSXm8yNaWgz6ZPg"],
-        "issued_at": "2018-08-06T16:53:10.138335Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zOez7r3wSLKkQGhLe2O7jQ"],
+        "issued_at": "2018-09-24T20:31:44.756771Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7548,22 +7548,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ec23f8a-de59-432b-bc1e-164f2674fa67
+      - req-d4c322dd-9926-418f-a52f-41bbe150f48b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3ec23f8a-de59-432b-bc1e-164f2674fa67
+      - req-d4c322dd-9926-418f-a52f-41bbe150f48b
       Date:
-      - Mon, 06 Aug 2018 16:53:11 GMT
+      - Mon, 24 Sep 2018 20:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7573,7 +7573,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7591,15 +7591,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:11 GMT
+      - Mon, 24 Sep 2018 20:31:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-837a9be6-204b-4f32-93df-70312a52d396
+      - req-b84cecb2-9eb0-4d2a-ba92-3c5453bfcb2f
       Content-Length:
       - '7278'
       Connection:
@@ -7611,7 +7611,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:11.601170Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:45.300018Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7690,10 +7690,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BX8VJcd3R3u1HgmeO12_6w"],
-        "issued_at": "2018-08-06T16:53:11.601264Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tMUj_SGYQzOABusLeNJJnA"],
+        "issued_at": "2018-09-24T20:31:45.300043Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7708,22 +7708,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28bb3ccb-3750-41bb-9a19-6acca26ac7cd
+      - req-b59a1183-5416-4510-8ca9-4c28acb721be
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-28bb3ccb-3750-41bb-9a19-6acca26ac7cd
+      - req-b59a1183-5416-4510-8ca9-4c28acb721be
       Date:
-      - Mon, 06 Aug 2018 16:53:12 GMT
+      - Mon, 24 Sep 2018 20:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7733,7 +7733,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7748,22 +7748,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a9d45a0-a7e5-4a92-a6c4-7ae050e9e886
+      - req-3551617a-c6aa-4053-aeb7-671a96569230
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4a9d45a0-a7e5-4a92-a6c4-7ae050e9e886
+      - req-3551617a-c6aa-4053-aeb7-671a96569230
       Date:
-      - Mon, 06 Aug 2018 16:53:13 GMT
+      - Mon, 24 Sep 2018 20:31:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7773,7 +7773,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7791,15 +7791,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:13 GMT
+      - Mon, 24 Sep 2018 20:31:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3b353f8c-825a-460a-b1b3-491fdbed20cb
+      - req-179c5542-1e43-464b-a19d-5a26f88607dd
       Content-Length:
       - '7265'
       Connection:
@@ -7811,7 +7811,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:13.356387Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:45.994297Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7890,10 +7890,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SYTLohBGSmS82TyWiRzLsA"],
-        "issued_at": "2018-08-06T16:53:13.356467Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QeuInDtISmyh7_ZG30uR7A"],
+        "issued_at": "2018-09-24T20:31:45.994316Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7908,22 +7908,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eede0dbf-af71-4d46-83b7-3902df976e29
+      - req-b6a0525c-0563-4bb1-8f9e-d749a592b7d2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-eede0dbf-af71-4d46-83b7-3902df976e29
+      - req-b6a0525c-0563-4bb1-8f9e-d749a592b7d2
       Date:
-      - Mon, 06 Aug 2018 16:53:14 GMT
+      - Mon, 24 Sep 2018 20:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7933,7 +7933,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7951,15 +7951,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:14 GMT
+      - Mon, 24 Sep 2018 20:31:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d898bb8f-94bc-42aa-a067-a443bf0c208a
+      - req-8db94e39-ed0c-4063-aa74-c5f3625615aa
       Content-Length:
       - '7278'
       Connection:
@@ -7971,7 +7971,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:14.390387Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:46.439261Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8050,10 +8050,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8YSikr7gQxKCDs-jYUU8bg"],
-        "issued_at": "2018-08-06T16:53:14.390459Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mzCb2CG4SsSLKNbZhGtVvA"],
+        "issued_at": "2018-09-24T20:31:46.439280Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8068,22 +8068,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cd6f7a95-9c48-4350-8081-63376fc7bc89
+      - req-43f3cda9-239e-4e95-a25e-0615ece9c04d
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-cd6f7a95-9c48-4350-8081-63376fc7bc89
+      - req-43f3cda9-239e-4e95-a25e-0615ece9c04d
       Date:
-      - Mon, 06 Aug 2018 16:53:15 GMT
+      - Mon, 24 Sep 2018 20:31:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -8093,7 +8093,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8111,15 +8111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:15 GMT
+      - Mon, 24 Sep 2018 20:31:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 944acba135024d6f8eb679f2d946af56
+      - 9414d36bf6ee4c4fb5441330d6b2e406
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aaaeb321-19ee-43ca-b34e-ce8cd5a67d25
+      - req-f58bfb58-801d-425a-b00e-9e376d8a6ad6
       Content-Length:
       - '7311'
       Connection:
@@ -8131,7 +8131,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:15.517537Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:46.918783Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8210,10 +8210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tfw_PlAXTSOz5_pT8Rw9UQ"],
-        "issued_at": "2018-08-06T16:53:15.517608Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YKfB_bVIQAWQX_Lgj_saMA"],
+        "issued_at": "2018-09-24T20:31:46.918804Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -8228,7 +8228,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 944acba135024d6f8eb679f2d946af56
+      - 9414d36bf6ee4c4fb5441330d6b2e406
   response:
     status:
       code: 200
@@ -8239,13 +8239,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:53:15 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8263,15 +8263,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:15 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3bf5dc7f7adb4ed289ad2f74458950c8
+      - 9d5574e3180a493390c3e01ab1b50cf7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7b9a48df-67da-422f-aa69-6765dcbae093
+      - req-20e916b4-b4a4-49b7-a011-57f59da336cb
       Content-Length:
       - '7278'
       Connection:
@@ -8283,7 +8283,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:15.936815Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:47.196392Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8362,10 +8362,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WkEuT58ZRISQvsdkbySrvw"],
-        "issued_at": "2018-08-06T16:53:15.936890Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["umOIAFcPR0muIeKZere7Og"],
+        "issued_at": "2018-09-24T20:31:47.196412Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8380,7 +8380,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3bf5dc7f7adb4ed289ad2f74458950c8
+      - 9d5574e3180a493390c3e01ab1b50cf7
   response:
     status:
       code: 200
@@ -8391,16 +8391,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ec24816d-0e85-4369-83e9-b1ef20ebd89b
+      - req-628d4577-1ab2-4a26-afe8-46504efa6367
       Date:
-      - Mon, 06 Aug 2018 16:53:16 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8418,15 +8418,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:16 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 856aaaf296064fc6826f403b17c34f57
+      - e8672cb946564d7aa408a2ea08765270
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf36ca02-84c6-417a-8fbe-32ee41ccea84
+      - req-061293db-835d-4b05-a6a8-992f138c95a6
       Content-Length:
       - '7278'
       Connection:
@@ -8438,7 +8438,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:16.463642Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:47.503307Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8517,10 +8517,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eFbMPaMaT8yNa_On5n2B4A"],
-        "issued_at": "2018-08-06T16:53:16.463722Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nOmSuaO4QUiWwPwfnJnhxA"],
+        "issued_at": "2018-09-24T20:31:47.503328Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8535,7 +8535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 856aaaf296064fc6826f403b17c34f57
+      - e8672cb946564d7aa408a2ea08765270
   response:
     status:
       code: 200
@@ -8546,16 +8546,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8809fdc0-46cb-49cc-85a9-a377fa4375a1
+      - req-c38a5ead-cb77-4bb0-ac04-25446c17b16e
       Date:
-      - Mon, 06 Aug 2018 16:53:16 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8573,15 +8573,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:16 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4eda03ea411482a988386f7fa45daf1
+      - 106c38b07bc34ce7ae4f38485844fd39
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-801c4cba-c25b-418f-b48e-19f8ff52a189
+      - req-485ba426-62c1-4198-8662-9c3b96d44062
       Content-Length:
       - '7264'
       Connection:
@@ -8593,7 +8593,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:17.037301Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:47.809583Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8672,10 +8672,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N-8s1jRBTJymuBILy16xdw"],
-        "issued_at": "2018-08-06T16:53:17.037368Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NUczhtKHQ0aSKCo-1jTGWA"],
+        "issued_at": "2018-09-24T20:31:47.809604Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8690,7 +8690,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4eda03ea411482a988386f7fa45daf1
+      - 106c38b07bc34ce7ae4f38485844fd39
   response:
     status:
       code: 200
@@ -8701,16 +8701,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3ca79b87-8221-485b-a0f1-bf6eacd39a31
+      - req-280cfb84-5dd3-49e6-9217-c2f1e60b40c6
       Date:
-      - Mon, 06 Aug 2018 16:53:17 GMT
+      - Mon, 24 Sep 2018 20:31:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8728,15 +8728,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:17 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 44644d849b4d4d2cac4ac364d3df06c3
+      - b0675682eca1471c97cf1d13153d5eb9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9208b6ce-fb59-45db-b534-2e06f682a9bf
+      - req-6ca58263-18ee-4d5a-92a6-c7c547652772
       Content-Length:
       - '7278'
       Connection:
@@ -8748,7 +8748,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:17.910218Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:48.122541Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8827,10 +8827,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Bpo2VCCwQ_ul8PvHIPXm4w"],
-        "issued_at": "2018-08-06T16:53:17.910294Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Al6W2-8FTdiI7qbIBBebvg"],
+        "issued_at": "2018-09-24T20:31:48.122562Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8845,7 +8845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44644d849b4d4d2cac4ac364d3df06c3
+      - b0675682eca1471c97cf1d13153d5eb9
   response:
     status:
       code: 200
@@ -8856,16 +8856,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0df3fbad-eeb4-4789-b7f9-7fd08a538cdf
+      - req-7475d60a-e32e-49af-9f3e-d2551acdf4d8
       Date:
-      - Mon, 06 Aug 2018 16:53:18 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8880,7 +8880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 944acba135024d6f8eb679f2d946af56
+      - 9414d36bf6ee4c4fb5441330d6b2e406
   response:
     status:
       code: 200
@@ -8891,16 +8891,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-60459fe6-3050-4f54-91d7-d7ad51f3a655
+      - req-904bf07a-b90a-444c-8b95-135ddb4524ca
       Date:
-      - Mon, 06 Aug 2018 16:53:18 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8918,15 +8918,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:18 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8c8dcb1555054b539dec276bffc5d599
+      - 2a72b6af1f0d445d90dfb9855d37a35c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f33b1933-a9b7-4e49-ad03-9eea548af148
+      - req-326dbd09-d0ba-4ea7-8e93-2272d79ead26
       Content-Length:
       - '7265'
       Connection:
@@ -8938,7 +8938,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:18.740925Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:48.543449Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9017,10 +9017,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ExPp6A_TRtSnjHEEFZZdsw"],
-        "issued_at": "2018-08-06T16:53:18.741067Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1nOYsDRYS6W5V428zlfVng"],
+        "issued_at": "2018-09-24T20:31:48.543469Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -9035,7 +9035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c8dcb1555054b539dec276bffc5d599
+      - 2a72b6af1f0d445d90dfb9855d37a35c
   response:
     status:
       code: 200
@@ -9046,16 +9046,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a9686d41-bb2b-439b-94fa-c5ed514615e4
+      - req-ff6b0c43-9b02-4d80-ab3f-265de632fb38
       Date:
-      - Mon, 06 Aug 2018 16:53:18 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9073,15 +9073,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:19 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c8dd515ab104338a977e22706087edb
+      - 84ec680663e0484090e04e9892965fd9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa13a418-3cbd-4bbb-be2d-9016824e4053
+      - req-f17ff9cd-78b5-40b2-84b6-bc45dfa7aa73
       Content-Length:
       - '7278'
       Connection:
@@ -9093,7 +9093,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:19.272628Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:48.853644Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9172,10 +9172,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3GTvxPXBSFiMZa7ohptMwQ"],
-        "issued_at": "2018-08-06T16:53:19.272701Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qaqbc5c3RI2WfYmTpqu8Bw"],
+        "issued_at": "2018-09-24T20:31:48.853663Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -9190,7 +9190,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c8dd515ab104338a977e22706087edb
+      - 84ec680663e0484090e04e9892965fd9
   response:
     status:
       code: 200
@@ -9201,16 +9201,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-115c6566-632b-499e-ad3e-7bac12ff5366
+      - req-e5ed610b-ca4a-47db-8eab-5014f775c064
       Date:
-      - Mon, 06 Aug 2018 16:53:19 GMT
+      - Mon, 24 Sep 2018 20:31:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9225,7 +9225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9238,9 +9238,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-66963a89-53ed-4fb6-aff1-bb1036389319
+      - req-925c0d50-5ae6-473b-9860-3fe3c94781e9
       Date:
-      - Mon, 06 Aug 2018 16:53:19 GMT
+      - Mon, 24 Sep 2018 20:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9263,7 +9263,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9278,7 +9278,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9291,9 +9291,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-e61d4241-00f0-4b63-8759-6b39686d70a8
+      - req-5cf560a8-9211-47fd-8378-12afc162204e
       Date:
-      - Mon, 06 Aug 2018 16:53:20 GMT
+      - Mon, 24 Sep 2018 20:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9316,7 +9316,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9331,7 +9331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9344,9 +9344,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-810db3fa-844f-42e0-ba82-d4c4d83d3598
+      - req-3ec7734b-3fc6-480d-acaa-33ae92704d45
       Date:
-      - Mon, 06 Aug 2018 16:53:20 GMT
+      - Mon, 24 Sep 2018 20:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9369,7 +9369,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9384,7 +9384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9397,9 +9397,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-0c652426-b08b-4afa-823e-bd3162580720
+      - req-a3c89600-8e79-441e-a553-0332e98c8f49
       Date:
-      - Mon, 06 Aug 2018 16:53:20 GMT
+      - Mon, 24 Sep 2018 20:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9422,7 +9422,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9437,7 +9437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9450,9 +9450,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-de1c0b4b-9955-4159-a6bf-321e5078d15b
+      - req-17c726c7-d2ec-4d9a-a5b5-22f3a9816445
       Date:
-      - Mon, 06 Aug 2018 16:53:21 GMT
+      - Mon, 24 Sep 2018 20:31:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9475,7 +9475,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -9490,7 +9490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9503,15 +9503,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-605fc09d-a3ae-4d54-bcd6-5423db4f485e
+      - req-7a1d4ca3-64ac-47ab-be13-eca39aab8b06
       Date:
-      - Mon, 06 Aug 2018 16:53:21 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9526,7 +9526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9539,9 +9539,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-6f5949c6-6a1e-4eb4-852d-9522b4c2fb01
+      - req-21dbb505-6773-48fc-9bcb-9cca767ab454
       Date:
-      - Mon, 06 Aug 2018 16:53:21 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9564,7 +9564,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9579,7 +9579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9592,15 +9592,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-0772ecdb-4e17-43c2-810b-d9e67989e056
+      - req-d1e64d60-e48e-494c-9234-7013e4c266a6
       Date:
-      - Mon, 06 Aug 2018 16:53:21 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9615,7 +9615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9628,9 +9628,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-4ff9ba5a-ca3c-46fa-a966-b55a02fe8014
+      - req-a346cfcc-901c-429f-bde8-6fd9b6c087b8
       Date:
-      - Mon, 06 Aug 2018 16:53:22 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9653,7 +9653,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9668,7 +9668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9681,9 +9681,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-36a42bcf-1e4b-4694-8513-578da6557c09
+      - req-bc662571-5ba7-4f92-a485-2e99fcacde74
       Date:
-      - Mon, 06 Aug 2018 16:53:22 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9706,7 +9706,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-floating-ips
@@ -9721,7 +9721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a39736873d48ae8dd8b976d9f2f7e2
+      - b5c73be606fe4b21bad482d7dfb6c7cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9734,9 +9734,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-accecb2a-c48e-4bca-bf33-03c568874d57
+      - req-8fc2c4cd-bff0-488d-8b2e-a9de50fd7943
       Date:
-      - Mon, 06 Aug 2018 16:53:23 GMT
+      - Mon, 24 Sep 2018 20:31:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": "5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -9759,7 +9759,7 @@ http_interactions:
         "pool": "EmsRefreshSpec-NetworkPublic"}, {"instance_id": null, "ip": "172.16.17.14",
         "fixed_ip": null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60", "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9777,15 +9777,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:23 GMT
+      - Mon, 24 Sep 2018 20:31:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ddf6f4cd6ee3443388bbd043547512f9
+      - 3ae206fe68754278b0aa1a0d36904906
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64775336-f161-4853-bef8-715489df54a6
+      - req-02a980ac-2aa4-4c85-8fb2-e2df00872bae
       Content-Length:
       - '7311'
       Connection:
@@ -9797,7 +9797,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:23.337370Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:52.141653Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9876,16 +9876,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mx9QqLyySFetI5n63ImrIA"],
-        "issued_at": "2018-08-06T16:53:23.337441Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5w2zsJjaQKehZPfnKAz3Ng"],
+        "issued_at": "2018-09-24T20:31:52.141673Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"ddf6f4cd6ee3443388bbd043547512f9"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"3ae206fe68754278b0aa1a0d36904906"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9897,15 +9897,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:23 GMT
+      - Mon, 24 Sep 2018 20:31:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 80374c3c0e4f42f2813c8951ec146173
+      - dc845ee5a1ae41e3b0256f31349fe805
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-21d82ef2-5727-4a71-83bb-39e592e0c761
+      - req-b2ccc9fd-e2b7-49b6-8f0b-de16b5dfa427
       Content-Length:
       - '7346'
       Connection:
@@ -9917,7 +9917,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:23.337370Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:52.141653Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9996,10 +9996,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R4Ie6AC_QESRYJepFUZJGg",
-        "Mx9QqLyySFetI5n63ImrIA"], "issued_at": "2018-08-06T16:53:23.633744Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SQQs5GIwTcy6B5YQZhybNw",
+        "5w2zsJjaQKehZPfnKAz3Ng"], "issued_at": "2018-09-24T20:31:52.326660Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10017,15 +10017,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:23 GMT
+      - Mon, 24 Sep 2018 20:31:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 22eb0446fb3b4e6bba0319cdd6a5993f
+      - 0cda7e4132564ff8ad3cbd452dc024f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-798c9837-733c-4d9b-b64f-764df25514f6
+      - req-a0acc969-36f2-47cc-919d-a77100338e5b
       Content-Length:
       - '7311'
       Connection:
@@ -10037,7 +10037,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:24.017229Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:53.533738Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10116,16 +10116,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wrs4VpDiTxKyajfvf3jiaw"],
-        "issued_at": "2018-08-06T16:53:24.017317Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lIooKg-iQw-EDcLVz5ctEg"],
+        "issued_at": "2018-09-24T20:31:53.533758Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"22eb0446fb3b4e6bba0319cdd6a5993f"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"0cda7e4132564ff8ad3cbd452dc024f0"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10137,15 +10137,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:24 GMT
+      - Mon, 24 Sep 2018 20:31:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 418ff659447e4b21b06a8367c6495c4f
+      - 1de79781343e4d2aa7e5d785dab24a0b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa490732-4fa2-4b03-805c-155a6bbaf52a
+      - req-512cba6c-9a31-4784-bcd4-5e3d2459aa2e
       Content-Length:
       - '7346'
       Connection:
@@ -10157,7 +10157,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:24.017229Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:53.533738Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10236,10 +10236,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t_03zFbFRVesF8vgF6o3Xw",
-        "wrs4VpDiTxKyajfvf3jiaw"], "issued_at": "2018-08-06T16:53:24.355087Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TOosctlLQ2icYf0U2l_xEg",
+        "lIooKg-iQw-EDcLVz5ctEg"], "issued_at": "2018-09-24T20:31:53.712253Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -10254,7 +10254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d5bf394ab4414ca3ed0c799d4f0837
+      - 81558afd1ea546c48a1196f767520768
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -10267,14 +10267,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-ea2d1bbd-e1f6-4a72-ae53-fa2f20ea52f0
+      - req-39c2b4fe-683f-4f2f-abed-f2e8c9b85d28
       Date:
-      - Mon, 06 Aug 2018 16:53:24 GMT
+      - Mon, 24 Sep 2018 20:31:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -10289,27 +10289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f460a4fc-9ee3-4197-8094-2f287e91bd44
+      - req-07e4adba-65e6-4fde-86a3-5b078cc18ab7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f460a4fc-9ee3-4197-8094-2f287e91bd44
+      - req-07e4adba-65e6-4fde-86a3-5b078cc18ab7
       Date:
-      - Mon, 06 Aug 2018 16:53:24 GMT
+      - Mon, 24 Sep 2018 20:31:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -10324,27 +10324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-70244c3b-9150-4bcd-b9ae-45f87b60b8b7
+      - req-ea7f782c-cb08-4f63-bd7a-f025a7290d5d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-70244c3b-9150-4bcd-b9ae-45f87b60b8b7
+      - req-ea7f782c-cb08-4f63-bd7a-f025a7290d5d
       Date:
-      - Mon, 06 Aug 2018 16:53:25 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -10359,22 +10359,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a1eb93bb-16a1-41d5-be99-08f863608201
+      - req-4ab1a8c0-f892-4673-86f7-76be47db56a7
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-a1eb93bb-16a1-41d5-be99-08f863608201
+      - req-4ab1a8c0-f892-4673-86f7-76be47db56a7
       Date:
-      - Mon, 06 Aug 2018 16:53:25 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10407,7 +10407,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -10422,22 +10422,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-54778cec-adce-4d3a-bded-70160a95377e
+      - req-75689c7d-5ac9-4649-b68b-71fa70c36824
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-54778cec-adce-4d3a-bded-70160a95377e
+      - req-75689c7d-5ac9-4649-b68b-71fa70c36824
       Date:
-      - Mon, 06 Aug 2018 16:53:25 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -10454,7 +10454,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -10469,27 +10469,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23dfb1da-34ca-4bd8-b41d-17ac815d9f07
+      - req-bd6e538e-7c5c-42ea-ba01-fc0a7ef23311
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-23dfb1da-34ca-4bd8-b41d-17ac815d9f07
+      - req-bd6e538e-7c5c-42ea-ba01-fc0a7ef23311
       Date:
-      - Mon, 06 Aug 2018 16:53:25 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -10504,27 +10504,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7b88bd3-f5bc-445e-a1ac-f4d46417dbd7
+      - req-5ece0da7-0fb7-43fc-919b-f92077975284
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e7b88bd3-f5bc-445e-a1ac-f4d46417dbd7
+      - req-5ece0da7-0fb7-43fc-919b-f92077975284
       Date:
-      - Mon, 06 Aug 2018 16:53:26 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -10539,27 +10539,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aada8155-1823-4017-b80a-01143734b873
+      - req-78f529b3-2eb2-4005-9214-f39759d91d57
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aada8155-1823-4017-b80a-01143734b873
+      - req-78f529b3-2eb2-4005-9214-f39759d91d57
       Date:
-      - Mon, 06 Aug 2018 16:53:26 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -10574,27 +10574,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4adf079e-5348-4112-ab7e-811ab639392e
+      - req-54831143-1bcd-4c1d-b6ad-03853e0178f7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4adf079e-5348-4112-ab7e-811ab639392e
+      - req-54831143-1bcd-4c1d-b6ad-03853e0178f7
       Date:
-      - Mon, 06 Aug 2018 16:53:26 GMT
+      - Mon, 24 Sep 2018 20:31:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -10609,27 +10609,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2c585295-f594-4faf-8afe-d7c962c61720
+      - req-26dbade0-3c89-401c-957e-bb4240717fd2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2c585295-f594-4faf-8afe-d7c962c61720
+      - req-26dbade0-3c89-401c-957e-bb4240717fd2
       Date:
-      - Mon, 06 Aug 2018 16:53:27 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -10644,27 +10644,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ece34bab-c6d4-402d-adcd-84be20389d8c
+      - req-9a62e6d1-2632-4a25-acba-d9711b3f79bd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ece34bab-c6d4-402d-adcd-84be20389d8c
+      - req-9a62e6d1-2632-4a25-acba-d9711b3f79bd
       Date:
-      - Mon, 06 Aug 2018 16:53:27 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -10679,27 +10679,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc0eabed-4521-4b47-b96d-a0e4059d6246
+      - req-3d1c7d6e-1e8e-4b55-8a4f-89c27bae5917
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dc0eabed-4521-4b47-b96d-a0e4059d6246
+      - req-3d1c7d6e-1e8e-4b55-8a4f-89c27bae5917
       Date:
-      - Mon, 06 Aug 2018 16:53:27 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -10714,27 +10714,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ca14178c-5781-4418-a26f-e6cbc2c5b680
+      - req-643d3ee5-ee0e-408f-8f31-2d5d4973bf00
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ca14178c-5781-4418-a26f-e6cbc2c5b680
+      - req-643d3ee5-ee0e-408f-8f31-2d5d4973bf00
       Date:
-      - Mon, 06 Aug 2018 16:53:27 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -10749,22 +10749,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7ebc738-7027-45b9-ac75-3755c26e3b72
+      - req-3f744ee7-eafc-451f-a3b6-65810771eebf
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-e7ebc738-7027-45b9-ac75-3755c26e3b72
+      - req-3f744ee7-eafc-451f-a3b6-65810771eebf
       Date:
-      - Mon, 06 Aug 2018 16:53:27 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10779,7 +10779,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -10794,22 +10794,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-85c94e92-c0e0-4720-95ae-82043e085dfd
+      - req-1f7e31af-9d98-4a23-a329-a02209f249c4
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-85c94e92-c0e0-4720-95ae-82043e085dfd
+      - req-1f7e31af-9d98-4a23-a329-a02209f249c4
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -10824,7 +10824,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -10839,27 +10839,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-83172e17-2581-4c7f-90b9-0bb4fb361272
+      - req-bfcc8737-68ab-4ad0-a1ae-5c188682e324
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-83172e17-2581-4c7f-90b9-0bb4fb361272
+      - req-bfcc8737-68ab-4ad0-a1ae-5c188682e324
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -10874,27 +10874,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46e72971-34fd-4558-b518-6942ef1c88f0
+      - req-379e9e20-01e6-47e6-9cb4-64a345bbe751
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-46e72971-34fd-4558-b518-6942ef1c88f0
+      - req-379e9e20-01e6-47e6-9cb4-64a345bbe751
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -10909,27 +10909,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e00337cd-8161-4009-a6c9-ff336739ee92
+      - req-883c8200-c804-443b-a567-9ab51d3b39e2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e00337cd-8161-4009-a6c9-ff336739ee92
+      - req-883c8200-c804-443b-a567-9ab51d3b39e2
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -10944,27 +10944,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bbbe0319-6250-4c18-a5f6-729bf5aac54f
+      - req-25c2fcbc-ff56-4100-b0d2-a9c740292556
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bbbe0319-6250-4c18-a5f6-729bf5aac54f
+      - req-25c2fcbc-ff56-4100-b0d2-a9c740292556
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10979,27 +10979,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e243509b-d274-4554-9cf6-cedd5728e0d6
+      - req-f0e50e5f-ceb9-44c7-a625-3c5e1e342e1e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e243509b-d274-4554-9cf6-cedd5728e0d6
+      - req-f0e50e5f-ceb9-44c7-a625-3c5e1e342e1e
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -11014,27 +11014,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-095d432d-6147-409f-b96d-c0bb622befc4
+      - req-511bfc17-899d-4b1f-af70-9c5ffcba13db
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-095d432d-6147-409f-b96d-c0bb622befc4
+      - req-511bfc17-899d-4b1f-af70-9c5ffcba13db
       Date:
-      - Mon, 06 Aug 2018 16:53:28 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11049,27 +11049,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-235015d2-89b0-4bcb-a08b-ffd739a76044
+      - req-426387a3-641e-4ddd-8577-81d14051ebc8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-235015d2-89b0-4bcb-a08b-ffd739a76044
+      - req-426387a3-641e-4ddd-8577-81d14051ebc8
       Date:
-      - Mon, 06 Aug 2018 16:53:29 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -11084,27 +11084,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dfea7aca-ddb0-4364-adcf-5d50bd850a32
+      - req-1d417b89-7452-4da0-ac15-9840bd79e063
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dfea7aca-ddb0-4364-adcf-5d50bd850a32
+      - req-1d417b89-7452-4da0-ac15-9840bd79e063
       Date:
-      - Mon, 06 Aug 2018 16:53:29 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11119,27 +11119,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cad9e91e30e0410eb1ddce63016d3d62
+      - c3593852eba14c6fb781f1d6e6dacb81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-40dc9510-d12d-4d40-9e42-d0ae0b4346f6
+      - req-03e37055-e5bd-40dc-811c-68178875b911
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-40dc9510-d12d-4d40-9e42-d0ae0b4346f6
+      - req-03e37055-e5bd-40dc-811c-68178875b911
       Date:
-      - Mon, 06 Aug 2018 16:53:29 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11154,27 +11154,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7dd441518e8c45ea87e7df57a6d73c32
+      - 4b91a680c68b496d884aa7249980b5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7607549d-fbc1-42f6-bb0f-560d12e082c1
+      - req-ac6024ae-e391-461a-b89e-974397f70b9f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7607549d-fbc1-42f6-bb0f-560d12e082c1
+      - req-ac6024ae-e391-461a-b89e-974397f70b9f
       Date:
-      - Mon, 06 Aug 2018 16:53:29 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11189,22 +11189,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a1c926c-5e8e-4209-873d-62e85947a834
+      - req-1a77f6ac-3655-43b7-8ee9-08fa38563114
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-6a1c926c-5e8e-4209-873d-62e85947a834
+      - req-1a77f6ac-3655-43b7-8ee9-08fa38563114
       Date:
-      - Mon, 06 Aug 2018 16:53:30 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11237,7 +11237,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11252,22 +11252,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cf9054a7-b899-4d65-8b61-cc67208ec8c2
+      - req-54355e7e-5651-4819-9bfe-933d044ba201
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-cf9054a7-b899-4d65-8b61-cc67208ec8c2
+      - req-54355e7e-5651-4819-9bfe-933d044ba201
       Date:
-      - Mon, 06 Aug 2018 16:53:30 GMT
+      - Mon, 24 Sep 2018 20:31:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11308,7 +11308,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11323,22 +11323,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b7a3207-75c5-465d-a86a-e1ea5c7045b2
+      - req-97e19465-aa50-498f-bdcd-d55817d9f95a
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-7b7a3207-75c5-465d-a86a-e1ea5c7045b2
+      - req-97e19465-aa50-498f-bdcd-d55817d9f95a
       Date:
-      - Mon, 06 Aug 2018 16:53:30 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11372,7 +11372,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11387,27 +11387,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2cf5885fd52946b8a6a3e357e027043a
+      - f20db2bcde3b4db4860dea9838d86e52
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fda425c5-ebfe-49ac-83d7-bf1a4ca6ce2a
+      - req-73111f14-c200-4c32-81ff-a6dd92d73450
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fda425c5-ebfe-49ac-83d7-bf1a4ca6ce2a
+      - req-73111f14-c200-4c32-81ff-a6dd92d73450
       Date:
-      - Mon, 06 Aug 2018 16:53:31 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11422,27 +11422,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e25e243b18bf4886951279e452918e9f
+      - 9e2203afe6fb423e89058d7fb8f50f7d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2ab83494-2052-4cd4-8eb9-21a0e22b7ed7
+      - req-e3e6c9cf-8425-44b9-a1cc-3de970a18149
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2ab83494-2052-4cd4-8eb9-21a0e22b7ed7
+      - req-e3e6c9cf-8425-44b9-a1cc-3de970a18149
       Date:
-      - Mon, 06 Aug 2018 16:53:32 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11457,27 +11457,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1fdc621e6d184be6865cc4e81fd54f43
+      - a71e11e5656a4ee8b5574c1019e841d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7e39ced8-aed2-492d-ad8e-028cde964a49
+      - req-e4956d2a-5e72-4ed0-a97f-124681c560fc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7e39ced8-aed2-492d-ad8e-028cde964a49
+      - req-e4956d2a-5e72-4ed0-a97f-124681c560fc
       Date:
-      - Mon, 06 Aug 2018 16:53:32 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11492,27 +11492,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c7a3237e1c14de4af3ae8fc4589b3b3
+      - e8164025efc7495a97215c3e6da4f68e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3643321d-b110-41cd-b6ee-e18d6d24eea3
+      - req-6f536457-200e-489c-9da5-7ffbaa8aab36
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3643321d-b110-41cd-b6ee-e18d6d24eea3
+      - req-6f536457-200e-489c-9da5-7ffbaa8aab36
       Date:
-      - Mon, 06 Aug 2018 16:53:32 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -11527,27 +11527,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb8facf445c40bb9793fd60e8fdf6fb
+      - 31b4420bf168458a9361f8505dca12e5
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ebe7f6a3-42b7-4b82-8099-ce2a859b0e44
+      - req-b650e395-0451-4c26-acc9-915389b4a1b1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ebe7f6a3-42b7-4b82-8099-ce2a859b0e44
+      - req-b650e395-0451-4c26-acc9-915389b4a1b1
       Date:
-      - Mon, 06 Aug 2018 16:53:32 GMT
+      - Mon, 24 Sep 2018 20:31:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11565,15 +11565,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:34 GMT
+      - Mon, 24 Sep 2018 20:31:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4265d4ff8fa41a38ed67fb958b17429
+      - a8372d683698463a8f7a1d2c02d8d987
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5ee158d6-2915-4ad3-95db-e087538c69d4
+      - req-8b2e39dd-edf9-4043-b6a9-45ace4d0ed81
       Content-Length:
       - '7311'
       Connection:
@@ -11585,7 +11585,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:34.472531Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:58.945463Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11664,10 +11664,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a8wq06bPRTKeqNdudl0yAQ"],
-        "issued_at": "2018-08-06T16:53:34.472613Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oeZwJq2JSViJpMCiquoO5A"],
+        "issued_at": "2018-09-24T20:31:58.945495Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11685,15 +11685,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:34 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d79d445-4f7a-43af-9d20-dfc29dd497d4
+      - req-583a0e43-afa0-42a5-8e48-f24fdb630dac
       Content-Length:
       - '7311'
       Connection:
@@ -11705,7 +11705,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:34.897449Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:59.148304Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11784,10 +11784,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tzC7OKoHS8yR_Fvjd2Jnnw"],
-        "issued_at": "2018-08-06T16:53:34.897515Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Gf42ywhcSMGIGMM3zpbYDw"],
+        "issued_at": "2018-09-24T20:31:59.148324Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -11802,7 +11802,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -11813,27 +11813,42 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-b69f5813-338f-4c49-bcfe-418c3286c059
+      - req-a2fed3b5-0a86-4142-a0c6-a0dceb2c7d53
       Date:
-      - Mon, 06 Aug 2018 16:53:35 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "c2ab9441-dd1c-4acc-a3a6-753f1a582291"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -11863,29 +11878,14 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
+        99}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11903,15 +11903,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:35 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9b164379471c4e6e8ea10c49613a2299
+      - aa0da9bb363b4f2bb35883481c4920de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a58464c1-b98f-4ace-9e8d-26fbfb307289
+      - req-1d4b7f8b-91db-4e82-9f6f-f3ed3b372b6f
       Content-Length:
       - '7311'
       Connection:
@@ -11923,7 +11923,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:53:35.498370Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:31:59.474504Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12002,10 +12002,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U1g4vmWBSMGuUp5HFL4WAg"],
-        "issued_at": "2018-08-06T16:53:35.498444Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DkUecTjYQi2Jp6HHxPihWQ"],
+        "issued_at": "2018-09-24T20:31:59.474523Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12023,15 +12023,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:35 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9bd7d5ee90e4ac68b46bc681b143967
+      - b4b9ea8fe4724c838fab500e38a4bff9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-13645191-275c-4515-9595-3eb80b0d7bdf
+      - req-4c075e7b-1ead-41ff-9a78-b9f7684d6709
       Content-Length:
       - '297'
       Connection:
@@ -12040,12 +12040,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:53:35.740765Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:31:59.639838Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cSl0b4HJQ1y8KWpsmGDgWw"],
-        "issued_at": "2018-08-06T16:53:35.740835Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3pTeuH-RRUatak6eMqW5eQ"],
+        "issued_at": "2018-09-24T20:31:59.639856Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -12060,20 +12060,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9bd7d5ee90e4ac68b46bc681b143967
+      - b4b9ea8fe4724c838fab500e38a4bff9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:35 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f158242-71a4-415c-9f48-a65963d19bf9
+      - req-72306260-c4b7-43dd-803f-79cfc6b51b72
       Content-Length:
       - '2457'
       Connection:
@@ -12106,13 +12106,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"b9bd7d5ee90e4ac68b46bc681b143967"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"b4b9ea8fe4724c838fab500e38a4bff9"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -12124,15 +12124,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:36 GMT
+      - Mon, 24 Sep 2018 20:31:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9e511290876b49bb9f16e5051bac399a
+      - 98b7d3b113d64883a2000e56837b713c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f452cd37-a923-41f4-b056-d0096d7c2478
+      - req-dea2c6de-ef2d-4e2d-bc11-2988b9073861
       Content-Length:
       - '7313'
       Connection:
@@ -12144,7 +12144,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:35.740765Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:31:59.639838Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12223,10 +12223,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqyNNZZ1Q6SDthq7x2SzUw",
-        "cSl0b4HJQ1y8KWpsmGDgWw"], "issued_at": "2018-08-06T16:53:36.180678Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["li9nyoViSMOdJVK651ztNg",
+        "3pTeuH-RRUatak6eMqW5eQ"], "issued_at": "2018-09-24T20:31:59.941008Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12241,20 +12241,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e511290876b49bb9f16e5051bac399a
+      - 98b7d3b113d64883a2000e56837b713c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:36 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cdbe699e-7450-4bc3-a36e-22083099720b
+      - req-d55bbe2a-0972-45fb-a791-60e88fbe5b1e
       Content-Length:
       - '2179'
       Connection:
@@ -12287,7 +12287,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12305,15 +12305,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:36 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ebb4b1a3f3a54865ba0bf18f9de9f288
+      - e1ff889eb0514cc89666a5ffcf4c27e7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5eae81df-5976-4114-97ed-f90811f8b227
+      - req-4534bc7e-3eeb-4e65-b13a-2ba3f9410fa8
       Content-Length:
       - '7278'
       Connection:
@@ -12325,7 +12325,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:36.791223Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:00.227874Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12404,10 +12404,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y_DUM1pBT4W6qFuRHwWuKQ"],
-        "issued_at": "2018-08-06T16:53:36.791315Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yH3aEflHTNOQ3ijLwowUXQ"],
+        "issued_at": "2018-09-24T20:32:00.227892Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12425,15 +12425,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:36 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 24cbe1af6ed24ba586c76ece59171aa1
+      - 8a96aae169514f4db69b5977fe20e79d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6a5de8e9-1eb1-40e3-80bb-06df8173a811
+      - req-df2de81f-16c2-4b5c-80b2-1c296050bdb1
       Content-Length:
       - '7278'
       Connection:
@@ -12445,7 +12445,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:37.143963Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:00.420850Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12524,10 +12524,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MIxEJPSUSTudgTeKuzX5BA"],
-        "issued_at": "2018-08-06T16:53:37.144056Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CZ8KyVayS5-wBEzpY-62FQ"],
+        "issued_at": "2018-09-24T20:32:00.420868Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12545,15 +12545,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:37 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e5a4d0e4c725476fa6628ff19253b16a
+      - c101782e20e74a4980a2aef4c1710e1a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-38154866-6cda-4ea4-9a0b-dd64265318ab
+      - req-0fbd1bd2-29c0-48a1-b2d4-72e410fae995
       Content-Length:
       - '7264'
       Connection:
@@ -12565,7 +12565,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:37.476755Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:00.615843Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12644,10 +12644,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NReBAP8bTLWkXP4Eguqe7A"],
-        "issued_at": "2018-08-06T16:53:37.476836Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sNCngxOxTbmDTQ568qLAew"],
+        "issued_at": "2018-09-24T20:32:00.615861Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12665,15 +12665,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:37 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9857e11c44948269352154d644f67a4
+      - 4bcc7cec770044b3b1335b38eb8c9f89
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-68c35496-547b-49c3-a4a3-f91cac551db7
+      - req-f745b4bd-157a-403e-a2b5-c5bc07adba7f
       Content-Length:
       - '7278'
       Connection:
@@ -12685,7 +12685,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:37.810402Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:00.809480Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12764,10 +12764,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tBSAKnkkQUSemBMgGM9Q5w"],
-        "issued_at": "2018-08-06T16:53:37.810469Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dY-7PPRtS_60z3Re7w2fJg"],
+        "issued_at": "2018-09-24T20:32:00.809498Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12785,15 +12785,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:37 GMT
+      - Mon, 24 Sep 2018 20:32:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6a639a32d4534d8787c3c3ca755648f8
+      - 6067fa9ef3bd4f3f8f44f6cc003191da
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-580cdb1b-ac67-44b2-bdc9-a03419a346e5
+      - req-c4bb1d29-db8d-4ac7-9c49-01cd68803510
       Content-Length:
       - '7265'
       Connection:
@@ -12805,7 +12805,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:38.137649Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:01.002404Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12884,10 +12884,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kjJBcw5uQn2APaAVsV9x6Q"],
-        "issued_at": "2018-08-06T16:53:38.137715Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["twoRAhXPSGSW2nsquCxNnA"],
+        "issued_at": "2018-09-24T20:32:01.002423Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12905,15 +12905,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:38 GMT
+      - Mon, 24 Sep 2018 20:32:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6d486a5387464d6fb9d5796321f0c047
+      - e9367f6a9fac48bdba186265f3c88570
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-53aaecc7-b08d-4153-84ff-3d8242ab5ac5
+      - req-f3cabf01-5959-4682-9d4e-0c9f3ce498cc
       Content-Length:
       - '7278'
       Connection:
@@ -12925,7 +12925,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:38.730044Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:01.192627Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13004,10 +13004,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PDLZyzFuR0KY8IUkVjpCTQ"],
-        "issued_at": "2018-08-06T16:53:38.730240Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rd9d1hBxSZCUr_Z-Y5iJuA"],
+        "issued_at": "2018-09-24T20:32:01.192657Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13025,15 +13025,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:38 GMT
+      - Mon, 24 Sep 2018 20:32:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33dab8c200b54407bbd46227401769d8
+      - 6879024c74654591ab0c039b3bdafd94
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-282184e6-715d-430e-a407-55676814ef6e
+      - req-4e6b42cd-e4d4-47bb-b32f-5579acfdd24c
       Content-Length:
       - '7278'
       Connection:
@@ -13045,7 +13045,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:39.179164Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:01.401741Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13124,10 +13124,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["De-KjAeeRtKcgW47cZDPdQ"],
-        "issued_at": "2018-08-06T16:53:39.179235Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zXpQizBqSpmaqxe2V16HLA"],
+        "issued_at": "2018-09-24T20:32:01.401761Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -13142,7 +13142,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33dab8c200b54407bbd46227401769d8
+      - 6879024c74654591ab0c039b3bdafd94
   response:
     status:
       code: 200
@@ -13153,14 +13153,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-82e21235-d759-41be-90ab-9353d0343a64
+      - req-c7ab0dd2-c8a7-44fd-9363-554620e90d17
       Date:
-      - Mon, 06 Aug 2018 16:53:39 GMT
+      - Mon, 24 Sep 2018 20:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13178,15 +13178,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:39 GMT
+      - Mon, 24 Sep 2018 20:32:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e6b64a053a024d619ccece2c9da0d0dc
+      - a8da9e44185e46e798592a29b79a6bc5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6d363381-87d7-442e-97d3-8df9d69bb97a
+      - req-59c03f6c-d152-4039-9d5c-83613e429799
       Content-Length:
       - '7278'
       Connection:
@@ -13198,7 +13198,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:39.727279Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:01.731054Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13277,10 +13277,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mRlR9jfaSRalHZlJE5vR9Q"],
-        "issued_at": "2018-08-06T16:53:39.727359Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2LoVSdtLQPuPMEGgSsE2NQ"],
+        "issued_at": "2018-09-24T20:32:01.731078Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -13295,7 +13295,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6b64a053a024d619ccece2c9da0d0dc
+      - a8da9e44185e46e798592a29b79a6bc5
   response:
     status:
       code: 200
@@ -13306,14 +13306,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-03c4d788-2b66-48a9-9b59-ffbf5b86c8cb
+      - req-28470fb6-7ba0-4e48-9cce-d7149cfc00d4
       Date:
-      - Mon, 06 Aug 2018 16:53:39 GMT
+      - Mon, 24 Sep 2018 20:32:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13331,15 +13331,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:40 GMT
+      - Mon, 24 Sep 2018 20:32:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad4e7ddf-b2e2-4273-a25c-0288693b7c81
+      - req-7659651b-9727-40e0-a7ca-9651d1e15754
       Content-Length:
       - '7264'
       Connection:
@@ -13351,7 +13351,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:40.301887Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:07.326297Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13430,10 +13430,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MVG0IoOdTASJ01HT3lZGRA"],
-        "issued_at": "2018-08-06T16:53:40.301978Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UrxMoFCJRhCGLmBH0vx79w"],
+        "issued_at": "2018-09-24T20:32:07.326318Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -13448,7 +13448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -13459,9 +13459,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-c80c4823-47c7-4a14-8108-0c46aca5798b
+      - req-afc135b9-271b-41b4-9d26-5a9d05208b1a
       Date:
-      - Mon, 06 Aug 2018 16:53:40 GMT
+      - Mon, 24 Sep 2018 20:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -13495,7 +13495,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -13510,7 +13510,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -13521,14 +13521,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bbc42238-2dea-42fe-ab54-f04fb91fe2b6
+      - req-68073095-4424-4789-b081-e19e738ff97c
       Date:
-      - Mon, 06 Aug 2018 16:53:40 GMT
+      - Mon, 24 Sep 2018 20:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13546,15 +13546,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:40 GMT
+      - Mon, 24 Sep 2018 20:32:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bd5d504e9034f0eb109c5fab8f3ce32
+      - c1ad4a451ab64eed940b3372bd5437be
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-81e9b4b6-bfa4-4290-9171-cf839de60fbd
+      - req-6d08b3f6-cf38-414d-a063-78c5f02bc6b5
       Content-Length:
       - '7278'
       Connection:
@@ -13566,7 +13566,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:41.167324Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:07.752376Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13645,10 +13645,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cX7TflGhRBuDNNeG4bF2CQ"],
-        "issued_at": "2018-08-06T16:53:41.167415Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5PTc3Ar0SvabuNe32Rg5jA"],
+        "issued_at": "2018-09-24T20:32:07.752397Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -13663,7 +13663,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bd5d504e9034f0eb109c5fab8f3ce32
+      - c1ad4a451ab64eed940b3372bd5437be
   response:
     status:
       code: 200
@@ -13674,14 +13674,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c1c2390c-1f96-4e42-99c5-3c46ac7791bb
+      - req-c36da9b7-2b29-48cc-bc16-724fca74e92c
       Date:
-      - Mon, 06 Aug 2018 16:53:41 GMT
+      - Mon, 24 Sep 2018 20:32:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -13696,7 +13696,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9b164379471c4e6e8ea10c49613a2299
+      - aa0da9bb363b4f2bb35883481c4920de
   response:
     status:
       code: 200
@@ -13707,14 +13707,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-79caa8dc-3c87-4df8-8b09-55e3cfe58e92
+      - req-20846184-0558-4f18-a69d-8dedbb08ddb1
       Date:
-      - Mon, 06 Aug 2018 16:53:41 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13732,15 +13732,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:41 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f46269aa72b04455a30e43f88e25d5f7
+      - b49bd56866ee496f9c2ebab49113b620
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9dfa8579-78cb-4c7b-ba35-be01a296122d
+      - req-3bba348a-eb62-437e-94c5-e93bdd10e463
       Content-Length:
       - '7265'
       Connection:
@@ -13752,7 +13752,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:41.930798Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:08.189518Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13831,10 +13831,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HT0aULaaRKOf0scwOsDbQA"],
-        "issued_at": "2018-08-06T16:53:41.930861Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oCQGwOGUQKuiByCsyoLWAQ"],
+        "issued_at": "2018-09-24T20:32:08.189538Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -13849,7 +13849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f46269aa72b04455a30e43f88e25d5f7
+      - b49bd56866ee496f9c2ebab49113b620
   response:
     status:
       code: 200
@@ -13860,14 +13860,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3d73b69b-3cbe-40ae-83cb-1859b63d36f2
+      - req-af4ff988-7422-4a30-aee4-c7fe21ad04ba
       Date:
-      - Mon, 06 Aug 2018 16:53:42 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13885,15 +13885,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:42 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0d268a0616384971bf8123b25cd14c9c
+      - 8371831d08a848f080f54d35c55f4c65
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d567f618-e529-42bc-ac9c-786f356da3a8
+      - req-55619467-5933-4e5d-bbae-aa463c984829
       Content-Length:
       - '7278'
       Connection:
@@ -13905,7 +13905,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:42.511300Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:08.496864Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13984,10 +13984,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F3obmZLgROC2bG_hLofx-g"],
-        "issued_at": "2018-08-06T16:53:42.511382Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ciEtPZoGTTyj4B9MUAVZWg"],
+        "issued_at": "2018-09-24T20:32:08.496884Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -14002,7 +14002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0d268a0616384971bf8123b25cd14c9c
+      - 8371831d08a848f080f54d35c55f4c65
   response:
     status:
       code: 200
@@ -14013,14 +14013,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5698d64d-4fb7-4618-9e5d-cdaa781be587
+      - req-0b8c115c-237b-4335-999a-72162defe383
       Date:
-      - Mon, 06 Aug 2018 16:53:42 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -14035,7 +14035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14046,9 +14046,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bf07c60b-6fdd-4ae9-8afb-0b64a41e83d1
+      - req-47af425e-5769-48cb-99a9-8fb4b6282284
       Date:
-      - Mon, 06 Aug 2018 16:53:43 GMT
+      - Mon, 24 Sep 2018 20:32:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14075,7 +14075,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -14090,7 +14090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14101,9 +14101,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2b28b6d3-0086-4abc-a3ff-678e2d920b59
+      - req-f08e6d1e-1945-4973-a645-2eeb5b47ac6c
       Date:
-      - Mon, 06 Aug 2018 16:53:44 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14130,7 +14130,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -14145,7 +14145,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14156,9 +14156,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-49c8d009-ce5a-4994-89c8-ca189341c92d
+      - req-4b23da67-5182-482b-b4e5-35293a6eff9d
       Date:
-      - Mon, 06 Aug 2018 16:53:44 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -14185,7 +14185,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -14200,7 +14200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14211,9 +14211,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-a95ab519-cbad-44a9-96dd-5e1ada1bc48a
+      - req-f3a023ae-d289-4da4-bf6a-61e2e7179ab7
       Date:
-      - Mon, 06 Aug 2018 16:53:45 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14225,7 +14225,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -14240,7 +14240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14251,9 +14251,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-13f9f805-15b8-4e58-b9bd-8740cfcac2f6
+      - req-bbf2f393-7b5c-4a4a-9531-7936a32f541a
       Date:
-      - Mon, 06 Aug 2018 16:53:45 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14265,7 +14265,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -14280,7 +14280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d250d71d06094bc9a71c97b563b06720
+      - dc2ff0bd364e42918759abf4d6da9475
   response:
     status:
       code: 200
@@ -14291,9 +14291,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-064aff6a-78a4-46be-9210-33cbe27e3ede
+      - req-034a40f3-dd5c-4dcb-895a-189a87e3451d
       Date:
-      - Mon, 06 Aug 2018 16:53:45 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -14305,7 +14305,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14323,15 +14323,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:45 GMT
+      - Mon, 24 Sep 2018 20:32:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dce50e97-50c7-4bf3-a163-b1582232b80d
+      - req-98bdc5cd-9262-425b-ae37-739c4b61388b
       Content-Length:
       - '7278'
       Connection:
@@ -14343,7 +14343,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:45.893287Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:09.967530Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14422,10 +14422,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7Xk0rv5yTAa6zDvFJl1a1w"],
-        "issued_at": "2018-08-06T16:53:45.893353Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cgvKQE8_T1aOxGtqGrVWyg"],
+        "issued_at": "2018-09-24T20:32:09.967551Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14440,7 +14440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -14451,23 +14451,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-67ede455-83d7-4338-915b-402d299ac34a
+      - req-c74bbbc0-f7cb-494f-a5bf-e74160d4f755
       Date:
-      - Mon, 06 Aug 2018 16:53:46 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -14544,23 +14533,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:10 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -14572,7 +14572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -14583,12 +14583,36 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7a5c7b2b-c853-4a66-b8ba-01804fa6c865
+      - req-42399ca5-3c66-4497-8631-948fdf06091c
       Date:
-      - Mon, 06 Aug 2018 16:53:46 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
@@ -14652,44 +14676,20 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14707,15 +14707,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:46 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6e3fe759-6884-4cd5-9945-02614683ed9f
+      - req-3637d0cc-f59d-4a67-ac4a-a7f1b8b8d4f3
       Content-Length:
       - '7278'
       Connection:
@@ -14727,7 +14727,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:46.814640Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:10.474067Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14806,10 +14806,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Kbpd49biRH-tMn8lmULsiw"],
-        "issued_at": "2018-08-06T16:53:46.814724Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tCUl8TFYRmqAJ5d06YSzAA"],
+        "issued_at": "2018-09-24T20:32:10.474087Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -14824,7 +14824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -14835,23 +14835,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8302bdf4-c3a0-42d5-a1cd-39fb3c359d80
+      - req-6716797c-be85-4e18-8f95-22d902dec74c
       Date:
-      - Mon, 06 Aug 2018 16:53:47 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -14928,23 +14917,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:10 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -14956,7 +14956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -14967,51 +14967,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e2958fde-09b2-4ec1-9192-d9cc1c855113
+      - req-c88bdf84-c337-4a36-a744-3dfc62d33cf7
       Date:
-      - Mon, 06 Aug 2018 16:53:47 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -15060,20 +15037,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15091,15 +15091,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:47 GMT
+      - Mon, 24 Sep 2018 20:32:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-05a7cb5e-fe8e-441e-9e5c-037b72894ff4
+      - req-4771d216-568d-45c4-b177-431bd29bed73
       Content-Length:
       - '7264'
       Connection:
@@ -15111,7 +15111,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:47.586102Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:11.007324Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15190,10 +15190,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1pENW1qgSVeIHZQhQmESCQ"],
-        "issued_at": "2018-08-06T16:53:47.586223Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-WMEdo0nSZCqDsVrm1ZIqA"],
+        "issued_at": "2018-09-24T20:32:11.007344Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15208,7 +15208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -15219,23 +15219,76 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7e0e1d3f-9aa1-4016-b574-f6af5ca543d9
+      - req-c2057a4f-36ab-44c8-b368-4888dda6655e
       Date:
-      - Mon, 06 Aug 2018 16:53:47 GMT
+      - Mon, 24 Sep 2018 20:32:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
@@ -15259,25 +15312,56 @@ http_interactions:
         "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1fe03609-42e1-4fc8-939e-92ce3288bb6d
+      Date:
+      - Mon, 24 Sep 2018 20:32:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
@@ -15300,18 +15384,66 @@ http_interactions:
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -15325,7 +15457,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15340,7 +15472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -15351,16 +15483,160 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4a91e196-c558-4d0c-94ac-8635315b0152
+      - req-5e0f734b-7ecd-4164-8ec6-75e15698711f
       Date:
-      - Mon, 06 Aug 2018 16:53:48 GMT
+      - Mon, 24 Sep 2018 20:32:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-03a15de8-ead5-46a4-875a-016edaf3485b
+      Date:
+      - Mon, 24 Sep 2018 20:32:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -15426,38 +15702,26 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15475,15 +15739,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:48 GMT
+      - Mon, 24 Sep 2018 20:32:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64a0fff6-9df3-4b6b-a257-8757108b2262
+      - req-a365b349-b1f3-4583-a201-ce4a9e548418
       Content-Length:
       - '7278'
       Connection:
@@ -15495,7 +15759,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:48.405397Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:12.861009Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15574,10 +15838,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YoL06OQmRNiRi1lxXS3cHg"],
-        "issued_at": "2018-08-06T16:53:48.405466Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ckTy9G5nT3ufAOd757xDIA"],
+        "issued_at": "2018-09-24T20:32:12.861030Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -15592,7 +15856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -15603,419 +15867,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-797f1c01-d37b-4f00-9160-0292de872563
+      - req-95101a60-2677-41c2-8bed-35421cb0cb4e
       Date:
-      - Mon, 06 Aug 2018 16:53:48 GMT
+      - Mon, 24 Sep 2018 20:32:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-346d77ee-c2a6-4d71-8534-028f8d05d06c
-      Date:
-      - Mon, 06 Aug 2018 16:53:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:48 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0c21a3ad-142c-4f03-96fb-90dab23a51e4
-      Date:
-      - Mon, 06 Aug 2018 16:53:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.50.4", "end": "192.168.50.4"}, {"start":
-        "192.168.50.2", "end": "192.168.50.2"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
-        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-522fc6b5-dd98-478f-97ad-a9d97183e9ff
-      Date:
-      - Mon, 06 Aug 2018 16:53:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16092,20 +15949,559 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 28b4980640544b4d98bae4d003c2c399
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ceb6ae96-0ecd-47cb-8a39-272d3999639d
+      Date:
+      - Mon, 24 Sep 2018 20:32:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4c3172b5d634e589c6c91e9816061fb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cda352e4-d411-4464-b5df-f9cd282f6fc3
+      Date:
+      - Mon, 24 Sep 2018 20:32:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4c3172b5d634e589c6c91e9816061fb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e0381d41-1f11-4af9-9b7a-5342f85218cd
+      Date:
+      - Mon, 24 Sep 2018 20:32:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e4c3172b5d634e589c6c91e9816061fb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a3688696-071e-41b5-9f97-fdfe5b37629a
+      Date:
+      - Mon, 24 Sep 2018 20:32:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16123,15 +16519,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:49 GMT
+      - Mon, 24 Sep 2018 20:32:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9581232d-1c18-4da5-8a80-2acf32a48d2d
+      - req-6bf27147-fbc7-4ed4-9115-61f9e840dec9
       Content-Length:
       - '7265'
       Connection:
@@ -16143,7 +16539,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:49.754885Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:13.913966Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -16222,10 +16618,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["75BTQ5IkQVCmI0yRnqHwWw"],
-        "issued_at": "2018-08-06T16:53:49.754948Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GbsemH7RSSODSJqsbYrxAw"],
+        "issued_at": "2018-09-24T20:32:13.914002Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16240,7 +16636,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -16251,23 +16647,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-12921bda-cd27-44ff-9547-e58d62fe0c8e
+      - req-f01c9a03-8e87-4672-ba95-757016544cd6
       Date:
-      - Mon, 06 Aug 2018 16:53:50 GMT
+      - Mon, 24 Sep 2018 20:32:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16344,20 +16729,163 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fb6db1c6289a4639b339757a1311c5e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-15186856-2e3e-409d-826b-30be0ebd6923
+      Date:
+      - Mon, 24 Sep 2018 20:32:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -16372,7 +16900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -16383,13 +16911,78 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5cbbe2a3-1fbe-436b-9f2a-79ebedee280d
+      - req-bb5314b1-f154-404e-88ef-dbf18dff6a3f
       Date:
-      - Mon, 06 Aug 2018 16:53:50 GMT
+      - Mon, 24 Sep 2018 20:32:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -16400,6 +16993,194 @@ http_interactions:
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fb6db1c6289a4639b339757a1311c5e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-67e405fc-89db-4647-bbbd-46018bba9cd8
+      Date:
+      - Mon, 24 Sep 2018 20:32:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fb6db1c6289a4639b339757a1311c5e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7a1424fa-9630-4de2-95ff-7ffa40e276dd
+      Date:
+      - Mon, 24 Sep 2018 20:32:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16476,20 +17257,163 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fb6db1c6289a4639b339757a1311c5e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1ce5cfe0-150b-4502-8adb-18a62dc0f521
+      Date:
+      - Mon, 24 Sep 2018 20:32:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:32:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -16507,15 +17431,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:53:50 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8476aba2-6695-46de-9c4a-9f830fe0f11a
+      - req-440af5f5-73ac-404a-a614-9ee433786a25
       Content-Length:
       - '7278'
       Connection:
@@ -16527,7 +17451,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:53:50.915023Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:15.136337Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16606,10 +17530,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nhQR-sLxS32WUDUDyczynw"],
-        "issued_at": "2018-08-06T16:53:50.915085Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Fe8Sq-hAS6WEjwDhpQL7-Q"],
+        "issued_at": "2018-09-24T20:32:15.136369Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -16624,7 +17548,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -16635,23 +17559,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c96af4fa-7270-48f1-a5f3-521754e3eaad
+      - req-68ac7302-e7dc-46cc-87bd-f5f7190697d8
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16728,23 +17641,34 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
     body:
       encoding: US-ASCII
       string: ''
@@ -16756,7 +17680,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -16767,23 +17691,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d58925ab-5a5e-4057-98d6-cc587f278aa6
+      - req-be02b218-10b0-4800-81fa-107518ffd819
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -16860,20 +17773,31 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16888,7 +17812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -16899,9 +17823,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5e152ddc-dc50-492f-84d1-99d11af2f642
+      - req-cc791247-1a04-4b3b-b818-bfe69a655a88
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16943,7 +17867,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16958,7 +17882,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -16969,9 +17893,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ead26422-6717-4d25-ad14-f3858442f785
+      - req-7097c822-9661-4ef9-ac81-cb583ce2b12e
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17013,7 +17937,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17028,7 +17952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -17039,9 +17963,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0674c7db-cbcb-4ba3-917f-d1a052bd5e72
+      - req-5361615f-7a41-4a13-b39c-27025e3d616a
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17083,7 +18007,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17098,7 +18022,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -17109,9 +18033,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9a9f55e4-ce74-438a-835a-5897d93d5763
+      - req-4215b686-e350-4963-bde8-9ed818fda0a6
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17153,7 +18077,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17168,7 +18092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -17179,9 +18103,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-b53a5dc8-21be-4a56-9a46-8fa6c9318fbd
+      - req-bb7e025b-9b05-431d-81c4-a2948db6ac8a
       Date:
-      - Mon, 06 Aug 2018 16:53:51 GMT
+      - Mon, 24 Sep 2018 20:32:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17223,7 +18147,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17238,7 +18162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -17249,9 +18173,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4df98601-298c-4eec-acfb-7ebf9797eedb
+      - req-fdd4f8d7-eec5-49fe-8b26-b0a436d67175
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17293,7 +18217,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17308,7 +18232,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -17319,9 +18243,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-960c2be4-955e-4d4d-a7ff-734e5ad0afae
+      - req-b2b6d595-fe01-48f2-b57f-d85a49166abe
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17363,7 +18287,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17378,7 +18302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -17389,9 +18313,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-20685deb-14d7-4eec-928f-00ba001f4fbb
+      - req-92ad4c2c-1ddd-47fa-a3f1-1d765ab90aed
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17433,7 +18357,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17448,7 +18372,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -17459,9 +18383,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-24b9343c-9b23-4a10-9eef-0e0e18f8d87c
+      - req-1e30e873-b598-49db-87b5-e0e3f6cd1f56
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17503,7 +18427,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17518,7 +18442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -17529,9 +18453,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0613edb7-8480-4434-b065-228d9bbe55f8
+      - req-2c7ceb45-eb72-4aaf-8d90-7ba55a342ba4
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17573,7 +18497,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17588,7 +18512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -17599,9 +18523,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9352655d-5225-45d0-a60e-e8456bfcb7a3
+      - req-ee19b5f0-468f-47ae-a255-40ee40778b1e
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17643,7 +18567,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17658,7 +18582,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -17669,9 +18593,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-747d8523-447f-46ed-bd20-5037e0ae6ce7
+      - req-749fc039-bb02-4d34-b3e5-a8e2061678e6
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17713,7 +18637,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -17728,7 +18652,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -17739,9 +18663,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9fa37a95-5a36-473d-b56b-ec2ab25c3541
+      - req-2fa84df7-fb57-4b0d-b59d-b1efd1232d4a
       Date:
-      - Mon, 06 Aug 2018 16:53:52 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17783,7 +18707,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -17798,7 +18722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -17809,9 +18733,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2c90d0eb-1e96-4823-b50b-be74d2ced958
+      - req-d182b884-e03e-4f5c-baf5-476e5dae08fc
       Date:
-      - Mon, 06 Aug 2018 16:53:53 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -17853,7 +18777,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -17868,7 +18792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -17879,9 +18803,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4b3cacbf-2ddc-48ee-946e-79b18a574e9c
+      - req-5297d945-a27c-433d-bdab-450e3e456c05
       Date:
-      - Mon, 06 Aug 2018 16:53:53 GMT
+      - Mon, 24 Sep 2018 20:32:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18284,7 +19208,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -18299,7 +19223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -18310,9 +19234,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0ee409f6-06a5-472c-8d7c-cbcc631004de
+      - req-65e5030d-c810-405b-a62f-8a8caf95699b
       Date:
-      - Mon, 06 Aug 2018 16:53:53 GMT
+      - Mon, 24 Sep 2018 20:32:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18715,7 +19639,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18730,7 +19654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -18741,9 +19665,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ac65dbc0-a00a-4456-961d-af25016d3165
+      - req-a6f98206-4258-4723-b2fd-0f1d8354a47c
       Date:
-      - Mon, 06 Aug 2018 16:53:53 GMT
+      - Mon, 24 Sep 2018 20:32:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19146,7 +20070,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19161,7 +20085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -19172,9 +20096,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-faaed306-d480-4d8e-802e-43c1c13f2ce0
+      - req-1af53948-71f2-485d-8531-07e2d816e10b
       Date:
-      - Mon, 06 Aug 2018 16:53:54 GMT
+      - Mon, 24 Sep 2018 20:32:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19577,7 +20501,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19592,7 +20516,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -19603,9 +20527,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-190207d7-fc35-4481-966f-7772ec88e0e9
+      - req-c9ae5a22-3a05-4a7b-b994-fa866fdb4ea4
       Date:
-      - Mon, 06 Aug 2018 16:53:54 GMT
+      - Mon, 24 Sep 2018 20:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20008,7 +20932,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20023,7 +20947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -20034,9 +20958,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f5ee8c9c-80b4-4971-82d8-1fa27f9cfd06
+      - req-1a48bcf5-a49e-4cb4-8729-25412566694f
       Date:
-      - Mon, 06 Aug 2018 16:53:54 GMT
+      - Mon, 24 Sep 2018 20:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20439,7 +21363,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20454,7 +21378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -20465,9 +21389,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dfd860c3-b25c-4b00-8a59-ab8a6cc0344a
+      - req-f89f318e-d51b-481f-af5a-32ada48c0a3a
       Date:
-      - Mon, 06 Aug 2018 16:53:55 GMT
+      - Mon, 24 Sep 2018 20:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20870,7 +21794,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20885,7 +21809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -20896,9 +21820,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-562ffbbc-06ef-4819-9469-85f6504a5c75
+      - req-ab0a1d8f-2968-4eb9-a1ed-89d5e33c3ee9
       Date:
-      - Mon, 06 Aug 2018 16:53:55 GMT
+      - Mon, 24 Sep 2018 20:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21301,7 +22225,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21316,7 +22240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -21327,9 +22251,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ceaa64a3-dcdf-470b-9afe-da034ef298df
+      - req-59ee31e7-907f-4280-8193-e6211639f8a1
       Date:
-      - Mon, 06 Aug 2018 16:53:55 GMT
+      - Mon, 24 Sep 2018 20:32:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21732,7 +22656,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21747,7 +22671,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -21758,9 +22682,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f7cd5617-e09b-4636-ab18-db6b4572aa88
+      - req-52a46ec2-b4db-4aa8-b324-c062dc38d4e6
       Date:
-      - Mon, 06 Aug 2018 16:53:55 GMT
+      - Mon, 24 Sep 2018 20:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22163,7 +23087,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -22178,7 +23102,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -22189,9 +23113,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-87dfdf14-cd3f-4114-9f2f-ef516d5de6f3
+      - req-2230e5fd-4ffd-4b02-a11e-c79cfa8dd7b3
       Date:
-      - Mon, 06 Aug 2018 16:53:56 GMT
+      - Mon, 24 Sep 2018 20:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22594,7 +23518,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22609,7 +23533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -22620,9 +23544,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0e5c5f41-6d5d-4e6a-a1bb-05d088390724
+      - req-7aeee351-e8e4-443e-99d3-6058eab569e0
       Date:
-      - Mon, 06 Aug 2018 16:53:56 GMT
+      - Mon, 24 Sep 2018 20:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23025,7 +23949,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -23040,7 +23964,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -23051,9 +23975,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c44055c6-4afb-423d-9cdd-b7b4c6e58bcf
+      - req-01b15790-59a8-4531-992c-f766081ef91b
       Date:
-      - Mon, 06 Aug 2018 16:53:56 GMT
+      - Mon, 24 Sep 2018 20:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23456,7 +24380,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -23471,7 +24395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -23482,9 +24406,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-d2123073-4e68-4b4a-9128-1c7cd5fd097b
+      - req-f234843d-5e97-4a0b-89ee-08e9b254fbdb
       Date:
-      - Mon, 06 Aug 2018 16:53:56 GMT
+      - Mon, 24 Sep 2018 20:32:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -23887,7 +24811,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23902,7 +24826,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -23913,9 +24837,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-92c70d6d-3345-4617-8a4a-9a8939313830
+      - req-85a3bdc5-936d-44b6-855e-0f6610fa287b
       Date:
-      - Mon, 06 Aug 2018 16:53:57 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23947,7 +24871,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23962,7 +24886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -23973,9 +24897,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d2b6e1b8-5b52-4774-a635-f878ca90e385
+      - req-e2e48e3d-e614-40bf-b167-24ad441a711a
       Date:
-      - Mon, 06 Aug 2018 16:53:57 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24007,7 +24931,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24022,7 +24946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -24033,9 +24957,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e40e6668-748b-41b6-ac96-11d1ac565160
+      - req-a4b94efa-8a0d-4c48-a39b-982eef944ea4
       Date:
-      - Mon, 06 Aug 2018 16:53:57 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24067,7 +24991,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24082,7 +25006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -24093,9 +25017,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a819e28c-ce94-4f27-b23d-6b3055811ee1
+      - req-f384b185-2e74-4cb8-89ba-404fa2f182d3
       Date:
-      - Mon, 06 Aug 2018 16:53:57 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24127,7 +25051,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24142,7 +25066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -24153,9 +25077,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-eea6234a-cd5e-42ef-a414-a8b9fe05c685
+      - req-bcb482c2-6d0e-4ab1-b1bd-eeb3e46423dc
       Date:
-      - Mon, 06 Aug 2018 16:53:57 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24187,7 +25111,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24202,7 +25126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -24213,9 +25137,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-1e5f4322-077c-43b6-a7d4-4a016acb7875
+      - req-53381ba6-54f1-4fa0-8612-8dfe4006bbfc
       Date:
-      - Mon, 06 Aug 2018 16:53:58 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24247,7 +25171,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24262,7 +25186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -24273,9 +25197,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5fa12401-620f-4181-a694-ca557a1fea2f
+      - req-1527e24a-202e-49a2-bee5-e94abda6541a
       Date:
-      - Mon, 06 Aug 2018 16:53:58 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24307,7 +25231,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24322,7 +25246,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -24333,9 +25257,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3f4a615b-29ee-4992-ad88-73b20949f768
+      - req-8be3ee7c-4585-4b10-8081-f095bfc59e37
       Date:
-      - Mon, 06 Aug 2018 16:53:58 GMT
+      - Mon, 24 Sep 2018 20:32:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24367,7 +25291,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24382,7 +25306,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -24393,9 +25317,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-16b7fad1-6500-4efd-9a52-24c826fb491a
+      - req-f8f9b260-d3d9-46d9-a850-9d846827ad55
       Date:
-      - Mon, 06 Aug 2018 16:53:59 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24427,7 +25351,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24442,7 +25366,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -24453,9 +25377,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-45b8abf1-c617-4c5c-9f38-2c90d671c475
+      - req-973b6ea6-c427-4839-a097-70325e1c63bd
       Date:
-      - Mon, 06 Aug 2018 16:53:59 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24487,7 +25411,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:53:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24502,7 +25426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -24513,9 +25437,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5c1f9efc-d7be-4354-aa44-b214e142b639
+      - req-7f19b101-85b3-4f93-9e06-d267cf3f63a7
       Date:
-      - Mon, 06 Aug 2018 16:53:59 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24547,7 +25471,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24562,7 +25486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -24573,9 +25497,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cf59675d-3d59-4168-9aab-c4ac0de0ffb1
+      - req-5e4c5b82-9c01-4941-9046-78124b929d74
       Date:
-      - Mon, 06 Aug 2018 16:54:00 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24607,7 +25531,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -24622,7 +25546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -24633,9 +25557,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-0d283072-2bfc-4888-a5aa-d5ab728b5212
+      - req-deb2521f-9346-4940-a340-846d1f67404b
       Date:
-      - Mon, 06 Aug 2018 16:54:00 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24667,7 +25591,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -24682,7 +25606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -24693,9 +25617,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8597ee44-5f1b-4442-bf4d-610f21f2a95c
+      - req-a8b1914d-f866-4dad-ba78-ea79be65c9ca
       Date:
-      - Mon, 06 Aug 2018 16:54:01 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -24727,7 +25651,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24742,7 +25666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -24753,9 +25677,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-d7c1fbcb-b1a2-4f49-aba3-f67395153146
+      - req-41dc73b2-bb95-45af-a037-b00590f9d61f
       Date:
-      - Mon, 06 Aug 2018 16:54:01 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24790,7 +25714,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24805,7 +25729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -24816,9 +25740,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9c22d83e-bb01-40ad-bece-15d01e3ffc33
+      - req-8e56ba0d-fcfe-4ed5-bd75-f2cf465b48b7
       Date:
-      - Mon, 06 Aug 2018 16:54:01 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24861,7 +25785,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24876,7 +25800,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -24887,9 +25811,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-fbfc31ad-273b-43b9-97fd-9801a95cdbc6
+      - req-da843230-c48f-4832-892e-f58ed78e80d4
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24932,7 +25856,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24947,7 +25871,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -24958,9 +25882,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-373d0131-b412-4c33-b589-3f99bcb1ede5
+      - req-3c84ffbf-9fc3-4408-9b39-94c5a7c813d1
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25067,7 +25991,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25082,7 +26006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -25093,9 +26017,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f5b3a7e4-e18b-4660-b59c-a73595b037a3
+      - req-71001cfe-0caa-4dd3-8a64-ce83c2009d6e
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25137,7 +26061,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25152,7 +26076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c094de13176e432cbddba9ca9b23083d
+      - f0536b0cefe44275b19da7b1bab03959
   response:
     status:
       code: 200
@@ -25163,15 +26087,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-a76f4094-758d-4a6f-bb75-30912d752a02
+      - req-633d9d83-cdb0-4d0f-af04-47c50f8d980f
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25186,7 +26110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25197,9 +26121,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-76eadcdf-672e-4734-ad96-cf814d363385
+      - req-56bbb0e5-ce94-4303-a724-d24c8809c4a1
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25234,7 +26158,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25249,7 +26173,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25260,9 +26184,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a42c7fb4-b25e-4a28-ba3c-18c3536d70ee
+      - req-4d4d3808-00c5-4f2b-a903-8b8497001b92
       Date:
-      - Mon, 06 Aug 2018 16:54:02 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25305,7 +26229,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25320,7 +26244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25331,9 +26255,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a864d839-4731-4dd2-8b5d-b2e41ab23172
+      - req-7969849d-1cbe-452d-a937-1d038371e287
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25376,7 +26300,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25391,7 +26315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25402,9 +26326,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-1b187bb7-d189-4a2c-9688-662284816881
+      - req-51b2ec09-ecbd-4b98-84ba-7031b57b23d8
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25511,7 +26435,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25526,7 +26450,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25537,9 +26461,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cb1f74b0-fd7f-4897-ab59-c2b43379eca3
+      - req-16f8587e-e8ef-4fd5-9ff1-19de73f677b5
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25581,7 +26505,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25596,7 +26520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be127882bd1d479c8d6ed3a62fc5a248
+      - a86bcfa4dc0b4035b82e31ac13bc5526
   response:
     status:
       code: 200
@@ -25607,15 +26531,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-2ad64059-494a-4b0a-b5e3-32158949a9fe
+      - req-fd3b7868-e4c1-4051-8c00-e480b00114aa
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25630,7 +26554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -25641,9 +26565,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-c85227a0-739e-4dc7-bea3-f9b88080b93a
+      - req-55bc1324-2a28-494a-a9eb-a3d26821ce13
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25678,7 +26602,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25693,7 +26617,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -25704,9 +26628,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a392ef72-d685-4fac-bfa4-c2ed4971fa86
+      - req-f061f930-0fc7-4e6b-9043-49d5a27e0377
       Date:
-      - Mon, 06 Aug 2018 16:54:03 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25749,7 +26673,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25764,7 +26688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -25775,9 +26699,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-02c50692-b101-40fd-84a2-9e5c96016212
+      - req-aa17241c-166b-4653-84fc-93b96f7e07f8
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25820,7 +26744,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25835,7 +26759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -25846,9 +26770,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-2621dfe3-6a47-416e-b457-7c9303c974b5
+      - req-4855606f-9c20-4aa1-9f58-3203b67ba034
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25955,7 +26879,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25970,7 +26894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -25981,9 +26905,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9fb571da-f470-48f1-93f9-e2cb18cf5e6a
+      - req-c7686335-5960-41b3-b092-b4155a00c542
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26025,7 +26949,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26040,7 +26964,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb5bf27cdbc64881b8b55f7c86d53641
+      - 79aec743bf5b4f3ba2ec89e01dff7e76
   response:
     status:
       code: 200
@@ -26051,15 +26975,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-a09bb8ce-eee7-4815-b931-e25a0e8703b2
+      - req-8d3696d2-9e8b-4273-95dc-ad7cf0bffabc
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26074,7 +26998,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26085,9 +27009,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-dc71a30a-84c6-4194-82f7-ae2baebb8195
+      - req-f77d44cd-5a16-4fe6-8f3f-dd2767ce0a68
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26122,7 +27046,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26137,7 +27061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26148,9 +27072,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9ecf0fda-2619-418f-bfc0-2a90ea52ff5c
+      - req-d6a31f6b-7778-44b5-a306-683b92f9288f
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26193,7 +27117,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26208,7 +27132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26219,9 +27143,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a1c3ff3d-385a-4280-9d94-f06acb6724b9
+      - req-c050e942-2c70-442d-92fc-6331226efb32
       Date:
-      - Mon, 06 Aug 2018 16:54:04 GMT
+      - Mon, 24 Sep 2018 20:32:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26264,7 +27188,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26279,7 +27203,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26290,9 +27214,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-8742f7cd-05fd-482e-bc29-718b4d6f4f1c
+      - req-1f78e6d3-0f8b-4bef-b7b4-f09e8831b802
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26399,7 +27323,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26414,7 +27338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26425,9 +27349,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-78f3007c-746f-4c83-a557-14ad0ee38c77
+      - req-2789ba43-34ec-4f94-bc97-92f386a7a1a3
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26469,7 +27393,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26484,7 +27408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2715c712388345c1abef5ac7c0c996c5
+      - 28b4980640544b4d98bae4d003c2c399
   response:
     status:
       code: 200
@@ -26495,15 +27419,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-be000fb6-4d4a-42c8-993f-f6a2a09eed99
+      - req-87a0641f-d541-46c7-a7b5-d48ac9b8d3b7
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26518,7 +27442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26529,9 +27453,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-55f88b43-8aaa-4668-b5f2-09743bee5f2e
+      - req-cab22e95-7916-4fb8-bbd4-833e94b8e368
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26566,7 +27490,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26581,7 +27505,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26592,9 +27516,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d4483eea-170f-4c0a-b43d-f5dd18d5d51f
+      - req-3314b2eb-d70d-417b-ac50-d04832cb6d35
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26637,7 +27561,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26652,7 +27576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26663,9 +27587,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b09506e9-5b6b-4f00-bf24-bdb80623f98a
+      - req-b19c4b8a-6017-4d61-9aed-1c7f1193ef40
       Date:
-      - Mon, 06 Aug 2018 16:54:05 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26708,7 +27632,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26723,7 +27647,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26734,9 +27658,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-3503a788-e07b-4c34-8444-7b7555d04965
+      - req-c86874b5-4d67-4fe2-8f3b-0382d1ac5e14
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26843,7 +27767,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26858,7 +27782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26869,9 +27793,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-209561b2-0da5-4f97-ae7a-2d1c4c1e73d0
+      - req-ef3a6389-9133-43c8-a1a3-63a11a9a605f
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26913,7 +27837,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26928,7 +27852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57f62534d5714cb08da5daa158475eee
+      - e4c3172b5d634e589c6c91e9816061fb
   response:
     status:
       code: 200
@@ -26939,15 +27863,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-1599e057-18a5-42a7-917a-67ffc7bffb9a
+      - req-f7784387-58fb-46d9-85e8-02f241ad3d8d
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26962,7 +27886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -26973,9 +27897,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-e7f0d266-353b-44da-b669-a9d25b14c234
+      - req-e33d5721-17ad-44ad-95ec-71c501e96ed8
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27010,7 +27934,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27025,7 +27949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -27036,9 +27960,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c933ba08-abe2-47a1-b8ee-d87f1874166b
+      - req-6b660490-dad0-4fc1-80e0-3b4a2d794662
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27081,7 +28005,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27096,7 +28020,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -27107,9 +28031,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c8d074b0-e82f-49d3-89ee-d8e9891afa82
+      - req-87df6980-1d1f-414a-8606-c702ae8886bb
       Date:
-      - Mon, 06 Aug 2018 16:54:06 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27152,7 +28076,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27167,7 +28091,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -27178,9 +28102,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-6a34d0f3-87df-4c29-b180-6276002b9417
+      - req-fc5f2d95-5d69-428b-aad7-8e5b7ca30e78
       Date:
-      - Mon, 06 Aug 2018 16:54:07 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27287,7 +28211,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27302,7 +28226,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -27313,9 +28237,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-97875884-3e53-4f58-a2f7-53eb4f704921
+      - req-62c1cf3a-2a4a-4bb2-92ea-1929e3c4e83d
       Date:
-      - Mon, 06 Aug 2018 16:54:07 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27357,7 +28281,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27372,7 +28296,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40a1f139aad841d88bac4e6f3caed542
+      - fb6db1c6289a4639b339757a1311c5e2
   response:
     status:
       code: 200
@@ -27383,15 +28307,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-fa867d3f-28a9-4e9d-af0c-4e57627e70b9
+      - req-affe347e-5cd8-49a1-b5ea-5fc0f9271e2e
       Date:
-      - Mon, 06 Aug 2018 16:54:07 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -27406,7 +28330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27417,9 +28341,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2308ef19-ea6e-488c-a19b-ae6533b2c552
+      - req-13b509d7-c968-419e-97b5-f493fce94a9c
       Date:
-      - Mon, 06 Aug 2018 16:54:07 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -27454,7 +28378,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -27469,7 +28393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27480,9 +28404,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bc1c7197-1d10-438a-8077-99c8ff555f79
+      - req-6599f988-9273-4fb6-af67-bbecac4c027f
       Date:
-      - Mon, 06 Aug 2018 16:54:08 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -27525,7 +28449,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -27540,7 +28464,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27551,9 +28475,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e53d6639-2aaf-489b-a574-641e910a241f
+      - req-17797d9a-8318-4dc0-837c-7d0e43dbaf82
       Date:
-      - Mon, 06 Aug 2018 16:54:08 GMT
+      - Mon, 24 Sep 2018 20:32:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -27596,7 +28520,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -27611,7 +28535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27622,9 +28546,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-56c5a776-7682-479a-b5e1-6079f6d2335c
+      - req-c208c960-2d0e-4ad8-8eea-248bd8a7077c
       Date:
-      - Mon, 06 Aug 2018 16:54:08 GMT
+      - Mon, 24 Sep 2018 20:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -27731,7 +28655,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -27746,7 +28670,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27757,9 +28681,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-df67c15d-37f5-4db7-87c7-f2c6d1b21c1a
+      - req-abf2342b-2c66-4064-888d-92c9d8a64582
       Date:
-      - Mon, 06 Aug 2018 16:54:08 GMT
+      - Mon, 24 Sep 2018 20:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -27801,7 +28725,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -27816,7 +28740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d9cef21ce994d10bf4c33b826c45976
+      - 6939679fb3184b34b85916a54aef8573
   response:
     status:
       code: 200
@@ -27827,15 +28751,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-0e672300-ec4d-46ce-850c-63da0d1c88b5
+      - req-f66aadef-5ad8-462d-9298-528b7e60b8d0
       Date:
-      - Mon, 06 Aug 2018 16:54:08 GMT
+      - Mon, 24 Sep 2018 20:32:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27853,15 +28777,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:09 GMT
+      - Mon, 24 Sep 2018 20:32:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 28bd0ce6f6d74a029385d907e025474b
+      - 232acced0118466081a7187e52c42734
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b2959247-4bfd-4825-841f-ee6e71b2e5e2
+      - req-9c2ec2e0-df4b-4438-a786-df720ebaa2d8
       Content-Length:
       - '7311'
       Connection:
@@ -27873,7 +28797,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:09.601375Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:26.909175Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27952,10 +28876,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["alHb0YywRCG9kS0a0gQHqQ"],
-        "issued_at": "2018-08-06T16:54:09.601445Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hl8CbWOtSU-KC9VciEnG7Q"],
+        "issued_at": "2018-09-24T20:32:26.909209Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27973,15 +28897,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:09 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-84b03c4c-5cbe-44e4-882b-7a05824a9073
+      - req-e7011332-42f5-4b79-b654-a36f198d4ef9
       Content-Length:
       - '7311'
       Connection:
@@ -27993,7 +28917,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:09.953373Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:27.136166Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28072,10 +28996,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ii0-5ezrQhG1q6DyDmxxCQ"],
-        "issued_at": "2018-08-06T16:54:09.953452Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z3NJm72XTHqWdm2hPttdkg"],
+        "issued_at": "2018-09-24T20:32:27.136203Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28093,15 +29017,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:10 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 77d99277d26140a5947e319cd25c0f55
+      - f3a41d8652d94239b6e65293f3a9945f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c9e5bf21-e4cd-4baa-b626-b040390a254f
+      - req-4254d65b-2e22-4138-a6c0-6908a5accf17
       Content-Length:
       - '297'
       Connection:
@@ -28110,12 +29034,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:10.182532Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:32:27.299357Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WhcmYhrFRiOirDnPNFAwHg"],
-        "issued_at": "2018-08-06T16:54:10.182592Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["13lisusWRs6UNK1gpYYjIw"],
+        "issued_at": "2018-09-24T20:32:27.299376Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -28130,20 +29054,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d99277d26140a5947e319cd25c0f55
+      - f3a41d8652d94239b6e65293f3a9945f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:10 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f1fe07de-f3e4-4a40-bd61-f05e50f1252b
+      - req-411f37b5-d8d6-4514-b40c-aab25b6588b6
       Content-Length:
       - '2457'
       Connection:
@@ -28176,13 +29100,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"77d99277d26140a5947e319cd25c0f55"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"f3a41d8652d94239b6e65293f3a9945f"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -28194,15 +29118,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:10 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 51a043bb55ea4e149f920f91e2918b43
+      - 1735ae030ef7404482a580a89e440c9b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd059e29-8b2f-47ca-8ae9-920e4668b12a
+      - req-ce66e22b-5af5-4276-9641-bb5c535f6907
       Content-Length:
       - '7313'
       Connection:
@@ -28214,7 +29138,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:10.182532Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:27.299357Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28293,10 +29217,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fqNxJDZCRv6ZaKiVkfmq0g",
-        "WhcmYhrFRiOirDnPNFAwHg"], "issued_at": "2018-08-06T16:54:10.713706Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["37MqQ1UtQGmpZYrOu_sIvg",
+        "13lisusWRs6UNK1gpYYjIw"], "issued_at": "2018-09-24T20:32:27.602845Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -28311,20 +29235,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51a043bb55ea4e149f920f91e2918b43
+      - 1735ae030ef7404482a580a89e440c9b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:10 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dc8c5425-cd9c-4b86-a0a0-b8ee19413f55
+      - req-3a2a1e8f-e0b1-4324-9762-c03d308379ec
       Content-Length:
       - '2179'
       Connection:
@@ -28357,7 +29281,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28375,15 +29299,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:11 GMT
+      - Mon, 24 Sep 2018 20:32:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a988a30f1125459cb41d6831843424b7
+      - ae8925bff67b4781b90b6505bb32f9da
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3efaf729-c9df-4fb6-9a1c-b5dfd5e8acfb
+      - req-80a9a9ec-85d3-4520-aae8-59581ecabbe7
       Content-Length:
       - '7278'
       Connection:
@@ -28395,7 +29319,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:11.228241Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:27.937203Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28474,10 +29398,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["54EJy8jpQPmFtQxI7uU__A"],
-        "issued_at": "2018-08-06T16:54:11.228310Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qZl_j9PATQ-S-JONa1nzMQ"],
+        "issued_at": "2018-09-24T20:32:27.937222Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28495,15 +29419,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:11 GMT
+      - Mon, 24 Sep 2018 20:32:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bb7895b9f2d94828898115d5a7503b1e
+      - 90ca83bf692a4a6fb8276be2d4b94d7b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ff11d22d-f6b7-4c84-b81f-df692814acd7
+      - req-b25c5f9d-a490-49f1-8b93-b20148513707
       Content-Length:
       - '7278'
       Connection:
@@ -28515,7 +29439,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:11.565448Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:28.138000Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28594,10 +29518,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["00--bdfhRECPJLsP0JTIqA"],
-        "issued_at": "2018-08-06T16:54:11.565517Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XfR9rQDaSg-CifbpZJuoEQ"],
+        "issued_at": "2018-09-24T20:32:28.138021Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28615,15 +29539,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:11 GMT
+      - Mon, 24 Sep 2018 20:32:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0737de6eb38e466ebdc236f555fd4989
+      - 871f5fcd99294cea91b7f1ba23f04e1d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8ccc289b-b4f2-4b60-8fee-6fa9610516d2
+      - req-4f249591-8ee5-4768-bd7a-decaf95a9a36
       Content-Length:
       - '7264'
       Connection:
@@ -28635,7 +29559,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:11.908513Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:28.335868Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28714,10 +29638,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wP4NnVe-Sg-smh_hKiPgAg"],
-        "issued_at": "2018-08-06T16:54:11.908576Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CT_oV0UcSTmRnurEfQdFtg"],
+        "issued_at": "2018-09-24T20:32:28.335889Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28735,15 +29659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:12 GMT
+      - Mon, 24 Sep 2018 20:32:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc116c56bf0242608e57fdcc39f3b1da
+      - bf98a94153a54154b719629e46223056
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-69c71bda-ff41-4b70-b221-c233161a290f
+      - req-45f52dd6-3f3c-4b37-9c4f-e5e6a4069117
       Content-Length:
       - '7278'
       Connection:
@@ -28755,7 +29679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:12.236471Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:28.534031Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -28834,10 +29758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nDFAnlvtSCmz4uZRUrZffA"],
-        "issued_at": "2018-08-06T16:54:12.236535Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rro5MvGyTEK3RiaJK-7zJw"],
+        "issued_at": "2018-09-24T20:32:28.534050Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28855,15 +29779,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:12 GMT
+      - Mon, 24 Sep 2018 20:32:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5fbd599237ca4f20be16ebe5e2059551
+      - 8489a3c2141a4cbf944bb762eed164dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-30b9b995-d09e-4840-867e-ab026e371097
+      - req-bf0a51cc-0901-46b8-87d2-9575ac792e9c
       Content-Length:
       - '7265'
       Connection:
@@ -28875,7 +29799,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:12.590035Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:28.729645Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -28954,10 +29878,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TbS22RXCRqOoPf-tR6248Q"],
-        "issued_at": "2018-08-06T16:54:12.590158Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YPtkv89zQtCuO1vMxNDtbA"],
+        "issued_at": "2018-09-24T20:32:28.729664Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -28975,15 +29899,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:12 GMT
+      - Mon, 24 Sep 2018 20:32:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 83144d2e24654879986a80c7c24ef934
+      - bb981e1621c24291bf4780bcdb172db8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6c1042a1-f927-4d45-9956-8888bfe4e522
+      - req-1848b01d-5bf4-4061-b9e8-54d4f937b4b7
       Content-Length:
       - '7278'
       Connection:
@@ -28995,7 +29919,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:12.958591Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:28.923624Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29074,10 +29998,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nd254ObzT2WxeI0pD_37WQ"],
-        "issued_at": "2018-08-06T16:54:12.958656Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QGIxRMLHSlK7JCDkLrzWNw"],
+        "issued_at": "2018-09-24T20:32:28.923643Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29095,15 +30019,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:13 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cc731966-ea78-4246-a055-b1f53a0a8147
+      - req-db0998f2-0e55-4cc6-9b46-e0d15d46b5fb
       Content-Length:
       - '7278'
       Connection:
@@ -29115,7 +30039,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:13.261364Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:29.142550Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29194,10 +30118,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kDNPlHdNSzme43ZYbSiVfw"],
-        "issued_at": "2018-08-06T16:54:13.261421Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["q6EwhtjxSCK3Pa0n1YJ5-Q"],
+        "issued_at": "2018-09-24T20:32:29.142575Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -29212,27 +30136,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-50c08224-f1aa-4a32-bccc-18bbfd5df347
+      - req-513ee7d1-4afe-4800-b121-37953f5b4849
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-50c08224-f1aa-4a32-bccc-18bbfd5df347
+      - req-513ee7d1-4afe-4800-b121-37953f5b4849
       Date:
-      - Mon, 06 Aug 2018 16:54:13 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29250,15 +30174,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:13 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-202cb36c-790b-4ede-b332-f85aa589839a
+      - req-2ad3e208-1652-4d72-aa2b-ff74862e1da4
       Content-Length:
       - '7278'
       Connection:
@@ -29270,7 +30194,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:13.871380Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:29.464616Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29349,10 +30273,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PX4kYBr_RS-TVC_psPKSVA"],
-        "issued_at": "2018-08-06T16:54:13.871444Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QGeYvavsS4ueke4X3Em5rg"],
+        "issued_at": "2018-09-24T20:32:29.464636Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -29367,27 +30291,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c26a57a3-970b-441d-989e-ab590c2409cc
+      - req-cee9923c-1b4e-494c-a592-f4f8e7b22520
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c26a57a3-970b-441d-989e-ab590c2409cc
+      - req-cee9923c-1b4e-494c-a592-f4f8e7b22520
       Date:
-      - Mon, 06 Aug 2018 16:54:14 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29405,15 +30329,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:14 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c05121f9-2c9d-4ac0-b1f1-9fc6eaed2914
+      - req-d5a9f3d6-e791-4860-bd17-a553df7fb612
       Content-Length:
       - '7264'
       Connection:
@@ -29425,7 +30349,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:14.553513Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:29.792766Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29504,10 +30428,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jw6DbFt_R7GD_alncm7Viw"],
-        "issued_at": "2018-08-06T16:54:14.553599Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2BJj5hJ9RZWWn-9xuelCpA"],
+        "issued_at": "2018-09-24T20:32:29.792789Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -29522,22 +30446,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94263cbc-7715-4f44-870b-f8c04e61e788
+      - req-eb862aa2-a232-482f-999c-7c9684c8629d
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-94263cbc-7715-4f44-870b-f8c04e61e788
+      - req-eb862aa2-a232-482f-999c-7c9684c8629d
       Date:
-      - Mon, 06 Aug 2018 16:54:15 GMT
+      - Mon, 24 Sep 2018 20:32:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -29570,7 +30494,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -29585,22 +30509,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d646bb07-5709-49dd-95b3-36a8890cc6cd
+      - req-8793718b-a7ab-4722-b5c0-dbef97fbcdca
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-d646bb07-5709-49dd-95b3-36a8890cc6cd
+      - req-8793718b-a7ab-4722-b5c0-dbef97fbcdca
       Date:
-      - Mon, 06 Aug 2018 16:54:15 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -29641,7 +30565,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -29656,22 +30580,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b230377-8ba1-4519-bbb7-fb3a6386c335
+      - req-ee10ec17-fd84-42d7-ad89-f4f124117302
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-8b230377-8ba1-4519-bbb7-fb3a6386c335
+      - req-ee10ec17-fd84-42d7-ad89-f4f124117302
       Date:
-      - Mon, 06 Aug 2018 16:54:15 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -29705,7 +30629,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -29720,27 +30644,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f88ba29-8d51-41c3-8558-b8274c187dae
+      - req-b768dc74-fc5b-4956-b124-c6f0c155858d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2f88ba29-8d51-41c3-8558-b8274c187dae
+      - req-b768dc74-fc5b-4956-b124-c6f0c155858d
       Date:
-      - Mon, 06 Aug 2018 16:54:16 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29758,15 +30682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:16 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03972ebb-4174-452d-b8f7-88d7a7f5d0d2
+      - req-6ea1c180-8127-4b51-ae0d-30dd5209a67e
       Content-Length:
       - '7278'
       Connection:
@@ -29778,7 +30702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:16.866488Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:30.650878Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -29857,10 +30781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["okJewQnFRP6-F2EGPo7GRQ"],
-        "issued_at": "2018-08-06T16:54:16.866568Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C8l8emDARc-VD1NByy_lNQ"],
+        "issued_at": "2018-09-24T20:32:30.650903Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -29875,27 +30799,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3e36ebc5-506b-40de-9a39-06bf3c64c2c1
+      - req-4773e559-c5f3-419c-8f3c-494112c9cce7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3e36ebc5-506b-40de-9a39-06bf3c64c2c1
+      - req-4773e559-c5f3-419c-8f3c-494112c9cce7
       Date:
-      - Mon, 06 Aug 2018 16:54:17 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -29910,27 +30834,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9df4c4f0-31b6-4058-860e-0cd35fcf58bd
+      - req-289d062c-9bfe-4d74-9240-2232872eb84b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9df4c4f0-31b6-4058-860e-0cd35fcf58bd
+      - req-289d062c-9bfe-4d74-9240-2232872eb84b
       Date:
-      - Mon, 06 Aug 2018 16:54:17 GMT
+      - Mon, 24 Sep 2018 20:32:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29948,15 +30872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:17 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f33ddad3-9c71-40f0-9765-c3ab5ff09bd1
+      - req-eee6b1f3-34bc-4d7c-8635-06573b9f74f7
       Content-Length:
       - '7265'
       Connection:
@@ -29968,7 +30892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:17.734737Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:31.132298Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30047,10 +30971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kX7nc3m_Qz2a7TWh4FZVuQ"],
-        "issued_at": "2018-08-06T16:54:17.734804Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M-JdXcXhTvS5SjFLAo1AXQ"],
+        "issued_at": "2018-09-24T20:32:31.132320Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -30065,27 +30989,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aaf0cd57-6ba1-468f-bee0-af2ee57d1e5b
+      - req-e336688e-a1f4-4d5f-bfcf-4e6dbd60ddb4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aaf0cd57-6ba1-468f-bee0-af2ee57d1e5b
+      - req-e336688e-a1f4-4d5f-bfcf-4e6dbd60ddb4
       Date:
-      - Mon, 06 Aug 2018 16:54:18 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30103,15 +31027,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:18 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78092eb8-0455-4a74-8de5-82fc18908989
+      - req-499a1060-af8c-4465-96aa-23a53dee36b4
       Content-Length:
       - '7278'
       Connection:
@@ -30123,7 +31047,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:18.330858Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:31.457107Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30202,10 +31126,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dw6orGGkQ--5-8TFKieihQ"],
-        "issued_at": "2018-08-06T16:54:18.330925Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["261O8AV5T1KJHRlh6S6veg"],
+        "issued_at": "2018-09-24T20:32:31.457135Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -30220,27 +31144,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9f75c94-7d5f-4ef4-97eb-b78418689252
+      - req-a3e6f521-80b3-4d83-bef3-5df05dcf3ace
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e9f75c94-7d5f-4ef4-97eb-b78418689252
+      - req-a3e6f521-80b3-4d83-bef3-5df05dcf3ace
       Date:
-      - Mon, 06 Aug 2018 16:54:18 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -30255,27 +31179,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b1040b05-4423-48ce-8a3f-05184d52e8b8
+      - req-6a0a5372-00cd-4b55-b739-7ce75205ac58
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b1040b05-4423-48ce-8a3f-05184d52e8b8
+      - req-6a0a5372-00cd-4b55-b739-7ce75205ac58
       Date:
-      - Mon, 06 Aug 2018 16:54:18 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -30290,27 +31214,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2aa40f4-198a-4545-b4f6-77a2bd409356
+      - req-f864c6c0-86a6-4ed9-8a06-7036107b923b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2aa40f4-198a-4545-b4f6-77a2bd409356
+      - req-f864c6c0-86a6-4ed9-8a06-7036107b923b
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -30325,27 +31249,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-763e4060-893d-4342-8c39-5b2276244d90
+      - req-28024aba-1e9f-4bfe-a8b8-237475f73edc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-763e4060-893d-4342-8c39-5b2276244d90
+      - req-28024aba-1e9f-4bfe-a8b8-237475f73edc
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -30360,27 +31284,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3094dfd0-195e-4822-b405-672ac7ac0946
+      - req-18c52eda-b528-4b06-bc9f-06647746315e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3094dfd0-195e-4822-b405-672ac7ac0946
+      - req-18c52eda-b528-4b06-bc9f-06647746315e
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -30395,22 +31319,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-229165eb-8902-4e0f-93c5-67828ea31208
+      - req-445aa9cf-af79-45db-ac5b-9994830ddca2
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-229165eb-8902-4e0f-93c5-67828ea31208
+      - req-445aa9cf-af79-45db-ac5b-9994830ddca2
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -30425,7 +31349,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -30440,22 +31364,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ba288cf-fb45-42fa-9f51-c4c1f77d96d6
+      - req-010aef73-f7b7-41db-a14d-e3b0284cbe2b
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-4ba288cf-fb45-42fa-9f51-c4c1f77d96d6
+      - req-010aef73-f7b7-41db-a14d-e3b0284cbe2b
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -30470,7 +31394,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -30485,27 +31409,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38926624-f3f2-4467-a3b9-cdaec68a9f31
+      - req-70c77642-612d-4411-8a2d-f96e78446211
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-38926624-f3f2-4467-a3b9-cdaec68a9f31
+      - req-70c77642-612d-4411-8a2d-f96e78446211
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -30520,27 +31444,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a8944727-1e09-448a-a4c6-692c0887ee10
+      - req-69b0af9f-3f44-4475-af2e-6d194e9fa149
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a8944727-1e09-448a-a4c6-692c0887ee10
+      - req-69b0af9f-3f44-4475-af2e-6d194e9fa149
       Date:
-      - Mon, 06 Aug 2018 16:54:19 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -30555,27 +31479,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d3feb4db-6b15-456c-81ca-2a669cfe9921
+      - req-4e4dcfc6-6458-425b-9b3e-c0644be2c7fe
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d3feb4db-6b15-456c-81ca-2a669cfe9921
+      - req-4e4dcfc6-6458-425b-9b3e-c0644be2c7fe
       Date:
-      - Mon, 06 Aug 2018 16:54:20 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -30590,27 +31514,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94a98be3-2389-4f00-814c-4c612589045c
+      - req-00d67c98-48ad-4e9b-91cf-13f129ce29ab
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-94a98be3-2389-4f00-814c-4c612589045c
+      - req-00d67c98-48ad-4e9b-91cf-13f129ce29ab
       Date:
-      - Mon, 06 Aug 2018 16:54:20 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -30625,27 +31549,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-174bc53f-4ede-45ac-af40-4283e26896fd
+      - req-e26669ac-910f-48a3-9d8e-97b189245b6a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-174bc53f-4ede-45ac-af40-4283e26896fd
+      - req-e26669ac-910f-48a3-9d8e-97b189245b6a
       Date:
-      - Mon, 06 Aug 2018 16:54:20 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -30660,27 +31584,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-105bdd43-2b41-4428-8361-82c00114f77f
+      - req-e961b8d3-4182-46b2-b5e7-e62128e2edce
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-105bdd43-2b41-4428-8361-82c00114f77f
+      - req-e961b8d3-4182-46b2-b5e7-e62128e2edce
       Date:
-      - Mon, 06 Aug 2018 16:54:20 GMT
+      - Mon, 24 Sep 2018 20:32:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -30695,27 +31619,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd783066-34ee-4df8-b1f3-449b70f2221a
+      - req-50d5a1bd-178f-406c-8d8c-bd011aa1ea09
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fd783066-34ee-4df8-b1f3-449b70f2221a
+      - req-50d5a1bd-178f-406c-8d8c-bd011aa1ea09
       Date:
-      - Mon, 06 Aug 2018 16:54:20 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -30730,27 +31654,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8430b3b-dda9-46d5-896f-70c3593edeb4
+      - req-0bf61d81-acaf-422e-9584-3e3380bff276
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f8430b3b-dda9-46d5-896f-70c3593edeb4
+      - req-0bf61d81-acaf-422e-9584-3e3380bff276
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -30765,27 +31689,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61bce7de-bde1-46e3-b944-f98f5c25a251
+      - req-ec27088e-58ef-4779-b96d-ca743ddf577d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-61bce7de-bde1-46e3-b944-f98f5c25a251
+      - req-ec27088e-58ef-4779-b96d-ca743ddf577d
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -30800,27 +31724,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-681383b3-8a51-46a6-971f-0a9cfd0f7031
+      - req-08a5ffb2-a3d8-4a67-b92a-7df50aa8d4ff
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-681383b3-8a51-46a6-971f-0a9cfd0f7031
+      - req-08a5ffb2-a3d8-4a67-b92a-7df50aa8d4ff
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -30835,27 +31759,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b87e1c6b-cd92-498d-996f-de9c2a5e00eb
+      - req-80cda556-19de-4742-a172-fd254f43354a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b87e1c6b-cd92-498d-996f-de9c2a5e00eb
+      - req-80cda556-19de-4742-a172-fd254f43354a
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -30870,27 +31794,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0a40242c-d42a-4684-b553-c88ac167ba12
+      - req-886b9987-8994-4b74-96d9-20592ff028a6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0a40242c-d42a-4684-b553-c88ac167ba12
+      - req-886b9987-8994-4b74-96d9-20592ff028a6
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -30905,27 +31829,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-55898f06-e37b-4718-83bb-227b0092d6e8
+      - req-6d47fb04-b0ed-41e8-ac92-8f62e3804a88
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-55898f06-e37b-4718-83bb-227b0092d6e8
+      - req-6d47fb04-b0ed-41e8-ac92-8f62e3804a88
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -30940,27 +31864,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f4142f0-7558-470b-95ea-fe14b535c1f4
+      - req-0b9122bd-7c14-4e60-954f-e8951f27b5c2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2f4142f0-7558-470b-95ea-fe14b535c1f4
+      - req-0b9122bd-7c14-4e60-954f-e8951f27b5c2
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -30975,27 +31899,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-84154149-6136-49e4-b538-fee2d8a67c8e
+      - req-7810fead-e672-40df-ae37-6b077cc3dfc9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-84154149-6136-49e4-b538-fee2d8a67c8e
+      - req-7810fead-e672-40df-ae37-6b077cc3dfc9
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -31010,27 +31934,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8edca855-95b3-41e5-b5de-6973f81d8851
+      - req-6aead762-c447-47b4-aa6c-c46f71b99cb4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8edca855-95b3-41e5-b5de-6973f81d8851
+      - req-6aead762-c447-47b4-aa6c-c46f71b99cb4
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -31045,27 +31969,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe83ab79-4174-493b-8caf-ff8dffd14823
+      - req-c81cf618-770f-4a3d-a411-2c69f8d52f2a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fe83ab79-4174-493b-8caf-ff8dffd14823
+      - req-c81cf618-770f-4a3d-a411-2c69f8d52f2a
       Date:
-      - Mon, 06 Aug 2018 16:54:21 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -31080,27 +32004,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3bda142-91b6-40c2-9c11-c97440c8bdee
+      - req-9a58626c-7c24-49f3-96df-599a13b99515
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f3bda142-91b6-40c2-9c11-c97440c8bdee
+      - req-9a58626c-7c24-49f3-96df-599a13b99515
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -31115,27 +32039,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89821d97-b653-4a8a-81fe-ea7a0d2fcc61
+      - req-a77e083f-529a-4516-9f1e-a1d28b19f684
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-89821d97-b653-4a8a-81fe-ea7a0d2fcc61
+      - req-a77e083f-529a-4516-9f1e-a1d28b19f684
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -31150,27 +32074,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-419a1595-028c-4c78-808a-1eec8cc0bdd4
+      - req-cc773bc8-9961-43d6-8f1b-9b9d8e642f5e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-419a1595-028c-4c78-808a-1eec8cc0bdd4
+      - req-cc773bc8-9961-43d6-8f1b-9b9d8e642f5e
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -31185,27 +32109,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8018bcfc-f1e5-4a1a-bcff-38dd9701ea54
+      - req-438b56c8-1cd7-4147-94b5-26801f363a58
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8018bcfc-f1e5-4a1a-bcff-38dd9701ea54
+      - req-438b56c8-1cd7-4147-94b5-26801f363a58
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -31220,27 +32144,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1f7319ab-7539-4a88-9b7d-84e09b8e3165
+      - req-cc62f4ec-d5b4-4cb8-a328-24e37d1cb514
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1f7319ab-7539-4a88-9b7d-84e09b8e3165
+      - req-cc62f4ec-d5b4-4cb8-a328-24e37d1cb514
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -31255,22 +32179,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-056d3f1d-e54a-4ed9-9eb4-51e5f6528f03
+      - req-bb979c0b-cad3-4f5a-ad37-c92c7b459c02
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-056d3f1d-e54a-4ed9-9eb4-51e5f6528f03
+      - req-bb979c0b-cad3-4f5a-ad37-c92c7b459c02
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31282,7 +32206,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31297,22 +32221,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0807f527d5f1419b8bf13626c76dfd89'
+      - bb649ed98a9b4de39d3bb3c6115a3773
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f152fb31-7ac9-4eb5-9dc3-10f7042da2f4
+      - req-a346863c-0208-42f4-8214-c6ec0f57f029
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f152fb31-7ac9-4eb5-9dc3-10f7042da2f4
+      - req-a346863c-0208-42f4-8214-c6ec0f57f029
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31324,7 +32248,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -31339,22 +32263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5f6087b-0626-4f78-95ba-ee790beb7a09
+      - req-ae3e2ec6-9064-4221-82cd-dda9f3ba062d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a5f6087b-0626-4f78-95ba-ee790beb7a09
+      - req-ae3e2ec6-9064-4221-82cd-dda9f3ba062d
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31366,7 +32290,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31381,22 +32305,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15b597d8a43d47fcbc500d645863bdea
+      - 5f53f2a0f3354476b4a36f5b09657568
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be68026b-012b-490a-939b-05bfffc090fa
+      - req-802bf15e-4a95-41ac-a66c-019b0b477933
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-be68026b-012b-490a-939b-05bfffc090fa
+      - req-802bf15e-4a95-41ac-a66c-019b0b477933
       Date:
-      - Mon, 06 Aug 2018 16:54:22 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31408,7 +32332,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -31423,22 +32347,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-29b4171a-1704-42c0-a7ed-7570cbb87fd0
+      - req-e4ff3767-d8a9-4889-8d09-bb83ec1b5d93
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-29b4171a-1704-42c0-a7ed-7570cbb87fd0
+      - req-e4ff3767-d8a9-4889-8d09-bb83ec1b5d93
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31450,7 +32374,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31465,22 +32389,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8700d4f0d4f24dd18ea5b2345ab24a3f
+      - 45049e348202464f945fa35c42ce3175
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3a5b026-17f2-495d-9d31-bf2ecfb4df84
+      - req-c7d43f62-a8a0-462f-9651-ea1338760288
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b3a5b026-17f2-495d-9d31-bf2ecfb4df84
+      - req-c7d43f62-a8a0-462f-9651-ea1338760288
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31492,7 +32416,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -31507,22 +32431,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5f4cb32-48c9-4cc7-905e-399e77b6b704
+      - req-1c6f6f3e-e999-4131-bd5a-71985b5135b9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e5f4cb32-48c9-4cc7-905e-399e77b6b704
+      - req-1c6f6f3e-e999-4131-bd5a-71985b5135b9
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31534,7 +32458,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31549,22 +32473,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ab599f98b074e3c833cd63e45b7a720
+      - f2ee798185fb438dafc43b6cfdba58d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffa66c5b-92d8-496c-8aec-47713182f255
+      - req-46a014ea-753a-47ab-a0c5-daca62247233
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ffa66c5b-92d8-496c-8aec-47713182f255
+      - req-46a014ea-753a-47ab-a0c5-daca62247233
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31576,7 +32500,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -31591,22 +32515,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dad8c4ab-f6d1-4956-99de-d37d28c0b9b5
+      - req-ea2074f0-a1fa-43ef-9f3a-90f03762a112
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dad8c4ab-f6d1-4956-99de-d37d28c0b9b5
+      - req-ea2074f0-a1fa-43ef-9f3a-90f03762a112
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31618,7 +32542,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31633,22 +32557,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499536d75c3e4abe8d717f9c105da6f9
+      - 5d013707390244b6b642ca14ec93880b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e64f987d-90c1-4a5e-a0e4-a2c24ed108a1
+      - req-59bee263-08f4-4e5d-b46f-2daf3f681f1c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e64f987d-90c1-4a5e-a0e4-a2c24ed108a1
+      - req-59bee263-08f4-4e5d-b46f-2daf3f681f1c
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31660,7 +32584,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -31675,22 +32599,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-38d8e558-eccf-4280-97b0-856c6ba2cff7
+      - req-fd7fca5e-c715-41bd-a5e5-05d0ebbdfd70
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-38d8e558-eccf-4280-97b0-856c6ba2cff7
+      - req-fd7fca5e-c715-41bd-a5e5-05d0ebbdfd70
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31702,7 +32626,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31717,22 +32641,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd125d12b7154d25ac19efd31fdbf7ab
+      - fe0306922e7b4ea8baa0b4b567ec41f2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a06bc3c9-a2f6-47de-8a71-85aec9367a45
+      - req-456821cc-96ff-4235-8b3d-0a0396d5eea4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a06bc3c9-a2f6-47de-8a71-85aec9367a45
+      - req-456821cc-96ff-4235-8b3d-0a0396d5eea4
       Date:
-      - Mon, 06 Aug 2018 16:54:23 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31744,7 +32668,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -31759,22 +32683,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4cc7d75-02f3-4b2c-8a72-c5f5113d2135
+      - req-87dd9b11-8464-4722-964a-6a0df4c1b738
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a4cc7d75-02f3-4b2c-8a72-c5f5113d2135
+      - req-87dd9b11-8464-4722-964a-6a0df4c1b738
       Date:
-      - Mon, 06 Aug 2018 16:54:24 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31786,7 +32710,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -31801,22 +32725,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ead4ea1e84c424f82edc664661bedcf
+      - a4455094b8a842c086b4d9b94a082767
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-361aead2-2a3a-4dd6-afa5-8cc63c78ea44
+      - req-8caca634-d1b9-4db6-88f5-3a5d341f0a8f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-361aead2-2a3a-4dd6-afa5-8cc63c78ea44
+      - req-8caca634-d1b9-4db6-88f5-3a5d341f0a8f
       Date:
-      - Mon, 06 Aug 2018 16:54:24 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -31828,7 +32752,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31846,15 +32770,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:24 GMT
+      - Mon, 24 Sep 2018 20:32:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8a1a5c9035624d77809944ff71e1ba50
+      - aa5ab4f9b016473a86a8f1834c959559
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4bb98fdd-b59f-42f7-9931-a42c8b764a1d
+      - req-6dabc12e-6403-4830-b5db-3ac4b1ae7b4a
       Content-Length:
       - '7311'
       Connection:
@@ -31866,7 +32790,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:25.104681Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:36.915023Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -31945,10 +32869,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GunoYCbwSni6DAQdBYoj_w"],
-        "issued_at": "2018-08-06T16:54:25.104759Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6j9Ddmf1SjCCUQMFhxTLEA"],
+        "issued_at": "2018-09-24T20:32:36.915043Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -31966,15 +32890,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:25 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5f41dfae1704404aaacf2f1ce7b99f63
+      - 7c6b0d8d807d48e7ba762f8f7e153cca
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a03bedce-32ce-4cc8-ad83-839b48bab03c
+      - req-c5503c34-7443-42ba-b1fd-25f0742c2163
       Content-Length:
       - '7311'
       Connection:
@@ -31986,7 +32910,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:25.446430Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:37.150752Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32065,10 +32989,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3v3o2xlMQLGTZqOMNG2YOw"],
-        "issued_at": "2018-08-06T16:54:25.446505Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OFkz8j4KTYOhCKrHxQxYeA"],
+        "issued_at": "2018-09-24T20:32:37.150775Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32086,15 +33010,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:25 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 12ee7c0a4f09430180d65f197ea9396b
+      - d2374edec9334c73adaf280216c67523
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8c991c09-0275-4dec-8d59-42dd31ca6542
+      - req-2c29ee89-935b-4fa4-983f-082dfabd0c01
       Content-Length:
       - '297'
       Connection:
@@ -32103,12 +33027,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:25.671776Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:32:37.308831Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Uj-qu3sQUC-oFE-n4H2Ug"],
-        "issued_at": "2018-08-06T16:54:25.671837Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a75rJ0xPRN-QdED-sYLBSw"],
+        "issued_at": "2018-09-24T20:32:37.308850Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -32123,20 +33047,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12ee7c0a4f09430180d65f197ea9396b
+      - d2374edec9334c73adaf280216c67523
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:25 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc3e4093-2559-46cb-bdd0-98fe22ddd47f
+      - req-770631ec-d19d-4e3c-b263-a6d322387a05
       Content-Length:
       - '2457'
       Connection:
@@ -32169,13 +33093,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"12ee7c0a4f09430180d65f197ea9396b"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"d2374edec9334c73adaf280216c67523"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -32187,15 +33111,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:25 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 01bba11a893649daa1230ddf589617e7
+      - 1716bce61d834207b75da37bd47b2b94
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-21bcbebb-33e7-42aa-a3dd-57ca88d8a54a
+      - req-a4f3175c-b792-4a75-bba2-5396a08a3fe6
       Content-Length:
       - '7313'
       Connection:
@@ -32207,7 +33131,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:25.671776Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:37.308831Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32286,10 +33210,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J4--wvYdQlydCuq70Y5EQw",
-        "2Uj-qu3sQUC-oFE-n4H2Ug"], "issued_at": "2018-08-06T16:54:26.124872Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["W34Qa9MwSyKx1fQ67QRSEg",
+        "a75rJ0xPRN-QdED-sYLBSw"], "issued_at": "2018-09-24T20:32:37.609454Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -32304,20 +33228,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 01bba11a893649daa1230ddf589617e7
+      - 1716bce61d834207b75da37bd47b2b94
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:26 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0402aaf4-fdaf-48dc-a867-04defdf4ecb6
+      - req-8183b3eb-fc77-46f9-8db9-e24f649489e1
       Content-Length:
       - '2179'
       Connection:
@@ -32350,7 +33274,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32368,15 +33292,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:26 GMT
+      - Mon, 24 Sep 2018 20:32:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c9524ee68064750a24edaa49a2d57b6
+      - 92b9cd58ac5c4a3a8b692f2bf8907547
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2594de80-1907-442d-8f9c-8f3e2d19cb30
+      - req-5372c130-560a-4b3f-9459-dbdce180f179
       Content-Length:
       - '7278'
       Connection:
@@ -32388,7 +33312,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:26.650738Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:37.901755Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32467,10 +33391,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6clBl68HT92wdXOrtOJNRw"],
-        "issued_at": "2018-08-06T16:54:26.650824Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p36FWN_cQYuXLEY0uj5d1A"],
+        "issued_at": "2018-09-24T20:32:37.901774Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32488,15 +33412,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:26 GMT
+      - Mon, 24 Sep 2018 20:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 13d7a1e13d984c818c7be60a2a526854
+      - 861f3d20f9a4476eb552baf4409cf83f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-31813316-782d-4ff1-b96e-9e2044bcfa05
+      - req-0e5cfe44-4379-4f6e-b1b9-c39d74e0b049
       Content-Length:
       - '7278'
       Connection:
@@ -32508,7 +33432,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:27.073856Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:38.092281Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32587,10 +33511,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0brqCPhoSTSGAH5OPNvolA"],
-        "issued_at": "2018-08-06T16:54:27.073930Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Gis7lUhSQgWteDokooNV_w"],
+        "issued_at": "2018-09-24T20:32:38.092299Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32608,15 +33532,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:27 GMT
+      - Mon, 24 Sep 2018 20:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b6cf9523bcc1432ab87cec9f4fefac86
+      - 2989d2055ab24c39a40b688c025e341a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0aa5d57d-5358-442e-a5d2-436dcf205163
+      - req-d604d610-ab86-4673-9e59-cd1ad0b29b4a
       Content-Length:
       - '7264'
       Connection:
@@ -32628,7 +33552,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:27.459982Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:38.283849Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32707,10 +33631,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gKWULFSPQeCbnHIYtN4Evg"],
-        "issued_at": "2018-08-06T16:54:27.460047Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nRxYPI2wQImudRtF3xU52w"],
+        "issued_at": "2018-09-24T20:32:38.283868Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32728,15 +33652,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:27 GMT
+      - Mon, 24 Sep 2018 20:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4fbf35750fb84ea5b46c05957cf33d3f
+      - 82f59091c03e4f6094d587392a7c30c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d3b6c88e-c4d2-487f-87ca-7bb387457f8c
+      - req-c9e02e3d-92d1-40c7-b90f-462c74e8b793
       Content-Length:
       - '7278'
       Connection:
@@ -32748,7 +33672,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:27.776413Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:38.472786Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -32827,10 +33751,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xt8L4njbR5uATYoK8pZr8A"],
-        "issued_at": "2018-08-06T16:54:27.776471Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZHyG505LSoiZZKJ2NQvbIw"],
+        "issued_at": "2018-09-24T20:32:38.472805Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32848,15 +33772,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:27 GMT
+      - Mon, 24 Sep 2018 20:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 933383b244504485b0d593c02b7217b7
+      - b647a115cd424c0a8a1f556623b1b113
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0e41d699-5101-4127-bd3a-2cbf1c3ab3a6
+      - req-273627d0-9e76-477c-943e-cd709ff70ffa
       Content-Length:
       - '7265'
       Connection:
@@ -32868,7 +33792,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:28.192478Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:38.666041Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -32947,10 +33871,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rTF-aDhgSFa38ZkO8RClfQ"],
-        "issued_at": "2018-08-06T16:54:28.192553Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F3cqZe4yT3WfVn-vKu1BXw"],
+        "issued_at": "2018-09-24T20:32:38.666060Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -32968,15 +33892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:28 GMT
+      - Mon, 24 Sep 2018 20:32:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2941ca839c2b41df8ce239e35b78d49b
+      - 3bce7cda0a2840aab092dddc6862f745
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9e4f4c62-95a6-45bb-b202-d67f7d1de2e2
+      - req-50f71845-5ef2-48b3-86c1-ad806e5b5da6
       Content-Length:
       - '7278'
       Connection:
@@ -32988,7 +33912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:28.626285Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:38.866578Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33067,10 +33991,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hUZ_SNkjR1OSL7blJ92dYQ"],
-        "issued_at": "2018-08-06T16:54:28.626393Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r7ogC88TSoO6gw3d9ZJ2dw"],
+        "issued_at": "2018-09-24T20:32:38.866604Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33088,15 +34012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:28 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e2d30d75efdc4bf8abac426dfb0f0cd8
+      - 36837bf8eaa24bad821272870f327b0a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b6dbdfce-15a9-43ac-8974-cac816742fb3
+      - req-67b8b3a3-60f6-4df2-968f-2c3dd2ec8f66
       Content-Length:
       - '7278'
       Connection:
@@ -33108,7 +34032,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:29.027534Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:39.089911Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33187,10 +34111,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["83DFOkHdSZ6NGcAvCXNqMA"],
-        "issued_at": "2018-08-06T16:54:29.027598Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KF90GgPxQDyd1MO0K7qkbg"],
+        "issued_at": "2018-09-24T20:32:39.089936Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -33205,7 +34129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e2d30d75efdc4bf8abac426dfb0f0cd8
+      - 36837bf8eaa24bad821272870f327b0a
   response:
     status:
       code: 200
@@ -33218,22 +34142,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574469.20414'
+      - '1537821159.26578'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574469.20414'
+      - '1537821159.26578'
       X-Trans-Id:
-      - tx65898532fb294e2f98332-005b687d45
+      - tx14469dfbcb4945a9b163d-005ba949e7
       Date:
-      - Mon, 06 Aug 2018 16:54:29 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33251,15 +34175,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:29 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 226d96d2ad6b4320acc122a4c6413170
+      - fb8c882b02174815bb1f4f4b0bee10d0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1970e370-f3f0-4ecf-a914-3965b7d201ec
+      - req-bfcd49a5-10fb-4817-8183-39ca4aac60a9
       Content-Length:
       - '7278'
       Connection:
@@ -33271,7 +34195,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:29.501463Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:39.452675Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33350,10 +34274,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pAEwVMCWSZ-fwIMClEUkUg"],
-        "issued_at": "2018-08-06T16:54:29.501528Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TQh5av_sRgOZH3qelqUnzQ"],
+        "issued_at": "2018-09-24T20:32:39.452695Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -33368,7 +34292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 226d96d2ad6b4320acc122a4c6413170
+      - fb8c882b02174815bb1f4f4b0bee10d0
   response:
     status:
       code: 200
@@ -33381,22 +34305,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574469.72104'
+      - '1537821159.58001'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574469.72104'
+      - '1537821159.58001'
       X-Trans-Id:
-      - tx85b602f9f98e485eb43ce-005b687d45
+      - tx0376934f7a984eecb94cb-005ba949e7
       Date:
-      - Mon, 06 Aug 2018 16:54:29 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33414,15 +34338,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:29 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-21d0725a-3162-4cd2-95dc-29258033436f
+      - req-dd070254-eca2-4d56-b736-8c0f17f58a60
       Content-Length:
       - '7264'
       Connection:
@@ -33434,7 +34358,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:30.133916Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:39.768767Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33513,10 +34437,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P8ASFKzASCqlPSqjjOAbpw"],
-        "issued_at": "2018-08-06T16:54:30.134029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lSWiUWIMQ_m2PUj78fjicw"],
+        "issued_at": "2018-09-24T20:32:39.768788Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -33531,7 +34455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
   response:
     status:
       code: 200
@@ -33560,15 +34484,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txc7f67334760a4d9797fb1-005b687d46
+      - tx7b0e5364ce864a878d7d6-005ba949e7
       Date:
-      - Mon, 06 Aug 2018 16:54:30 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -33583,7 +34507,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
   response:
     status:
       code: 200
@@ -33612,14 +34536,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txba1f881adabe431ca2c18-005b687d46
+      - txe36fd841ca884d95a076b-005ba949e7
       Date:
-      - Mon, 06 Aug 2018 16:54:30 GMT
+      - Mon, 24 Sep 2018 20:32:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33637,15 +34561,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:30 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 110eeda9281143b8ab7376d4ed7b69b9
+      - 75c52c908b8c4ce5a24f0632879009dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-130baa50-3bd5-4459-bc84-922d22f84c38
+      - req-bf514d63-73da-4747-b560-e302806b6bbc
       Content-Length:
       - '7278'
       Connection:
@@ -33657,7 +34581,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:30.787419Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:40.174679Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -33736,10 +34660,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5uGolzcUR5W6qoiIc-BRUw"],
-        "issued_at": "2018-08-06T16:54:30.787495Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Ad-Xz93Qp2py1WnGjnVpw"],
+        "issued_at": "2018-09-24T20:32:40.174700Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -33754,7 +34678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 110eeda9281143b8ab7376d4ed7b69b9
+      - 75c52c908b8c4ce5a24f0632879009dc
   response:
     status:
       code: 200
@@ -33767,22 +34691,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574471.02363'
+      - '1537821160.35647'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574471.02363'
+      - '1537821160.35647'
       X-Trans-Id:
-      - tx6faff2f7e3da432094386-005b687d46
+      - tx93fb568fbd1542d99d9dd-005ba949e8
       Date:
-      - Mon, 06 Aug 2018 16:54:31 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -33797,7 +34721,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5f41dfae1704404aaacf2f1ce7b99f63
+      - 7c6b0d8d807d48e7ba762f8f7e153cca
   response:
     status:
       code: 200
@@ -33810,22 +34734,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574471.18823'
+      - '1537821160.46370'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574471.18823'
+      - '1537821160.46370'
       X-Trans-Id:
-      - tx707061583e754487a3325-005b687d47
+      - txa6a2280b4dd34e27abadd-005ba949e8
       Date:
-      - Mon, 06 Aug 2018 16:54:31 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -33843,15 +34767,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:31 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9dde1c6d9e394caeb7954c01e098aa2e
+      - bf8d514580944e228ad4bc570d741373
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f0c6d187-e50e-47b1-a67b-4bce49daa6da
+      - req-e7940b38-ea00-49ec-9446-e17cf9083d01
       Content-Length:
       - '7265'
       Connection:
@@ -33863,7 +34787,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:31.503962Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:40.657314Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -33942,10 +34866,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O2GbHKxsTna_ITs0MTYKMg"],
-        "issued_at": "2018-08-06T16:54:31.504061Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yl5nhSWNR06pmw-7HTd4jw"],
+        "issued_at": "2018-09-24T20:32:40.657334Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -33960,7 +34884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dde1c6d9e394caeb7954c01e098aa2e
+      - bf8d514580944e228ad4bc570d741373
   response:
     status:
       code: 200
@@ -33973,22 +34897,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574471.70282'
+      - '1537821160.78937'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574471.70282'
+      - '1537821160.78937'
       X-Trans-Id:
-      - tx0d88ec0b13d845058d4fa-005b687d47
+      - txb69caad3e3d8402082b77-005ba949e8
       Date:
-      - Mon, 06 Aug 2018 16:54:31 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -34006,15 +34930,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:31 GMT
+      - Mon, 24 Sep 2018 20:32:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3c098d6649924d74a47dfe13a09d657e
+      - ba9a2e77abfb44f2af69d60094424635
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cbc54c16-6a51-4c18-9ad3-18fee2904566
+      - req-a55724cc-175b-4813-ba4c-6ea24bc96f68
       Content-Length:
       - '7278'
       Connection:
@@ -34026,7 +34950,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:32.032267Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:40.985789Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -34105,10 +35029,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MDJgQE6cTcqSHAB3bhLywg"],
-        "issued_at": "2018-08-06T16:54:32.032336Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VJBlVYP2SXyqbmjoSy1ixw"],
+        "issued_at": "2018-09-24T20:32:40.985809Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -34123,7 +35047,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3c098d6649924d74a47dfe13a09d657e
+      - ba9a2e77abfb44f2af69d60094424635
   response:
     status:
       code: 200
@@ -34136,22 +35060,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574472.22998'
+      - '1537821161.12971'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574472.22998'
+      - '1537821161.12971'
       X-Trans-Id:
-      - tx3fde4219a4254d949c228-005b687d48
+      - tx97bc72c11663435aaa636-005ba949e9
       Date:
-      - Mon, 06 Aug 2018 16:54:32 GMT
+      - Mon, 24 Sep 2018 20:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -34166,7 +35090,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
   response:
     status:
       code: 200
@@ -34187,9 +35111,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx43d846e0a4634e6d812f0-005b687d48
+      - tx7ab63bc21ed740ac8716f-005ba949e9
       Date:
-      - Mon, 06 Aug 2018 16:54:32 GMT
+      - Mon, 24 Sep 2018 20:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -34199,7 +35123,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -34214,7 +35138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
   response:
     status:
       code: 200
@@ -34235,14 +35159,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2744b61d9e914612a7868-005b687d48
+      - tx444a93abf89d49e3a08b8-005ba949e9
       Date:
-      - Mon, 06 Aug 2018 16:54:32 GMT
+      - Mon, 24 Sep 2018 20:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -34257,7 +35181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe6a04e76e0e488a8fccb65f9d55cd1e
+      - 4ded672e769c4b6ea208a326492ca1e8
   response:
     status:
       code: 200
@@ -34278,12 +35202,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx54e0701a08fc429b85058-005b687d48
+      - tx33a7ea67b65c4a16a1adc-005ba949e9
       Date:
-      - Mon, 06 Aug 2018 16:54:32 GMT
+      - Mon, 24 Sep 2018 20:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:44 GMT
+      - Mon, 24 Sep 2018 20:33:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-565bb955-e191-4224-ac00-ba3c454be20b
+      - req-12074b7e-1003-4779-baba-67d4faf6e40d
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:44.965810Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:35.713011Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GITwMhR8Qsi5lCf4qAZBsQ"],
-        "issued_at": "2018-08-06T16:54:44.965877Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SRLIwQW2RWm_39cgbkglhg"],
+        "issued_at": "2018-09-24T20:33:35.713035Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:45 GMT
+      - Mon, 24 Sep 2018 20:33:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,15 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-eb0d4313-2e4e-4019-b035-dc80299671e4
+      - req-72b38e41-fadc-4de1-aa05-52f52773c76a
       Date:
-      - Mon, 06 Aug 2018 16:54:45 GMT
+      - Mon, 24 Sep 2018 20:33:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -208,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:45 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01a43672-317a-451d-b851-62481619b536
+      - req-97f0c68c-0cb0-4271-8922-b30457773520
       Content-Length:
       - '7311'
       Connection:
@@ -228,7 +228,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:45.897600Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:36.120139Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -307,10 +307,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wnf-leVZSayT6sS8avKdoA"],
-        "issued_at": "2018-08-06T16:54:45.897663Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U_SIODrvSNq25yIN7USZXw"],
+        "issued_at": "2018-09-24T20:33:36.120160Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -325,28 +325,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ef17c13e-90a8-4a69-abe4-cae7a64cc110
+      - req-37065dd5-1545-4d80-adfe-6b9507bb1a7b
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-ef17c13e-90a8-4a69-abe4-cae7a64cc110
+      - req-37065dd5-1545-4d80-adfe-6b9507bb1a7b
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +374,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a130ad85-aeaf-4be6-9b02-1d85c8761fa7
+      - req-4c7c1f2c-49fe-4203-bedc-a6ef04859bdc
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:54:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:33:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:54:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:33:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:54:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:33:34.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:54:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:54:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:33:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +408,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +421,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-71b19838-2371-409a-9903-589a618ca9e0
+      - req-0efec09e-45a0-4183-840b-12f28434d04b
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:54:45.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:33:34.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:54:44.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:33:34.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:54:45.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:33:34.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:54:38.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:33:34.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:54:38.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:33:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +468,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-703e4d47-ae41-474b-8539-aa823c02af09
+      - req-d62c1140-81b7-4b1c-a58c-03e8066b2c91
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +484,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +512,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-57fc9f56-a742-4b94-814b-bd44c920b2f6
+      - req-ca5d8e66-bb36-4940-ac3f-8bbbd99b0ff0
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +528,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +543,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +556,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-96eb09e1-d9b7-42a0-b3da-67efbae9e5b1
+      - req-07a21107-b8bc-46b2-83cc-24c73ca87768
       Date:
-      - Mon, 06 Aug 2018 16:54:46 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +573,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +601,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-5acf9a2b-054b-4d89-95ca-3c6755ba532d
+      - req-8ca7918e-eaf6-4590-a347-0cc7b1c2c215
       Date:
-      - Mon, 06 Aug 2018 16:54:47 GMT
+      - Mon, 24 Sep 2018 20:33:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +613,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +631,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:47 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 03ca8c04352340efaaddfa07ca9b8037
+      - da50c617161f4303bd029792f6a74ee7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d0405d2a-fa74-4673-a9f3-2a3352e3c12b
+      - req-9da23a8f-5981-41ef-be20-8705f61e717e
       Content-Length:
       - '7311'
       Connection:
@@ -651,7 +651,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:47.455958Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:37.064818Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -730,10 +730,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2v2thBMKRS6HnfwgO3WQKQ"],
-        "issued_at": "2018-08-06T16:54:47.456028Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6Z1gXfoBTkWy3-XNeu-8Bg"],
+        "issued_at": "2018-09-24T20:33:37.064840Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -748,20 +748,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 03ca8c04352340efaaddfa07ca9b8037
+      - da50c617161f4303bd029792f6a74ee7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:47 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7b25d850-6041-482a-801f-bc36a93a5835
+      - req-dbf94fba-20b5-4121-b984-2a1d698356d2
       Content-Length:
       - '2179'
       Connection:
@@ -794,7 +794,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -809,7 +809,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -822,15 +822,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-7629b8f6-2f5f-4718-8ad8-6e6184e8d82b
+      - req-b88a0da1-97d2-4ae0-bb88-c2e4dd4fa746
       Date:
-      - Mon, 06 Aug 2018 16:54:47 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -848,15 +848,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:47 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4a6788b02de4494ac41b376a488cad9
+      - c8f72e9cf87d499e8dbf78384d79411e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d3fa0f26-4027-4371-86fe-1b05d7ea934e
+      - req-fa287b1d-5ede-40ba-8177-33a5c3a7821b
       Content-Length:
       - '7311'
       Connection:
@@ -868,7 +868,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:48.087404Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:37.458498Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -947,10 +947,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4NG_5kIvRbWvG8IcLOzFRA"],
-        "issued_at": "2018-08-06T16:54:48.087466Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nM2t7QjESKi5NkMMv-BpRA"],
+        "issued_at": "2018-09-24T20:33:37.458518Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -965,7 +965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4a6788b02de4494ac41b376a488cad9
+      - c8f72e9cf87d499e8dbf78384d79411e
   response:
     status:
       code: 300
@@ -976,7 +976,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -989,7 +989,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4a6788b02de4494ac41b376a488cad9
+      - c8f72e9cf87d499e8dbf78384d79411e
   response:
     status:
       code: 200
@@ -1015,14 +1015,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7c69eefd-0260-4ebd-9fab-923cef29e640
+      - req-2b3bddc6-a2d6-4970-a0c0-b96f727153a7
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4a6788b02de4494ac41b376a488cad9
+      - c8f72e9cf87d499e8dbf78384d79411e
   response:
     status:
       code: 200
@@ -1048,9 +1048,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4b7b0ed2-b1d9-47d4-b306-3885c2e2e800
+      - req-9c084d9b-a9c4-4788-abef-6b97e0390f05
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1092,7 +1092,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -1107,7 +1107,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1120,9 +1120,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-96e648ff-b7eb-4722-92ce-f416426ffec4
+      - req-0f18b1b9-6117-404a-a5d7-0b361949b46e
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1132,7 +1132,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1147,7 +1147,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1160,9 +1160,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-09b7ed44-900e-418f-af2c-d0915b45dc3f
+      - req-9d3e71f1-eabb-427c-a7ae-b309710cc931
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1172,7 +1172,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1190,15 +1190,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:48 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71d4fee230d84c0a9ba04ac1d8198213
+      - 3f89066af950427f820596bbe4aad240
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-949a9a4a-2ac0-417d-b9fa-449b52095b1a
+      - req-8a5283b7-a311-45f2-936c-a1e1ff442745
       Content-Length:
       - '7311'
       Connection:
@@ -1210,7 +1210,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:54:49.121628Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:38.198228Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1289,10 +1289,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9NvBg0KcTE6X0eJZ_N5PAQ"],
-        "issued_at": "2018-08-06T16:54:49.121703Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pl0iO0MfQzKP1zOzOjQ48Q"],
+        "issued_at": "2018-09-24T20:33:38.198248Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1310,15 +1310,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:49 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7cea50d7f3d34956b727764f627e9300
+      - a3d270fb040746f8be857c5fc6dbaf1c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc541d79-633b-4556-be6b-e228c6830838
+      - req-6daef729-d2f8-4c9e-bee7-8849fe4c6d60
       Content-Length:
       - '297'
       Connection:
@@ -1327,12 +1327,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:54:49.529821Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:33:38.361482Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vGUY-04QQrWF1-uhr19HCg"],
-        "issued_at": "2018-08-06T16:54:49.529883Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0pJGN6ZgSjiQeIBoved97A"],
+        "issued_at": "2018-09-24T20:33:38.361501Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1347,20 +1347,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cea50d7f3d34956b727764f627e9300
+      - a3d270fb040746f8be857c5fc6dbaf1c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:49 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eed7fad4-d5b5-486f-ae73-8718a2186005
+      - req-f48e0590-92df-4044-aee6-0e23d65d6eef
       Content-Length:
       - '2457'
       Connection:
@@ -1393,13 +1393,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7cea50d7f3d34956b727764f627e9300"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"a3d270fb040746f8be857c5fc6dbaf1c"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1411,15 +1411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:49 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 43f4bb52b7a343ee87abf95ccb7b7790
+      - 2696a653e8f74dcead2e95ab6efb9f7b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2787c1d6-aab0-454b-b75c-9108dc90269c
+      - req-6b00964a-0319-4781-b379-599697c7340f
       Content-Length:
       - '7313'
       Connection:
@@ -1431,7 +1431,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:49.529821Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:38.361482Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1510,10 +1510,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ARkP0QgGSgm3sI1yaoaK4w",
-        "vGUY-04QQrWF1-uhr19HCg"], "issued_at": "2018-08-06T16:54:49.959876Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uR9nKu5VTVCa-zIcJuUoSw",
+        "0pJGN6ZgSjiQeIBoved97A"], "issued_at": "2018-09-24T20:33:38.654171Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1528,20 +1528,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 43f4bb52b7a343ee87abf95ccb7b7790
+      - 2696a653e8f74dcead2e95ab6efb9f7b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:50 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-167e0456-394b-418c-94ee-1ad18a4ac4cd
+      - req-839cf3a7-d913-47e4-bf75-14dfef7a4d48
       Content-Length:
       - '2179'
       Connection:
@@ -1574,7 +1574,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1592,15 +1592,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:50 GMT
+      - Mon, 24 Sep 2018 20:33:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8b55ee42859f4557be39a20a50e2a785
+      - 290b510ca44d44f09b6c8f1a4a2adda6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b43cdfb1-c9d9-47e1-a850-ef860813fd09
+      - req-2e0f7b93-b464-49c3-9f65-ac19fb916ad1
       Content-Length:
       - '7278'
       Connection:
@@ -1612,7 +1612,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:50.424884Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:38.945811Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1691,10 +1691,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1j_gBB9xTc6IVGozY_phrA"],
-        "issued_at": "2018-08-06T16:54:50.425010Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iwVv1cKSSOmllVqbmNJOpA"],
+        "issued_at": "2018-09-24T20:33:38.945831Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1709,7 +1709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b55ee42859f4557be39a20a50e2a785
+      - 290b510ca44d44f09b6c8f1a4a2adda6
   response:
     status:
       code: 200
@@ -1720,7 +1720,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:50 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1729,7 +1729,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1747,15 +1747,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:50 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - afe2c03bbe7c460fa92b0632e1e38814
+      - f6598acfaf0a439885a03476d2052cd1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e0ceb776-9c2a-4eaf-9249-f15a55ddc81e
+      - req-2e279a58-7dfc-43dc-83b7-6fc2411e880d
       Content-Length:
       - '7278'
       Connection:
@@ -1767,7 +1767,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:50.910750Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:39.221426Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1846,10 +1846,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oYyHN11HQgy0jOK_DJLKqA"],
-        "issued_at": "2018-08-06T16:54:50.910829Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7_bFb5IYQAqZqcwA-aE47Q"],
+        "issued_at": "2018-09-24T20:33:39.221447Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1864,7 +1864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - afe2c03bbe7c460fa92b0632e1e38814
+      - f6598acfaf0a439885a03476d2052cd1
   response:
     status:
       code: 200
@@ -1875,7 +1875,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1884,7 +1884,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1902,15 +1902,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 27fe85ced827483780124d88bf7a1796
+      - 1d6ef88ca8434f0d8a605359d113a93e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6e1c436d-3e8e-449b-ba76-dda4319329c8
+      - req-f3bc751a-d0e2-42b4-acdd-a1710a8edff6
       Content-Length:
       - '7264'
       Connection:
@@ -1922,7 +1922,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:51.321384Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:39.494208Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2001,10 +2001,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["g9UnY-wrSSeCGSCVQgu5HQ"],
-        "issued_at": "2018-08-06T16:54:51.321450Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LDOHMPSwSkWtayJ9gNhk7w"],
+        "issued_at": "2018-09-24T20:33:39.494228Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2019,7 +2019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27fe85ced827483780124d88bf7a1796
+      - 1d6ef88ca8434f0d8a605359d113a93e
   response:
     status:
       code: 200
@@ -2030,7 +2030,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2039,7 +2039,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2057,15 +2057,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 10ff7d8ffaf949299d29a390328b1fe1
+      - a15905cf79294e9ca82e6e7dfe27c83f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c76481f7-5fa6-40bf-b0d9-99f1fbbb868b
+      - req-2ea41bbc-88b2-44cf-9d96-5831fda16d5a
       Content-Length:
       - '7278'
       Connection:
@@ -2077,7 +2077,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:51.726842Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:39.778983Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2156,10 +2156,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RiAmXRTjQdqSp--2-9M1qQ"],
-        "issued_at": "2018-08-06T16:54:51.726908Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ozXDauUHRQiQhkU6hYT2vg"],
+        "issued_at": "2018-09-24T20:33:39.779015Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2174,7 +2174,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10ff7d8ffaf949299d29a390328b1fe1
+      - a15905cf79294e9ca82e6e7dfe27c83f
   response:
     status:
       code: 200
@@ -2185,7 +2185,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2194,7 +2194,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2212,15 +2212,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:51 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fc2c3680ce834e5b8eaa86f2f4d55a2d
+      - e319dcb1e8fe4e33b6818b6057a50111
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-121e4f05-5c4c-4b36-a754-c9613f168c0f
+      - req-e7c832f1-5163-487d-942f-2ba59aaee3f6
       Content-Length:
       - '7265'
       Connection:
@@ -2232,7 +2232,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:52.166659Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:40.061621Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2311,10 +2311,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uAqDV0EHTtKodjY3ymqZMQ"],
-        "issued_at": "2018-08-06T16:54:52.166731Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zRx1ToRDQ4yxDSmaEytQHA"],
+        "issued_at": "2018-09-24T20:33:40.061641Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2329,7 +2329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc2c3680ce834e5b8eaa86f2f4d55a2d
+      - e319dcb1e8fe4e33b6818b6057a50111
   response:
     status:
       code: 200
@@ -2340,7 +2340,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:52 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2349,7 +2349,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2367,15 +2367,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:52 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 89fa97a588bb491dacb58a8ef4605ae2
+      - e614c7f5b1ca430d8300b18797af7123
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ff9bcb31-e28d-42be-96cc-9bb2e5d6b124
+      - req-b53b40d6-8f87-41de-a893-abdd5735124e
       Content-Length:
       - '7278'
       Connection:
@@ -2387,7 +2387,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:52.668646Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:40.353606Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2466,10 +2466,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fDvsbwoCRXqS6FJFV1xb1w"],
-        "issued_at": "2018-08-06T16:54:52.668728Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yQk3tp2RTOC8U8dBRqs2RQ"],
+        "issued_at": "2018-09-24T20:33:40.353626Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2484,7 +2484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89fa97a588bb491dacb58a8ef4605ae2
+      - e614c7f5b1ca430d8300b18797af7123
   response:
     status:
       code: 200
@@ -2495,7 +2495,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:54:52 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2504,7 +2504,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2522,15 +2522,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:52 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 67e07c7c486641528d5ca2a5aa07cbb8
+      - c5ed68b62d8e4d08a9f0074d6f2c8289
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1f69d7e7-e728-4700-a649-606f770bfc34
+      - req-633f4717-de0c-4f2e-9fc8-811a87e3f7a7
       Content-Length:
       - '7278'
       Connection:
@@ -2542,7 +2542,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:53.098253Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:40.619882Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2621,10 +2621,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9GDa6LPjTaSC4PfwPA2SHg"],
-        "issued_at": "2018-08-06T16:54:53.098339Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Gm3eWQU_TcucOfUko4zndg"],
+        "issued_at": "2018-09-24T20:33:40.619901Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -2639,7 +2639,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 67e07c7c486641528d5ca2a5aa07cbb8
+      - c5ed68b62d8e4d08a9f0074d6f2c8289
   response:
     status:
       code: 200
@@ -2650,14 +2650,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7a6ddd0c-e4dc-4b51-b28c-76b69fa0f840
+      - req-79f714ca-0585-4170-ae0b-28627cd1c703
       Date:
-      - Mon, 06 Aug 2018 16:54:53 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2675,15 +2675,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:53 GMT
+      - Mon, 24 Sep 2018 20:33:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d9f2ad7c419c463d8971aac6695236f1
+      - 735a56bea78b49fea73cfbde9dc461aa
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc83d641-37f7-442e-a8bb-f4fd49e85349
+      - req-3886c6e7-1cd8-461b-9dde-85bd52292810
       Content-Length:
       - '7278'
       Connection:
@@ -2695,7 +2695,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:53.760006Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:40.944342Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2774,10 +2774,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UNN-vKqoQL2wVRMZPr0xFg"],
-        "issued_at": "2018-08-06T16:54:53.760073Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h6dFOzyNQy2uvOIeWwKEdQ"],
+        "issued_at": "2018-09-24T20:33:40.944362Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -2792,7 +2792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9f2ad7c419c463d8971aac6695236f1
+      - 735a56bea78b49fea73cfbde9dc461aa
   response:
     status:
       code: 200
@@ -2803,14 +2803,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-250839eb-b02d-41af-aa35-4fcca64cb5ad
+      - req-c22cf40e-bf40-405a-8c6c-95f94a2c54be
       Date:
-      - Mon, 06 Aug 2018 16:54:54 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2828,15 +2828,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:54 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-26742d4a-a3c1-434d-8dc7-b549bf33e698
+      - req-80ce0134-a8e3-4c10-8422-4002828e37b1
       Content-Length:
       - '7264'
       Connection:
@@ -2848,7 +2848,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:54.690715Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:41.263862Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2927,10 +2927,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o12L5zpZS7iZBIVOu0QBVg"],
-        "issued_at": "2018-08-06T16:54:54.690792Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rxW7ieCBQYal5zZ4jDRNmA"],
+        "issued_at": "2018-09-24T20:33:41.263883Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -2945,7 +2945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -2956,9 +2956,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-089e81e5-7d3d-40d8-8de8-802c4c20383b
+      - req-d28dc0de-a56d-43c4-86b4-f0137f0690d8
       Date:
-      - Mon, 06 Aug 2018 16:54:55 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2992,7 +2992,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -3007,7 +3007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3018,14 +3018,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8e283f2f-a093-4544-8bb8-75b892f3aecc
+      - req-10cf8b37-e619-4d80-8562-5e1e77ef8970
       Date:
-      - Mon, 06 Aug 2018 16:54:55 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3043,15 +3043,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:55 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f0a200f36eee44a29fc2e9bb92b7388c
+      - 756a5e8474a3458d94070a00f8ea13c9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7efce0cd-9a2b-4c06-b389-19c4bd6d66b1
+      - req-0ec7dd90-6564-49c9-ba71-043ef47a7cbe
       Content-Length:
       - '7278'
       Connection:
@@ -3063,7 +3063,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:55.568163Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:41.722623Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3142,10 +3142,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xe6CHYeHQr-mfz7wkk46-g"],
-        "issued_at": "2018-08-06T16:54:55.568231Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mzut22nPTsSRXLS6J7qorQ"],
+        "issued_at": "2018-09-24T20:33:41.722643Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -3160,7 +3160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f0a200f36eee44a29fc2e9bb92b7388c
+      - 756a5e8474a3458d94070a00f8ea13c9
   response:
     status:
       code: 200
@@ -3171,14 +3171,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a2660004-7a0b-4095-ad72-6413403b0e0e
+      - req-a65bf845-38a0-438a-acd0-7b419335dfb0
       Date:
-      - Mon, 06 Aug 2018 16:54:55 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -3193,7 +3193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71d4fee230d84c0a9ba04ac1d8198213
+      - 3f89066af950427f820596bbe4aad240
   response:
     status:
       code: 200
@@ -3204,14 +3204,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a2330195-9388-46a4-8832-c55a1d882114
+      - req-e268b11b-f924-41f9-a434-e01941dcdf36
       Date:
-      - Mon, 06 Aug 2018 16:54:56 GMT
+      - Mon, 24 Sep 2018 20:33:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3229,15 +3229,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:56 GMT
+      - Mon, 24 Sep 2018 20:33:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3f750e1ca4e848eda3d126c719daaae1
+      - 7f74380dea9f4e339ab4230b933dbc69
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ded48649-426e-41d0-98ab-f3220e4e66d4
+      - req-34e6c187-29fc-4de0-b1a9-f34275177d61
       Content-Length:
       - '7265'
       Connection:
@@ -3249,7 +3249,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:56.335295Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:42.147406Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3328,10 +3328,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2-qCnk5JRqOmDclkHpR3JA"],
-        "issued_at": "2018-08-06T16:54:56.335360Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LKbX1122R7O2zGi1RNfAYA"],
+        "issued_at": "2018-09-24T20:33:42.147427Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -3346,7 +3346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f750e1ca4e848eda3d126c719daaae1
+      - 7f74380dea9f4e339ab4230b933dbc69
   response:
     status:
       code: 200
@@ -3357,14 +3357,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-dd362087-dae6-4ba0-9392-89ddc3393971
+      - req-3dd67253-04bb-4e27-ac01-7cec2a8cc7bf
       Date:
-      - Mon, 06 Aug 2018 16:54:56 GMT
+      - Mon, 24 Sep 2018 20:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3382,15 +3382,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:54:56 GMT
+      - Mon, 24 Sep 2018 20:33:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 55f5ac3a1c6645db9a3e85174de4577d
+      - 56b41a4498674bed88c57ec49a3d418e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-30994927-77a8-40a7-a3c0-fe83590fb3ee
+      - req-c575c0f4-ee36-46a2-b353-ef299113e264
       Content-Length:
       - '7278'
       Connection:
@@ -3402,7 +3402,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:54:56.984386Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:42.473768Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3481,10 +3481,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZqzBohUARtyyypYVQ5CZvQ"],
-        "issued_at": "2018-08-06T16:54:56.984446Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["axFc8ZklSsWm5CSM8wKXMQ"],
+        "issued_at": "2018-09-24T20:33:42.473788Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55f5ac3a1c6645db9a3e85174de4577d
+      - 56b41a4498674bed88c57ec49a3d418e
   response:
     status:
       code: 200
@@ -3510,14 +3510,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a0761fea-0d2b-4301-83a8-83d2faf65aa6
+      - req-6da531d2-61f5-42ec-9ac1-34603014dab0
       Date:
-      - Mon, 06 Aug 2018 16:54:57 GMT
+      - Mon, 24 Sep 2018 20:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3543,9 +3543,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1f55735b-71b4-4045-bea0-85017d6c5cc0
+      - req-e3985622-97bf-4481-96f2-d7c7cacaf90c
       Date:
-      - Mon, 06 Aug 2018 16:54:58 GMT
+      - Mon, 24 Sep 2018 20:33:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3572,7 +3572,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -3587,7 +3587,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3598,9 +3598,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-905bdc56-00e0-40a2-a9bc-9ba497eb7fec
+      - req-01acb3a5-f835-44f8-b754-3661156bb9ae
       Date:
-      - Mon, 06 Aug 2018 16:54:58 GMT
+      - Mon, 24 Sep 2018 20:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3627,7 +3627,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -3642,7 +3642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3653,9 +3653,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-66434f88-9cf5-4305-a0b7-3c0c9e878952
+      - req-1387cef3-b925-4629-a937-6bb8e5efebec
       Date:
-      - Mon, 06 Aug 2018 16:54:59 GMT
+      - Mon, 24 Sep 2018 20:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3682,7 +3682,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -3697,7 +3697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3708,9 +3708,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-a443d652-7b5b-4bfb-94ff-bcc8ed61bc33
+      - req-bf8c26fb-9877-4b1b-9ee7-4a74ed8fc402
       Date:
-      - Mon, 06 Aug 2018 16:54:59 GMT
+      - Mon, 24 Sep 2018 20:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3766,7 +3766,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:54:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -3781,7 +3781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -3792,9 +3792,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-8b529a24-ed48-4f26-a13b-ef0cf84775ed
+      - req-38d64144-88a4-499a-a0a0-db4882980cb7
       Date:
-      - Mon, 06 Aug 2018 16:55:00 GMT
+      - Mon, 24 Sep 2018 20:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3806,7 +3806,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -3821,7 +3821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3834,13 +3834,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-3c501dee-d8ca-4298-938b-188558e6240a
+      - req-65362759-99b1-4f36-bace-1a055801453f
       Date:
-      - Mon, 06 Aug 2018 16:55:00 GMT
+      - Mon, 24 Sep 2018 20:33:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:23Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -3882,7 +3882,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -3897,7 +3897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3910,9 +3910,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-e77f3cc9-7cb1-4ac8-be8a-04d935b045b5
+      - req-3c7a6b61-36fd-47ae-8e23-16153ac971a4
       Date:
-      - Mon, 06 Aug 2018 16:55:01 GMT
+      - Mon, 24 Sep 2018 20:33:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -3936,7 +3936,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:57:56Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -3958,7 +3958,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -3973,7 +3973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3986,13 +3986,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-ee716e15-1709-45f0-880f-66897517ecd2
+      - req-2d9d9463-3e5c-4661-beac-64e163d18b38
       Date:
-      - Mon, 06 Aug 2018 16:55:01 GMT
+      - Mon, 24 Sep 2018 20:33:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:19Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -4013,7 +4013,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:46:48Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -4036,7 +4036,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -4051,7 +4051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4064,9 +4064,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-526373d3-86b3-484e-8040-9880d1267375
+      - req-0ede9951-2e25-4a17-b2cf-0cbfdaf00e53
       Date:
-      - Mon, 06 Aug 2018 16:55:02 GMT
+      - Mon, 24 Sep 2018 20:33:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -4108,7 +4108,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -4123,7 +4123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4136,9 +4136,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-ccf6b96a-a3a0-4eee-8e0c-3ae533481a92
+      - req-8aada33b-048d-4271-a925-42566c1cb460
       Date:
-      - Mon, 06 Aug 2018 16:55:02 GMT
+      - Mon, 24 Sep 2018 20:33:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -4161,7 +4161,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -4176,7 +4176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -4187,9 +4187,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-3a1cdfb3-5d2c-486c-a74d-95675b634798
+      - req-7e45de44-eaa3-4808-ad62-42d19c603ab7
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4245,7 +4245,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -4260,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -4271,9 +4271,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fda404d8-928e-48b6-a8db-0f70a4a26818
+      - req-7f1337dc-1451-475f-894b-7e36e1edec61
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4285,7 +4285,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -4300,7 +4300,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -4311,9 +4311,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-1e3bbf05-8acb-4675-a098-da4c64676c4c
+      - req-3a788e1e-ee0a-4db3-a149-8ee8acbdbc64
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -4369,7 +4369,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -4384,7 +4384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82628d7c7cf24f15ae61804c3002b792
+      - d586adb76a3d441cb15ae8d73d897688
   response:
     status:
       code: 200
@@ -4395,9 +4395,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b65598d3-cede-4bae-9854-24629a514437
+      - req-66b2c624-ae0f-4f18-8da3-696c00218dcd
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4409,7 +4409,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4424,7 +4424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8b55ee42859f4557be39a20a50e2a785
+      - 290b510ca44d44f09b6c8f1a4a2adda6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4437,9 +4437,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2d3244ba-93a8-4996-b2ce-f76a121312c6
+      - req-a4578387-1e6e-44fa-9690-de82516e7133
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4448,7 +4448,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4463,7 +4463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - afe2c03bbe7c460fa92b0632e1e38814
+      - f6598acfaf0a439885a03476d2052cd1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4476,9 +4476,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d14ba413-e9a8-4e09-8abb-2cad65928bd3
+      - req-bdb77cfb-4380-4f52-9c90-c4c310d23231
       Date:
-      - Mon, 06 Aug 2018 16:55:03 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4487,7 +4487,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4502,7 +4502,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27fe85ced827483780124d88bf7a1796
+      - 1d6ef88ca8434f0d8a605359d113a93e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4515,9 +4515,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-0c2613c8-ddf2-4b81-b32e-4717900bf8f2
+      - req-e31a94d9-1a4f-4240-af05-1be47a4cc990
       Date:
-      - Mon, 06 Aug 2018 16:55:04 GMT
+      - Mon, 24 Sep 2018 20:33:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4526,7 +4526,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4541,7 +4541,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 10ff7d8ffaf949299d29a390328b1fe1
+      - a15905cf79294e9ca82e6e7dfe27c83f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4554,9 +4554,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5f43dc31-43f7-4e1e-a68d-515f03a5c4f3
+      - req-daa829a6-efe2-4b6f-ade8-66136068d6b9
       Date:
-      - Mon, 06 Aug 2018 16:55:04 GMT
+      - Mon, 24 Sep 2018 20:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4565,7 +4565,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4580,7 +4580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4593,9 +4593,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f6f496a3-ec05-440d-a0ad-7bc31772c522
+      - req-8a0dce59-5d11-4ebf-ac36-037323a97a38
       Date:
-      - Mon, 06 Aug 2018 16:55:04 GMT
+      - Mon, 24 Sep 2018 20:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4604,7 +4604,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4619,7 +4619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fc2c3680ce834e5b8eaa86f2f4d55a2d
+      - e319dcb1e8fe4e33b6818b6057a50111
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4632,9 +4632,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7ffe44c4-f566-432d-92e0-6426ac818b56
+      - req-40b9e510-a93b-4fb5-b846-fff52b822dc6
       Date:
-      - Mon, 06 Aug 2018 16:55:04 GMT
+      - Mon, 24 Sep 2018 20:33:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4643,7 +4643,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4658,7 +4658,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 89fa97a588bb491dacb58a8ef4605ae2
+      - e614c7f5b1ca430d8300b18797af7123
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5741ee8e-b062-4983-bdc4-53a4c75aa866
+      - req-b33dcffe-e2dc-4a77-ac23-70cc5da21155
       Date:
-      - Mon, 06 Aug 2018 16:55:05 GMT
+      - Mon, 24 Sep 2018 20:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4682,7 +4682,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4700,15 +4700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:05 GMT
+      - Mon, 24 Sep 2018 20:33:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c706d2d99c94dcdbe458be72cd92eb6
+      - 6b3fbe54cd2c4084a30b715866408d6d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-75d127b9-d195-4a33-b469-0546501f1596
+      - req-9a60e3e8-2197-4a8c-bd61-e68d118053e0
       Content-Length:
       - '7278'
       Connection:
@@ -4720,7 +4720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:05.480840Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:47.294853Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4799,10 +4799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sFfn6fJOTQ2jIWMF5FO1GA"],
-        "issued_at": "2018-08-06T16:55:05.480913Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x8cJGL6sSCCcNTVGLbZatQ"],
+        "issued_at": "2018-09-24T20:33:47.294872Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4817,22 +4817,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5c706d2d99c94dcdbe458be72cd92eb6
+      - 6b3fbe54cd2c4084a30b715866408d6d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf4d84a1-b26d-472b-b0d0-f1095f0d08f4
+      - req-f7ae8bb2-0ad2-4d56-9c22-b7891886d563
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bf4d84a1-b26d-472b-b0d0-f1095f0d08f4
+      - req-f7ae8bb2-0ad2-4d56-9c22-b7891886d563
       Date:
-      - Mon, 06 Aug 2018 16:55:06 GMT
+      - Mon, 24 Sep 2018 20:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4842,7 +4842,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4860,15 +4860,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:06 GMT
+      - Mon, 24 Sep 2018 20:33:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4aa65587ccbe459988c4ce6323b6582b
+      - c3b96fe0f986406bac83bcda72bc2fe1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0562d279-0f83-465b-90d9-11c8e822c882
+      - req-eff73686-c75b-4803-9f43-96a784ee8a90
       Content-Length:
       - '7278'
       Connection:
@@ -4880,7 +4880,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:06.677659Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:47.727737Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4959,10 +4959,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Tx_M35nmRVSlZNivEQTaBg"],
-        "issued_at": "2018-08-06T16:55:06.677774Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OnXXMkZzSdSqUPC57Xtt5Q"],
+        "issued_at": "2018-09-24T20:33:47.727756Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4977,22 +4977,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4aa65587ccbe459988c4ce6323b6582b
+      - c3b96fe0f986406bac83bcda72bc2fe1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bcf844cc-d714-4d7d-b40c-363d299851c1
+      - req-4aa1f0c1-2e95-4c56-aac6-db04e5fed4d2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bcf844cc-d714-4d7d-b40c-363d299851c1
+      - req-4aa1f0c1-2e95-4c56-aac6-db04e5fed4d2
       Date:
-      - Mon, 06 Aug 2018 16:55:07 GMT
+      - Mon, 24 Sep 2018 20:33:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5002,7 +5002,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5020,15 +5020,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:07 GMT
+      - Mon, 24 Sep 2018 20:33:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7961801a61f04b4c9049641cc115e4c7
+      - 205819ac72984ab5aacd4c88f8ffc881
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8146ae3d-5dd3-41a0-9ff6-7142de945485
+      - req-afdc9fdf-8177-4abf-93da-27f0f9207d00
       Content-Length:
       - '7264'
       Connection:
@@ -5040,7 +5040,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:07.785226Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:48.149080Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5119,10 +5119,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9wnsIAPtQBiWrBC1XUkSgw"],
-        "issued_at": "2018-08-06T16:55:07.785343Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IGlpj4RERYW0rFm1JAnP5w"],
+        "issued_at": "2018-09-24T20:33:48.149100Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5137,22 +5137,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7961801a61f04b4c9049641cc115e4c7
+      - 205819ac72984ab5aacd4c88f8ffc881
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf6795b2-a514-4138-9164-44066a1b2102
+      - req-53032ed4-7066-4d27-a830-ebe6c9cff9b2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bf6795b2-a514-4138-9164-44066a1b2102
+      - req-53032ed4-7066-4d27-a830-ebe6c9cff9b2
       Date:
-      - Mon, 06 Aug 2018 16:55:08 GMT
+      - Mon, 24 Sep 2018 20:33:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5162,7 +5162,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5180,15 +5180,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:08 GMT
+      - Mon, 24 Sep 2018 20:33:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6afec2c48d7644af915ff8b2653d68d2
+      - 61ddbd39dda14c6e830ae965149a3dba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-429f7c8a-ab85-4cb8-aa5c-1a80b17522fa
+      - req-c8819c62-3da2-409f-a5d1-d2a4f90f2541
       Content-Length:
       - '7278'
       Connection:
@@ -5200,7 +5200,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:08.871329Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:48.578292Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5279,10 +5279,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zPW35FHgThqQ-kebPn4yVA"],
-        "issued_at": "2018-08-06T16:55:08.871406Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ctjrhWJwRXixcQA6gD8hCw"],
+        "issued_at": "2018-09-24T20:33:48.578312Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5297,22 +5297,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6afec2c48d7644af915ff8b2653d68d2
+      - 61ddbd39dda14c6e830ae965149a3dba
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1128f628-1eef-4070-b958-ddea40b3e960
+      - req-7efb7cf6-c2d1-4669-a70d-039993e607b9
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1128f628-1eef-4070-b958-ddea40b3e960
+      - req-7efb7cf6-c2d1-4669-a70d-039993e607b9
       Date:
-      - Mon, 06 Aug 2018 16:55:09 GMT
+      - Mon, 24 Sep 2018 20:33:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5322,7 +5322,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5337,22 +5337,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b3729774-5102-4076-99b7-90c46da9518a
+      - req-f5002b83-aa43-4401-b0f9-7f1d8498d5c7
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b3729774-5102-4076-99b7-90c46da9518a
+      - req-f5002b83-aa43-4401-b0f9-7f1d8498d5c7
       Date:
-      - Mon, 06 Aug 2018 16:55:10 GMT
+      - Mon, 24 Sep 2018 20:33:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5362,7 +5362,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5380,15 +5380,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:10 GMT
+      - Mon, 24 Sep 2018 20:33:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f9fc76cb5a764ffd86fcb02a23541b5f
+      - 5ad3506a39cc41eda074a485c8817a42
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5c2240db-96ff-49d5-849c-c48d1ed82444
+      - req-d144f312-a7f0-464d-94e9-7fa9c6d94580
       Content-Length:
       - '7265'
       Connection:
@@ -5400,7 +5400,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:10.392426Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:49.262742Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5479,10 +5479,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9-9ejGwbRuuHHKjaRZMUnQ"],
-        "issued_at": "2018-08-06T16:55:10.392493Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Dpf0xdICR9iarcTc9vFw0A"],
+        "issued_at": "2018-09-24T20:33:49.262762Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5497,22 +5497,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f9fc76cb5a764ffd86fcb02a23541b5f
+      - 5ad3506a39cc41eda074a485c8817a42
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-209be14b-6462-411a-ad38-d6a71f6d442d
+      - req-db9ca05d-38fd-43dc-b7a9-ba5c38110322
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-209be14b-6462-411a-ad38-d6a71f6d442d
+      - req-db9ca05d-38fd-43dc-b7a9-ba5c38110322
       Date:
-      - Mon, 06 Aug 2018 16:55:11 GMT
+      - Mon, 24 Sep 2018 20:33:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5522,7 +5522,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5540,15 +5540,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:11 GMT
+      - Mon, 24 Sep 2018 20:33:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aba93c1f8f1e460ca8ce6abfa9351f0b
+      - ee389cf56d264a6f992cf19ea5a7e65e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5469f9d8-a32b-41df-8ea1-3564ae6b8d17
+      - req-943e6327-5b6e-4fcb-b5ef-29c5d1cb9342
       Content-Length:
       - '7278'
       Connection:
@@ -5560,7 +5560,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:11.469785Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:49.711382Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5639,10 +5639,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MxY4JSi3SrymDne7jbC-Tw"],
-        "issued_at": "2018-08-06T16:55:11.469855Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZTJa87GgT9Sse8rjgqPIGw"],
+        "issued_at": "2018-09-24T20:33:49.711406Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5657,22 +5657,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aba93c1f8f1e460ca8ce6abfa9351f0b
+      - ee389cf56d264a6f992cf19ea5a7e65e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3f9d2a9d-1d6c-46e2-8ba1-6434f86eb0d8
+      - req-418b79a2-0803-400c-91a1-40f8f20eb264
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3f9d2a9d-1d6c-46e2-8ba1-6434f86eb0d8
+      - req-418b79a2-0803-400c-91a1-40f8f20eb264
       Date:
-      - Mon, 06 Aug 2018 16:55:12 GMT
+      - Mon, 24 Sep 2018 20:33:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5682,7 +5682,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5700,15 +5700,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:12 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71cea231504a47e9a84919fb6b299848
+      - 5ee01b3927c24866a5e3b40208444c15
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d32a4317-9f29-4112-b792-5a86bb4aac47
+      - req-c7dfcf17-6ca2-4499-a3a7-8738dc3509ee
       Content-Length:
       - '7311'
       Connection:
@@ -5720,7 +5720,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:12.449336Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:50.164263Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5799,10 +5799,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zj3I306ARtOruHX6692tXw"],
-        "issued_at": "2018-08-06T16:55:12.449407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jw5YtzcnQpWZKjjpP_Ln2w"],
+        "issued_at": "2018-09-24T20:33:50.164282Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -5817,7 +5817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71cea231504a47e9a84919fb6b299848
+      - 5ee01b3927c24866a5e3b40208444c15
   response:
     status:
       code: 200
@@ -5828,13 +5828,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:55:12 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5852,15 +5852,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:12 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 301403e7b303497c8fa0a941e8790183
+      - 52ca473a23f74e638a5e8bc19768625e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a4048281-8883-4408-83a4-6161d68127c1
+      - req-65f7bc51-76ab-4b9e-82ce-aeee1677250b
       Content-Length:
       - '7278'
       Connection:
@@ -5872,7 +5872,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:12.916763Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:50.430625Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5951,10 +5951,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b4xDpW--TYO_GIUIhN08hQ"],
-        "issued_at": "2018-08-06T16:55:12.916840Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AywnY4itQrSkt3DNdry1_Q"],
+        "issued_at": "2018-09-24T20:33:50.430644Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5969,7 +5969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 301403e7b303497c8fa0a941e8790183
+      - 52ca473a23f74e638a5e8bc19768625e
   response:
     status:
       code: 200
@@ -5980,16 +5980,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-3385a2ea-2b0d-4ec0-8ca8-17a364b93e8c
+      - req-dd63681c-3fe3-4f9e-af3c-177738cf73a2
       Date:
-      - Mon, 06 Aug 2018 16:55:13 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6007,15 +6007,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:13 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9d410aadf13416a929b1a0183455447
+      - 0c2a7f23ce064e59aeefcb76918ad19a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-90f9662d-7026-49b9-9de0-514703877168
+      - req-b748e6e0-8407-43c0-bfc3-4b55948056ff
       Content-Length:
       - '7278'
       Connection:
@@ -6027,7 +6027,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:13.419580Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:50.722340Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6106,10 +6106,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OGEh0dnOQEWXySMRJHtFIw"],
-        "issued_at": "2018-08-06T16:55:13.419649Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r6V7aneQQ-eefieOKE_e3g"],
+        "issued_at": "2018-09-24T20:33:50.722359Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6124,7 +6124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9d410aadf13416a929b1a0183455447
+      - 0c2a7f23ce064e59aeefcb76918ad19a
   response:
     status:
       code: 200
@@ -6135,16 +6135,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-dc0a1456-34f0-4c7d-8935-54db4ce69c93
+      - req-4879291b-1904-4740-bdac-668f6ac8c8be
       Date:
-      - Mon, 06 Aug 2018 16:55:13 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6162,15 +6162,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:13 GMT
+      - Mon, 24 Sep 2018 20:33:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0c81d714507b42908ae2462c0b2e0c96
+      - f0bd63586af84f05962a42ac5063fc4a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-15fdb793-a8c5-4a7e-9df3-8714ba12d223
+      - req-47b14151-1152-46e7-8e9d-1656c9eadb61
       Content-Length:
       - '7264'
       Connection:
@@ -6182,7 +6182,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:13.943488Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:51.014959Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6261,10 +6261,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uB3Xa-MRRkWXzhFFIPtllQ"],
-        "issued_at": "2018-08-06T16:55:13.943555Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PepTlTLDRr25sT8oX7K2OA"],
+        "issued_at": "2018-09-24T20:33:51.014978Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6279,7 +6279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c81d714507b42908ae2462c0b2e0c96
+      - f0bd63586af84f05962a42ac5063fc4a
   response:
     status:
       code: 200
@@ -6290,16 +6290,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e56bcc90-85b5-4dce-9b19-22a2865b7aaa
+      - req-9ca1c76e-e3a7-4974-bc1d-5bac6725d939
       Date:
-      - Mon, 06 Aug 2018 16:55:14 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6317,15 +6317,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:14 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e9df772dd897466d995bdf9811a5b547
+      - 35fbd814c01b49b388a737f974520d8c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-efcdc8bb-099f-4721-ae6f-0bf052e043d6
+      - req-e6c8a7d2-b091-4bd8-a4c2-a2171687dd68
       Content-Length:
       - '7278'
       Connection:
@@ -6337,7 +6337,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:14.472412Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:51.328040Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6416,10 +6416,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IPdo4OGHRbew29cW4_ctCw"],
-        "issued_at": "2018-08-06T16:55:14.472489Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2LZkIXPrRqCTH8u31TBKwQ"],
+        "issued_at": "2018-09-24T20:33:51.328060Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6434,7 +6434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9df772dd897466d995bdf9811a5b547
+      - 35fbd814c01b49b388a737f974520d8c
   response:
     status:
       code: 200
@@ -6445,16 +6445,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e40d5b13-d59a-4299-93e8-62e59a5b67bd
+      - req-b950809d-372c-40b0-8d19-ceadb858bf04
       Date:
-      - Mon, 06 Aug 2018 16:55:14 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6469,7 +6469,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71cea231504a47e9a84919fb6b299848
+      - 5ee01b3927c24866a5e3b40208444c15
   response:
     status:
       code: 200
@@ -6480,16 +6480,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7b15860e-83f5-4147-894c-66e8b0f2db3a
+      - req-8b67529b-0931-44fb-a755-170df4e8d49d
       Date:
-      - Mon, 06 Aug 2018 16:55:14 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6507,15 +6507,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:14 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a9f984b200e443faa7837e63240e938
+      - a61b4059b5814b59b9d40d790624d782
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-515bf152-b120-4808-a2b1-6d0f733b9112
+      - req-b3c41e51-c49a-49cb-8dcf-9d30ed6dcbf8
       Content-Length:
       - '7265'
       Connection:
@@ -6527,7 +6527,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:15.188608Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:51.741458Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6606,10 +6606,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xo2ttWliSFyU13QqwohHDQ"],
-        "issued_at": "2018-08-06T16:55:15.188675Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-J-Ggpr0Tm-y1kv6CmKoRA"],
+        "issued_at": "2018-09-24T20:33:51.741477Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6624,7 +6624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a9f984b200e443faa7837e63240e938
+      - a61b4059b5814b59b9d40d790624d782
   response:
     status:
       code: 200
@@ -6635,16 +6635,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e2f854d4-7c59-4819-9803-0809ff5bc61e
+      - req-59bc2a74-59d9-4657-9759-062c249a6dfb
       Date:
-      - Mon, 06 Aug 2018 16:55:15 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6662,15 +6662,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:15 GMT
+      - Mon, 24 Sep 2018 20:33:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bd0de46391bd4cca8ac0308855ae2a06
+      - d71efee002ba4b7abe2392b7ad7a6bc1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf157e1d-04af-4b99-89ea-b2cf257e00b2
+      - req-74687747-72ea-47bc-88eb-797663a03d57
       Content-Length:
       - '7278'
       Connection:
@@ -6682,7 +6682,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:15.672393Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:52.040945Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6761,10 +6761,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["APAiwxvcTKqkX-HoV93K2g"],
-        "issued_at": "2018-08-06T16:55:15.672461Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nt1kJsNiQai85hotPpc7zQ"],
+        "issued_at": "2018-09-24T20:33:52.040969Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6779,7 +6779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd0de46391bd4cca8ac0308855ae2a06
+      - d71efee002ba4b7abe2392b7ad7a6bc1
   response:
     status:
       code: 200
@@ -6790,16 +6790,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7d5706b4-2ce9-4350-8c22-6c519e9aabf6
+      - req-82751cd2-96ba-4235-842b-430d87f414d3
       Date:
-      - Mon, 06 Aug 2018 16:55:15 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-85539bba-a4a0-4ee2-a396-2494bd7af708
+      - req-20c697ac-dc76-43da-8d46-b072967e04d8
       Date:
-      - Mon, 06 Aug 2018 16:55:16 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6265d4a1-7d82-4fd1-b333-fe0994e173d5
+      - req-9da26a90-3472-4aec-a66d-7ef240617ae5
       Date:
-      - Mon, 06 Aug 2018 16:55:16 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-81c5eafb-d18f-4f42-9ded-b9d0a8d920f4
+      - req-f6d22576-6fa7-41dd-9da3-86c48f93c414
       Date:
-      - Mon, 06 Aug 2018 16:55:16 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b9f79ac1-75f3-4c0b-8ebd-616ddef87893
+      - req-c3656ae5-8c01-4293-a680-9413c313c286
       Date:
-      - Mon, 06 Aug 2018 16:55:16 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e26836b1-812d-4800-a764-381deaaea479
+      - req-ef9b049d-f79b-47ef-b64e-a7d6cd4c09e3
       Date:
-      - Mon, 06 Aug 2018 16:55:17 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6989,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,15 +7002,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-effd5a0a-2a64-4698-9e12-c30f3a6982a8
+      - req-e1144e68-d263-4687-8107-e1cf6d1bb5ed
       Date:
-      - Mon, 06 Aug 2018 16:55:17 GMT
+      - Mon, 24 Sep 2018 20:33:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7025,7 +7025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7038,14 +7038,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a4b63edb-d2d9-442f-9145-6836741ccde9
+      - req-24a9d5e9-2574-45e6-8dbf-8bacb71e6118
       Date:
-      - Mon, 06 Aug 2018 16:55:17 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -7060,7 +7060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7073,15 +7073,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-483b56a7-0d6e-43d1-8d6a-01442f83856b
+      - req-87d376c9-8149-45a9-8a56-94a2ca2f5449
       Date:
-      - Mon, 06 Aug 2018 16:55:18 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7096,7 +7096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7109,14 +7109,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2c0dcb98-ad35-4db1-8017-9eb29234a4e5
+      - req-0a1fd90e-2370-4073-8980-63af60e23e35
       Date:
-      - Mon, 06 Aug 2018 16:55:18 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7131,7 +7131,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7144,14 +7144,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a366dc13-5f22-4ea9-b4e0-1ad58999cdbc
+      - req-385a2069-d832-4c76-bd48-e7f43b88a871
       Date:
-      - Mon, 06 Aug 2018 16:55:18 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7166,7 +7166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7179,14 +7179,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-e5b30beb-0691-4090-8e01-0682816a8946
+      - req-b27d7cb4-e5ed-469e-a1c9-63da176b90c1
       Date:
-      - Mon, 06 Aug 2018 16:55:19 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7204,15 +7204,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:24 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 163e4d1526ce49cfa8ca8b93f3ff587f
+      - 187ee52f65db4d7fb48c1ad1501bbf2a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-be15c14c-1633-4bda-987e-d70dbbfcc9a9
+      - req-681e1548-f03c-45ce-9062-f9b18154e98b
       Content-Length:
       - '7311'
       Connection:
@@ -7224,7 +7224,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:24.483306Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:53.842323Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7303,16 +7303,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJQ10bRUR5u808Flre3VYQ"],
-        "issued_at": "2018-08-06T16:55:24.483374Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fGpdnRKPRVC0-64aZoM4Nw"],
+        "issued_at": "2018-09-24T20:33:53.842349Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"163e4d1526ce49cfa8ca8b93f3ff587f"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"187ee52f65db4d7fb48c1ad1501bbf2a"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7324,15 +7324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:24 GMT
+      - Mon, 24 Sep 2018 20:33:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5dca439e1d4d42cc89402ee0ae42d310
+      - 988b65ab79004d1caf928ca1526a8db4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-af86e2fc-1c58-410e-a51c-a10a45e1008e
+      - req-1c3a9971-a541-4933-b2a7-8ed77682e71f
       Content-Length:
       - '7346'
       Connection:
@@ -7344,7 +7344,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:24.483306Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:53.842323Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7423,10 +7423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fLfh8B9MSF65VEtZedFRsg",
-        "DJQ10bRUR5u808Flre3VYQ"], "issued_at": "2018-08-06T16:55:25.090614Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zHeTvGWqRqiHNuM0KPLgyw",
+        "fGpdnRKPRVC0-64aZoM4Nw"], "issued_at": "2018-09-24T20:33:54.022979Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7444,15 +7444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:25 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7a27aff172d84e379882dfabb87faa60
+      - 5277fe7c8b6e4c26912d9049ca1becfc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-116fb60b-6298-4261-afa7-8c5b692fa150
+      - req-302871a5-52c3-44ab-ab60-50ead556b1a5
       Content-Length:
       - '7311'
       Connection:
@@ -7464,7 +7464,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:25.468653Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:54.233530Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7543,16 +7543,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R3MFr7Q7TCu2n67aunAOXw"],
-        "issued_at": "2018-08-06T16:55:25.468725Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Thdk8eOAQUihFb-P3Vq4Vw"],
+        "issued_at": "2018-09-24T20:33:54.233550Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"7a27aff172d84e379882dfabb87faa60"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"5277fe7c8b6e4c26912d9049ca1becfc"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7564,15 +7564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:25 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8847c420f2af4f259c5cd517c6f4d5b1
+      - 24866ba01a56464780d14f01ac18fef3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-db6f82b2-8254-4c2f-8225-66c1352ac204
+      - req-06aadd7d-a012-4868-87f3-389cd6308332
       Content-Length:
       - '7346'
       Connection:
@@ -7584,7 +7584,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:25.468653Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:54.233530Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7663,10 +7663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_bGnRNGvTv-1Yo-0u_MvnA",
-        "R3MFr7Q7TCu2n67aunAOXw"], "issued_at": "2018-08-06T16:55:25.896730Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJ0nJGH7QbaxSpUEUvyKZw",
+        "Thdk8eOAQUihFb-P3Vq4Vw"], "issued_at": "2018-09-24T20:33:54.423505Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -7681,7 +7681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd7a7afb0bd14745b75eb6f4eeb07514
+      - a6196ee88e1340808ddaaaad15633be1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7694,14 +7694,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-ddba317d-c928-4064-93e8-5b2f8f212c19
+      - req-53d8a3f7-8c23-425c-abbe-895290fcc321
       Date:
-      - Mon, 06 Aug 2018 16:55:26 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -7716,22 +7716,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81de3f0e-6701-4560-901f-29e62c5d714d
+      - req-9cdb0d21-56ab-4e96-b73f-8cdd3105b110
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-81de3f0e-6701-4560-901f-29e62c5d714d
+      - req-9cdb0d21-56ab-4e96-b73f-8cdd3105b110
       Date:
-      - Mon, 06 Aug 2018 16:55:26 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -7764,7 +7764,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -7779,22 +7779,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-66010d49-9895-471d-b7e6-ddac7affe973
+      - req-d3940026-6f92-45a1-8986-be33536fba2d
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-66010d49-9895-471d-b7e6-ddac7affe973
+      - req-d3940026-6f92-45a1-8986-be33536fba2d
       Date:
-      - Mon, 06 Aug 2018 16:55:26 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -7811,307 +7811,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5c706d2d99c94dcdbe458be72cd92eb6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-946fc6b3-e236-4cb2-b14a-9b7ae0626900
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-946fc6b3-e236-4cb2-b14a-9b7ae0626900
-      Date:
-      - Mon, 06 Aug 2018 16:55:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5c706d2d99c94dcdbe458be72cd92eb6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-312de3bf-f264-4eb7-b614-a38bf45c953f
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-312de3bf-f264-4eb7-b614-a38bf45c953f
-      Date:
-      - Mon, 06 Aug 2018 16:55:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4aa65587ccbe459988c4ce6323b6582b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-879ad440-eb31-422b-862c-ae971c4234ef
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-879ad440-eb31-422b-862c-ae971c4234ef
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4aa65587ccbe459988c4ce6323b6582b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-4b0ab4eb-bb35-4862-834e-b2911e12694c
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-4b0ab4eb-bb35-4862-834e-b2911e12694c
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7961801a61f04b4c9049641cc115e4c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-ab8b0d72-58e0-4506-8180-0b1b55cf3e10
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1053'
-      X-Openstack-Request-Id:
-      - req-ab8b0d72-58e0-4506-8180-0b1b55cf3e10
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
-        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
-        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
-        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
-        "created_at": "2016-08-19T08:37:28.000000", "size": 1, "id": "8004ec8e-60fa-4b9b-9c36-8f9b99aa57bc",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
-        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
-        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
-        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
-        "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7961801a61f04b4c9049641cc115e4c7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-20a8541e-caa2-4528-a9f6-3d731ad304bc
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1081'
-      X-Openstack-Request-Id:
-      - req-20a8541e-caa2-4528-a9f6-3d731ad304bc
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
-        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
-        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
-        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
-        "created_at": "2016-08-19T08:37:28.000000", "size": 1, "id": "8004ec8e-60fa-4b9b-9c36-8f9b99aa57bc",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
-        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
-        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
-        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
-        "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
-        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6afec2c48d7644af915ff8b2653d68d2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-def8c980-ffa3-4346-b13b-b60562e42e56
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-def8c980-ffa3-4346-b13b-b60562e42e56
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6afec2c48d7644af915ff8b2653d68d2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-a7951457-f0e6-4dfa-a040-9cb1c89fa5ec
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-a7951457-f0e6-4dfa-a040-9cb1c89fa5ec
-      Date:
-      - Mon, 06 Aug 2018 16:55:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -8126,30 +7826,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e072b88f-45c5-4f1f-88f1-71068157357f
+      - req-1cc01023-67c7-46f8-b686-94274087e9d8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e072b88f-45c5-4f1f-88f1-71068157357f
+      - req-1cc01023-67c7-46f8-b686-94274087e9d8
       Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
+      - Mon, 24 Sep 2018 20:33:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:54 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
+    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available
     body:
       encoding: US-ASCII
       string: ''
@@ -8161,167 +7861,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0159dd7-7189-4809-b183-7e9ceb467de5
+      - req-b3e461cb-21b2-4616-a829-c69096e65a4a
       Content-Type:
       - application/json
       Content-Length:
-      - '17'
+      - '1098'
       X-Openstack-Request-Id:
-      - req-b0159dd7-7189-4809-b183-7e9ceb467de5
+      - req-b3e461cb-21b2-4616-a829-c69096e65a4a
       Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
+      - Mon, 24 Sep 2018 20:33:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
+      string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
+        "rel": "next"}], "snapshots": [{"status": "available", "metadata": {}, "os-extended-snapshot-attributes:progress":
+        "100%", "name": "EmsRefreshSpec-VolumeSnapshot_0_3", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
+        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
+        "created_at": "2016-08-19T08:37:28.000000", "size": 1, "id": "8004ec8e-60fa-4b9b-9c36-8f9b99aa57bc",
+        "description": "EmsRefreshSpec-VolumeSnapshot description"}, {"status": "available",
+        "metadata": {}, "os-extended-snapshot-attributes:progress": "100%", "name":
+        "EmsRefreshSpec-VolumeSnapshot_0_2", "volume_id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
+        "os-extended-snapshot-attributes:project_id": "4637c33fee924ebea81f8d209e452c91",
+        "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
+        "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f9fc76cb5a764ffd86fcb02a23541b5f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-a8b57ffc-ef14-47c7-ae9a-d51c40a5d9bc
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-a8b57ffc-ef14-47c7-ae9a-d51c40a5d9bc
-      Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f9fc76cb5a764ffd86fcb02a23541b5f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-63550875-a20a-43e8-83f4-2b4fb7466017
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-63550875-a20a-43e8-83f4-2b4fb7466017
-      Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aba93c1f8f1e460ca8ce6abfa9351f0b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-81ec8eb8-5545-433e-b4f5-5b490c39d770
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-81ec8eb8-5545-433e-b4f5-5b490c39d770
-      Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - aba93c1f8f1e460ca8ce6abfa9351f0b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-a0621d56-11eb-4e10-807b-4a3a0d47b227
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      X-Openstack-Request-Id:
-      - req-a0621d56-11eb-4e10-807b-4a3a0d47b227
-      Date:
-      - Mon, 06 Aug 2018 16:55:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"snapshots": []}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -8336,22 +7906,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0467bf1d-9367-4866-ad27-940d1b6d15e0
+      - req-4bd29839-1492-4698-bfd9-d22ae8b45041
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-0467bf1d-9367-4866-ad27-940d1b6d15e0
+      - req-4bd29839-1492-4698-bfd9-d22ae8b45041
       Date:
-      - Mon, 06 Aug 2018 16:55:29 GMT
+      - Mon, 24 Sep 2018 20:33:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -8384,7 +7954,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -8399,22 +7969,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-47c738ee-dc08-490a-9c04-924a77e19045
+      - req-a0640f54-3383-4fee-b266-ca8e273660cb
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-47c738ee-dc08-490a-9c04-924a77e19045
+      - req-a0640f54-3383-4fee-b266-ca8e273660cb
       Date:
-      - Mon, 06 Aug 2018 16:55:29 GMT
+      - Mon, 24 Sep 2018 20:33:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -8455,7 +8025,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -8470,22 +8040,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5d9ff0ec-a5e0-4995-b517-bfad9da536b7
+      - req-473f23e2-f362-40e5-8007-5e54915d1430
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-5d9ff0ec-a5e0-4995-b517-bfad9da536b7
+      - req-473f23e2-f362-40e5-8007-5e54915d1430
       Date:
-      - Mon, 06 Aug 2018 16:55:30 GMT
+      - Mon, 24 Sep 2018 20:33:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -8519,7 +8089,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -8534,27 +8104,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8cd138a23694bceb5c63d311ac1d432
+      - 8b0f6115b8b84335a475a3d29e3219e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd2d286a-d9cd-4a47-bb06-7ce7c2c90de1
+      - req-71d7f2ed-1857-4e8d-88de-42288d5fd243
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fd2d286a-d9cd-4a47-bb06-7ce7c2c90de1
+      - req-71d7f2ed-1857-4e8d-88de-42288d5fd243
       Date:
-      - Mon, 06 Aug 2018 16:55:30 GMT
+      - Mon, 24 Sep 2018 20:33:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8572,15 +8142,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:31 GMT
+      - Mon, 24 Sep 2018 20:33:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 75d4511fc55e4d04884f5ab2effd0252
+      - a55f46921cbb474dac0e8e168bdec15f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79641074-fa00-477b-a30e-e5b9ba1d5bae
+      - req-8460b02d-0cb3-4aa1-9f11-00068b4e92f6
       Content-Length:
       - '7311'
       Connection:
@@ -8592,7 +8162,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:32.228939Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:56.934259Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8671,10 +8241,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sKemJDuGSPiZC9FrNBpGLA"],
-        "issued_at": "2018-08-06T16:55:32.229040Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OrjDyJRgSUWQoA6AzS6ZkQ"],
+        "issued_at": "2018-09-24T20:33:56.934280Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8692,15 +8262,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:32 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b68d3536-8238-486b-92cc-350a775e3893
+      - req-c5da4785-d56f-4c7f-b503-c85d61e6ea05
       Content-Length:
       - '7311'
       Connection:
@@ -8712,7 +8282,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:32.669199Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:57.176325Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8791,10 +8361,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MpEMrRvzSoaTL_VJ78o_qg"],
-        "issued_at": "2018-08-06T16:55:32.669283Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3LngVYdcR_Seq_3nP8FbqQ"],
+        "issued_at": "2018-09-24T20:33:57.176363Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8809,7 +8379,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -8820,37 +8390,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-785cb30a-b6dc-49dc-aafc-d934b1e47653
+      - req-8948c5ce-fecf-4a6c-872a-e09fddd81826
       Date:
-      - Mon, 06 Aug 2018 16:55:32 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -8860,7 +8405,12 @@ http_interactions:
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
         false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "c2ab9441-dd1c-4acc-a3a6-753f1a582291"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
+        59}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -8880,19 +8430,39 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8910,15 +8480,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:33 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 72eb4dc671eb42f4b4e8e0752d9fd205
+      - 522448b849ae4bc3bb5be3bfecc73a88
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5ad76ad1-2001-4e88-a667-42cbaeb9f001
+      - req-6694a8a3-c044-46bf-bfe7-58ca6f26ed94
       Content-Length:
       - '7311'
       Connection:
@@ -8930,7 +8500,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:33.327888Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:57.507414Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9009,10 +8579,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UdMHuyXyRai1BpmTVNZXMA"],
-        "issued_at": "2018-08-06T16:55:33.327990Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eHbOZYHlTmqWtpnDgc-2qg"],
+        "issued_at": "2018-09-24T20:33:57.507434Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9030,15 +8600,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:33 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d75e0c1ab9094ab08fdc9e7dc9665331
+      - 54707b482cbb4aafbf247fb84604430e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-269b77c8-1f51-454c-9d9e-e2246b99e6a5
+      - req-70be650d-d042-4a5e-9130-d16e30a6901e
       Content-Length:
       - '297'
       Connection:
@@ -9047,12 +8617,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:55:33.636781Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:33:57.667801Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["feL3VqaESuiXIycdk7RPcQ"],
-        "issued_at": "2018-08-06T16:55:33.636842Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OoDKISJrT6SIZyF_mXPDBQ"],
+        "issued_at": "2018-09-24T20:33:57.667825Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -9067,20 +8637,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d75e0c1ab9094ab08fdc9e7dc9665331
+      - 54707b482cbb4aafbf247fb84604430e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:33 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a2f4d98-c001-4b9f-8848-71426a2a54a2
+      - req-839a4e6b-fee6-4033-a60c-0811b98245ed
       Content-Length:
       - '2457'
       Connection:
@@ -9113,13 +8683,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"d75e0c1ab9094ab08fdc9e7dc9665331"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"54707b482cbb4aafbf247fb84604430e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -9131,15 +8701,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:33 GMT
+      - Mon, 24 Sep 2018 20:33:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7eed7c5b079d4b50944947bbda1aa324
+      - b03a759fa9e642f39ff83c19dae6c12f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-535e2005-f466-4536-aacd-ad6323dc3df7
+      - req-1dd2e9ae-66c4-40aa-8f28-2e8fa47f1dfe
       Content-Length:
       - '7313'
       Connection:
@@ -9151,7 +8721,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:33.636781Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:57.667801Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9230,10 +8800,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a7ZEtPzURyK82FNWDpeWlQ",
-        "feL3VqaESuiXIycdk7RPcQ"], "issued_at": "2018-08-06T16:55:34.095920Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Il1-2TWbTMamh-ijbwd7dA",
+        "OoDKISJrT6SIZyF_mXPDBQ"], "issued_at": "2018-09-24T20:33:58.016612Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -9248,20 +8818,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eed7c5b079d4b50944947bbda1aa324
+      - b03a759fa9e642f39ff83c19dae6c12f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:34 GMT
+      - Mon, 24 Sep 2018 20:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33bb46af-00c7-40e0-af58-004c626925c0
+      - req-af2dca36-5246-4613-896d-e2b9f5c200f0
       Content-Length:
       - '2179'
       Connection:
@@ -9294,7 +8864,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9312,15 +8882,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:34 GMT
+      - Mon, 24 Sep 2018 20:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 439d203d33714c9da9bc3c407bfec22d
+      - 69bcd03dd52d4529ae9bfc6cee5cdaf9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7af7dc9f-7235-4a88-878a-926469340279
+      - req-6eeee189-f257-4350-a33d-6b16c2f96dcb
       Content-Length:
       - '7278'
       Connection:
@@ -9332,7 +8902,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:34.646366Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:58.342354Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9411,10 +8981,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gw6Z4aVeTeKbIGmmNU0z7w"],
-        "issued_at": "2018-08-06T16:55:34.646471Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UCQnytkySX6wSHc7afkNRw"],
+        "issued_at": "2018-09-24T20:33:58.342382Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9432,15 +9002,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:34 GMT
+      - Mon, 24 Sep 2018 20:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 521430cc36704aa7b4b468f0c96a0886
+      - 75cc5817535048d3a2ce2bb1bc1f2c22
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-69202cab-ac0f-4db3-ba4e-23cab39cdf2c
+      - req-0ebcf90d-b640-4490-be7e-f879a00c742b
       Content-Length:
       - '7278'
       Connection:
@@ -9452,7 +9022,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:35.031996Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:58.545920Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9531,10 +9101,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HwJ3GI8LTOKP_i-cckDF8Q"],
-        "issued_at": "2018-08-06T16:55:35.032039Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EcBLLndLRnOVxG06EdjDJg"],
+        "issued_at": "2018-09-24T20:33:58.545940Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9552,15 +9122,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:35 GMT
+      - Mon, 24 Sep 2018 20:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5a73c458bf6848098dd1ce9821079079
+      - ea03e7fbe5954eda88d92dc9eebd72ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-db2d8e52-5c59-4675-bd72-a48f3955693f
+      - req-84a4c402-f167-4945-a4b3-bd99e0df956b
       Content-Length:
       - '7264'
       Connection:
@@ -9572,7 +9142,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:35.280577Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:58.739291Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9651,10 +9221,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rccHf3IwTXm5hhCNOAN7UA"],
-        "issued_at": "2018-08-06T16:55:35.280627Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["d_X00V5mTeqQq0MdvNIM4g"],
+        "issued_at": "2018-09-24T20:33:58.739311Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9672,15 +9242,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:35 GMT
+      - Mon, 24 Sep 2018 20:33:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '0648f3743864432b9dd44c2eb259b1e9'
+      - 188ecdaf1e31422c8d9d12eb1fc5afdb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-36955875-4b45-4a5b-b03a-91f5a03bec8e
+      - req-17f45c0c-df64-48d3-a8c3-9d5f771aa4f2
       Content-Length:
       - '7278'
       Connection:
@@ -9692,7 +9262,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:35.577725Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:58.934452Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9771,10 +9341,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WE2yAfW-TOa6EpuaX4FFRA"],
-        "issued_at": "2018-08-06T16:55:35.577767Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["45PquUlWQq-jcFs4Kv4Tzg"],
+        "issued_at": "2018-09-24T20:33:58.934471Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9792,15 +9362,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:35 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9aee45b7a05c42abb5949bf853b4cc01
+      - 3b79db7e70a2473199217d5c0ae7e902
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ef9c7923-ae26-4dbf-8647-9f2483b67beb
+      - req-0e21183d-7c9d-45e7-82f6-8336aecd3e35
       Content-Length:
       - '7265'
       Connection:
@@ -9812,7 +9382,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:35.795803Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:59.151183Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9891,10 +9461,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aK2FsSFpTFiZfsGHwTp2hg"],
-        "issued_at": "2018-08-06T16:55:35.795838Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hUdIUv-tShqurhxyKIjM5Q"],
+        "issued_at": "2018-09-24T20:33:59.151209Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9912,15 +9482,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:35 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 144987f0197a45698bc17d1422e78449
+      - 7dcf0011932e464ab1a52fea1ac6035e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9430108d-8e90-4c21-a0cb-d01f34bb04ff
+      - req-43827e28-4a2c-4e28-8c3a-cd644225307a
       Content-Length:
       - '7278'
       Connection:
@@ -9932,7 +9502,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:36.167952Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:59.351676Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10011,10 +9581,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LKZiWCjCQ02dls5tVou4Iw"],
-        "issued_at": "2018-08-06T16:55:36.168038Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jSnWcUJ5Rq-nG4PDwUAAdw"],
+        "issued_at": "2018-09-24T20:33:59.351696Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10032,15 +9602,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:36 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7247342df6034c3386ffa262c6f257dd
+      - 7a8633de7a5f4594b1535a31885536a2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11b73ed5-1a6f-4f1b-a950-600bb3755b09
+      - req-ea028fd8-93d6-4c24-9fa2-203c74624592
       Content-Length:
       - '7278'
       Connection:
@@ -10052,7 +9622,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:36.493785Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:59.548754Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10131,10 +9701,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GbqBkSyvTZeuJeL36BvXvw"],
-        "issued_at": "2018-08-06T16:55:36.493855Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MSmLj3MHT9msg_X6WyZmyg"],
+        "issued_at": "2018-09-24T20:33:59.548788Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -10149,7 +9719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7247342df6034c3386ffa262c6f257dd
+      - 7a8633de7a5f4594b1535a31885536a2
   response:
     status:
       code: 200
@@ -10160,14 +9730,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c123c188-759a-4c3b-8063-f35a4dc7d6a1
+      - req-cd55dee7-7d43-4f1e-9515-f816cec8c411
       Date:
-      - Mon, 06 Aug 2018 16:55:36 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10185,15 +9755,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:36 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7b29a47f8b5541afb744411aef5e3a09
+      - 7aaa93d1a09649ed94a740c610f3d4b4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17507103-2309-46b4-9d5c-d7a3b37dbf85
+      - req-5fc97cd5-3dee-4ded-826f-269c9ff3ea7e
       Content-Length:
       - '7278'
       Connection:
@@ -10205,7 +9775,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:37.098923Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:59.862178Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10284,10 +9854,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1wd0gp9FSoWhi5DDoj4LLg"],
-        "issued_at": "2018-08-06T16:55:37.098988Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Af2SeRBhTMeQNMxwLRQMmA"],
+        "issued_at": "2018-09-24T20:33:59.862222Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -10302,7 +9872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b29a47f8b5541afb744411aef5e3a09
+      - 7aaa93d1a09649ed94a740c610f3d4b4
   response:
     status:
       code: 200
@@ -10313,14 +9883,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f4767e7b-eb4c-46dc-9420-23b3a7b13452
+      - req-543af0e0-f6a5-48cb-8a23-5967b5e09d6f
       Date:
-      - Mon, 06 Aug 2018 16:55:37 GMT
+      - Mon, 24 Sep 2018 20:33:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10338,15 +9908,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:37 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fab59308-f221-484f-a8fe-e35c1e9e4292
+      - req-6a899678-aa07-425a-a4bd-b10b2ba6af0a
       Content-Length:
       - '7264'
       Connection:
@@ -10358,7 +9928,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:37.612883Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:00.170006Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10437,10 +10007,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UuS0XBR-Tf-hLzrpqhzTCw"],
-        "issued_at": "2018-08-06T16:55:37.612952Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ck087wpMRB-kiOLuwu2_9g"],
+        "issued_at": "2018-09-24T20:34:00.170071Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -10455,7 +10025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -10466,9 +10036,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-e999472a-4227-4e1b-a6e6-dfdda75d7ddd
+      - req-0512bb69-50c9-4acd-b30f-c7d9b486ee7a
       Date:
-      - Mon, 06 Aug 2018 16:55:37 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -10502,7 +10072,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -10517,7 +10087,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -10528,14 +10098,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6973ca4c-bc3a-42da-9cce-ec1bddaf42f6
+      - req-6cae630f-98f9-4523-b981-075dcd3b4122
       Date:
-      - Mon, 06 Aug 2018 16:55:38 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10553,15 +10123,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:38 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8e6245908ce44f3da0f7e93418976a2d
+      - e33e6ed478964b54ad9385cb544fb390
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b81f2cd1-674e-4c08-af34-15a8bfd766c0
+      - req-e3a449df-56c2-47db-9fd6-3efe18111c0c
       Content-Length:
       - '7278'
       Connection:
@@ -10573,7 +10143,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:38.409584Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:00.599053Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10652,10 +10222,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IfSWoCFbSWuRarnS9_SAuw"],
-        "issued_at": "2018-08-06T16:55:38.409665Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tKhyfaNKQaWKiZS9ZKJtkw"],
+        "issued_at": "2018-09-24T20:34:00.599073Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -10670,7 +10240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8e6245908ce44f3da0f7e93418976a2d
+      - e33e6ed478964b54ad9385cb544fb390
   response:
     status:
       code: 200
@@ -10681,14 +10251,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-796154c1-3988-4edd-8bf1-82ba727d5998
+      - req-821b83df-55b3-447f-885b-28282733a858
       Date:
-      - Mon, 06 Aug 2018 16:55:38 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -10703,7 +10273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 72eb4dc671eb42f4b4e8e0752d9fd205
+      - 522448b849ae4bc3bb5be3bfecc73a88
   response:
     status:
       code: 200
@@ -10714,14 +10284,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1754f5e8-7e5d-41c0-9378-a74208074a98
+      - req-f21d6e77-dac7-4771-9f2c-9284212f56a5
       Date:
-      - Mon, 06 Aug 2018 16:55:38 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10739,15 +10309,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:39 GMT
+      - Mon, 24 Sep 2018 20:34:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2f9f9d4ccf00431e894336aee15c1d35
+      - 43cc518af3fd44d7836d26c20dd25bf5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ab03ec11-2660-49c6-b60a-2afea07a2459
+      - req-20f9e679-02ea-4ceb-8664-59b7f7c79e84
       Content-Length:
       - '7265'
       Connection:
@@ -10759,7 +10329,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:39.242660Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:01.024313Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10838,10 +10408,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qo-YaxsPRnO9UuPU0b123w"],
-        "issued_at": "2018-08-06T16:55:39.242743Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aYFZz2cIRk-ToRKjUIUCYQ"],
+        "issued_at": "2018-09-24T20:34:01.024333Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -10856,7 +10426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2f9f9d4ccf00431e894336aee15c1d35
+      - 43cc518af3fd44d7836d26c20dd25bf5
   response:
     status:
       code: 200
@@ -10867,14 +10437,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ac91df55-1a7e-479c-a572-0c806d0509fc
+      - req-ef83bc9c-7c59-438f-861a-3fe3d7ff138e
       Date:
-      - Mon, 06 Aug 2018 16:55:39 GMT
+      - Mon, 24 Sep 2018 20:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10892,15 +10462,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:39 GMT
+      - Mon, 24 Sep 2018 20:34:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 90672b4b32e34a8ba65c0ecbf72409df
+      - de3670ca4d2748c586ee47fce2222ae4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c4134670-6cc6-4c6d-8cf1-5693a8bc68e1
+      - req-745fc36d-01ac-4f5f-9d7e-3cafa57730d8
       Content-Length:
       - '7278'
       Connection:
@@ -10912,7 +10482,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:39.813839Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:01.348684Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10991,10 +10561,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4mltnIUbQnO3tka82OBuTA"],
-        "issued_at": "2018-08-06T16:55:39.813902Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zkzhay91TVWIfRRMLdo9gw"],
+        "issued_at": "2018-09-24T20:34:01.348705Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -11009,7 +10579,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90672b4b32e34a8ba65c0ecbf72409df
+      - de3670ca4d2748c586ee47fce2222ae4
   response:
     status:
       code: 200
@@ -11020,14 +10590,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f1c5725b-9282-49e1-90f7-05cbe84ff766
+      - req-bf3d9a41-7b8a-4491-9d12-57da6d564ca2
       Date:
-      - Mon, 06 Aug 2018 16:55:40 GMT
+      - Mon, 24 Sep 2018 20:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -11042,7 +10612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11053,9 +10623,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0c0c2855-23bf-4220-a827-081d9375071a
+      - req-33e76268-e6b1-40f7-a584-1565f328c97f
       Date:
-      - Mon, 06 Aug 2018 16:55:41 GMT
+      - Mon, 24 Sep 2018 20:34:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11082,7 +10652,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -11097,7 +10667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11108,9 +10678,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f20ee693-d7bd-4b18-9521-ef6c2971c7ff
+      - req-9f85a9d5-07cd-4b88-abae-89dee1c0f705
       Date:
-      - Mon, 06 Aug 2018 16:55:41 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11137,7 +10707,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -11152,7 +10722,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11163,9 +10733,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-47fd395c-b709-4c22-b057-f634703f5c52
+      - req-002c9adf-2374-4807-acdf-3a892a4811b1
       Date:
-      - Mon, 06 Aug 2018 16:55:42 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -11192,7 +10762,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -11207,7 +10777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11218,9 +10788,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-191bb4d7-5f78-4bb0-a013-d8497577357c
+      - req-a24b85bf-bb73-4b26-91f9-2d93b8932948
       Date:
-      - Mon, 06 Aug 2018 16:55:42 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11232,7 +10802,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -11247,7 +10817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11258,9 +10828,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-71b8c4c5-dd5d-4b64-9108-01148bc9272e
+      - req-a151b919-a6d2-4cf9-9ee0-efbf51f511c8
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11272,7 +10842,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -11287,7 +10857,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35d2d1ae675e424c9f2dae623addb719
+      - e7e3868fd743480ab1105aa1cdd6cb8e
   response:
     status:
       code: 200
@@ -11298,9 +10868,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-63ccf029-b43d-4ca5-96e9-c09359726dd2
+      - req-41838a65-5b7f-48a8-ad8d-555ee31dc502
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -11312,7 +10882,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -11327,7 +10897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -11338,51 +10908,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7cf3d042-8d5e-478a-a4f7-8ed2d42a7d6e
+      - req-4538e987-3513-49a0-9d70-3caada4ea15d
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
@@ -11431,20 +10978,175 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 20e870e756354be3909d1243df5b0a9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ffc15ab2-2744-4002-a9a1-eef334a200df
+      Date:
+      - Mon, 24 Sep 2018 20:34:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:34:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -11459,7 +11161,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -11470,13 +11172,78 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-113ff078-df3d-4f9b-942d-7d7c01b43c4c
+      - req-56f1c5b7-8512-4512-86f9-a14e7d5eec69
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -11487,6 +11254,194 @@ http_interactions:
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 20e870e756354be3909d1243df5b0a9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-98e5c23c-7a39-4d51-b7f0-156e99b5058a
+      Date:
+      - Mon, 24 Sep 2018 20:34:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 20e870e756354be3909d1243df5b0a9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-038b58fb-32f8-4bd0-9aa2-30bd9a5a7f74
+      Date:
+      - Mon, 24 Sep 2018 20:34:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -11563,20 +11518,163 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 20e870e756354be3909d1243df5b0a9a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7459ef20-5407-4597-9727-299bc5f38fe8
+      Date:
+      - Mon, 24 Sep 2018 20:34:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -11591,7 +11689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -11602,9 +11700,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3141812e-d54f-44a6-93aa-8a7878eeeeaa
+      - req-9cdfe4f2-0942-4cfb-aba2-deccc91411bd
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11646,7 +11744,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -11661,7 +11759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -11672,9 +11770,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-2b209c11-0eaa-4522-ab65-576ad5cdefb0
+      - req-f0b71db3-74ad-44d6-afbe-d24a661fe1e9
       Date:
-      - Mon, 06 Aug 2018 16:55:43 GMT
+      - Mon, 24 Sep 2018 20:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -11716,7 +11814,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -11731,7 +11829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -11742,9 +11840,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-a7156b92-6f57-4e56-9fd8-4da1da753868
+      - req-fe78def4-c6e0-4f1f-8aac-7beae0c4df27
       Date:
-      - Mon, 06 Aug 2018 16:55:44 GMT
+      - Mon, 24 Sep 2018 20:34:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12147,7 +12245,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -12162,7 +12260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12173,9 +12271,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-06a86ecc-ad45-468b-ba8c-5d04cc90ac86
+      - req-73e431f3-147c-49c5-b88c-9d89f4e72f83
       Date:
-      - Mon, 06 Aug 2018 16:55:44 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12578,7 +12676,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -12593,7 +12691,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12604,9 +12702,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9ff91ef7-7963-4821-8e86-6773ea449d91
+      - req-849fd2a0-77a5-41ba-a857-d857c0598cf0
       Date:
-      - Mon, 06 Aug 2018 16:55:44 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12638,7 +12736,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -12653,7 +12751,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12664,9 +12762,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e700b547-20f9-4943-8f44-3cff811179d1
+      - req-286d0670-9562-4287-a325-c0ae16b74e7f
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -12698,7 +12796,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -12713,7 +12811,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12724,9 +12822,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-1b4d4d74-f90e-4317-89f3-33357e618855
+      - req-bbac1085-5501-480a-9dcb-1a2619308325
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -12761,7 +12859,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -12776,7 +12874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12787,9 +12885,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-086edc60-2d9c-49f4-bdaa-254784981ec6
+      - req-948f0863-e7e4-4649-91b4-b312b2a5950a
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -12832,7 +12930,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -12847,7 +12945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12858,9 +12956,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-fb1565ce-bd38-4f13-990f-6c9a559344e1
+      - req-771a037a-d950-4f23-a4f1-ebbd64b083c2
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -12903,7 +13001,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -12918,7 +13016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -12929,9 +13027,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-f98e86b6-3a5b-4695-879f-6fad24a718c0
+      - req-d2294f2d-70b4-4a71-ba7b-ad24c6f9a732
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -13038,7 +13136,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -13053,7 +13151,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -13064,9 +13162,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-e18f1a93-7d55-492e-bc54-a9254f15285f
+      - req-7fd2e4b8-9e05-4752-8329-0ee205702e6c
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -13108,7 +13206,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -13123,7 +13221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09c8fbc8592047a0a06645c95389368b'
+      - 20e870e756354be3909d1243df5b0a9a
   response:
     status:
       code: 200
@@ -13134,15 +13232,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-6f8246dd-c529-4eed-aaf6-ff64285c8562
+      - req-b0554dc7-7905-43e9-9545-b10a5b38c4cb
       Date:
-      - Mon, 06 Aug 2018 16:55:45 GMT
+      - Mon, 24 Sep 2018 20:34:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13160,15 +13258,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:46 GMT
+      - Mon, 24 Sep 2018 20:34:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4b6e8541e18a440ea7c6367ad9bff2ad
+      - 684f49be85114d26839f42a003398e47
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2de96f34-8232-4f66-a49b-4abf73902802
+      - req-59a4c730-ce6d-4251-b03c-82dbe934073d
       Content-Length:
       - '7311'
       Connection:
@@ -13180,7 +13278,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:46.787322Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:34:06.630765Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13259,10 +13357,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["57Exgp37QsW9v1l0LZPxxg"],
-        "issued_at": "2018-08-06T16:55:46.787402Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X_Wz7luqT5SbeNxOrAOgzw"],
+        "issued_at": "2018-09-24T20:34:06.630784Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13280,15 +13378,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:46 GMT
+      - Mon, 24 Sep 2018 20:34:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-332fbd20-8754-41a8-b278-accd0215efff
+      - req-a6de9444-a86b-44b5-b38f-d6b5ef2191e1
       Content-Length:
       - '7311'
       Connection:
@@ -13300,7 +13398,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:55:47.142694Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:34:06.826209Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13379,10 +13477,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oHNHJpiXR4q9Blk2f71Qqg"],
-        "issued_at": "2018-08-06T16:55:47.142766Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["afw-xrvDT5eC0bUdoRN9Fw"],
+        "issued_at": "2018-09-24T20:34:06.826228Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13400,15 +13498,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:47 GMT
+      - Mon, 24 Sep 2018 20:34:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6672b8c747c84d99b3db18475da581a2
+      - 9fb1bbb8e7614df9a959d0259d6f30e5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-92895b9d-139d-49e6-ab3f-de55ce786953
+      - req-83b7a6be-70cb-4dc3-91e5-bc8e59751d98
       Content-Length:
       - '297'
       Connection:
@@ -13417,12 +13515,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:55:47.373680Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:34:07.020531Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cwLS_LycTQaz0Wod7qabCA"],
-        "issued_at": "2018-08-06T16:55:47.373739Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9xYl8N86TSSNgWtvcfCRxw"],
+        "issued_at": "2018-09-24T20:34:07.020551Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -13437,20 +13535,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6672b8c747c84d99b3db18475da581a2
+      - 9fb1bbb8e7614df9a959d0259d6f30e5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:47 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13770e27-f69b-4a72-babf-a373a099e7f2
+      - req-1b186ac9-917d-45ac-943d-c3e96c0feb36
       Content-Length:
       - '2457'
       Connection:
@@ -13483,13 +13581,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"6672b8c747c84d99b3db18475da581a2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"9fb1bbb8e7614df9a959d0259d6f30e5"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -13501,15 +13599,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:47 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be5194b1a15c49d2b9d647a8d54a7806
+      - 133084da053f413c97dc41226197e4d5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1b0b4669-db18-41a6-a962-c6aad94df16f
+      - req-881d6745-af24-4a9b-beb8-d604d2b397f1
       Content-Length:
       - '7313'
       Connection:
@@ -13521,7 +13619,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:47.373680Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:07.020531Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13600,10 +13698,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["y7sUMCgFQe25odMLkXR67Q",
-        "cwLS_LycTQaz0Wod7qabCA"], "issued_at": "2018-08-06T16:55:47.834474Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7MioRO6jRmeH6g-eONMrFA",
+        "9xYl8N86TSSNgWtvcfCRxw"], "issued_at": "2018-09-24T20:34:07.335934Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -13618,20 +13716,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be5194b1a15c49d2b9d647a8d54a7806
+      - 133084da053f413c97dc41226197e4d5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:47 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ab77d34a-6aae-427a-9f39-267446361ca1
+      - req-182e6d6b-a0a9-41f9-b1d6-1aa62b934bb0
       Content-Length:
       - '2179'
       Connection:
@@ -13664,7 +13762,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13682,15 +13780,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:48 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0a7320677dc548098f66330cd513a0ae
+      - b997639341084a83b4a257bdfc7844ce
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ecd47644-838b-4df5-8363-af0f58259189
+      - req-dcd4ccb9-5628-4c94-9246-576e80cd30c7
       Content-Length:
       - '7278'
       Connection:
@@ -13702,7 +13800,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:48.301413Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:07.628377Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13781,10 +13879,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oVamdsp2ScK8k202nHIiVQ"],
-        "issued_at": "2018-08-06T16:55:48.301482Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GLHPxjdQTuS32ae0I4Xvjg"],
+        "issued_at": "2018-09-24T20:34:07.628398Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13802,15 +13900,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:48 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ab08d6d843641ceb194f2e8f4dcb4c9
+      - 612478ae4b09485d98f1a13749ba2573
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-92e2cbea-e8ff-4cd6-bda3-a896ddaeffd9
+      - req-38f88a13-58c6-4c28-b0da-6908f7c2ac0e
       Content-Length:
       - '7278'
       Connection:
@@ -13822,7 +13920,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:48.949935Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:07.818411Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13901,10 +13999,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sSqI-K-zQV2e6SorTFx_aw"],
-        "issued_at": "2018-08-06T16:55:48.950022Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v06nXOSmSPSbVC03d6huJA"],
+        "issued_at": "2018-09-24T20:34:07.818430Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13922,15 +14020,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:49 GMT
+      - Mon, 24 Sep 2018 20:34:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 32f209de173f446ca1042e68263fdd7f
+      - 250d0384fbd84bc980752162790186df
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a99c954f-7678-4e1c-ad6e-f9596c26b8b3
+      - req-e0463661-0ec8-4faf-8c1f-518593563728
       Content-Length:
       - '7264'
       Connection:
@@ -13942,7 +14040,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:49.247454Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:08.012230Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14021,10 +14119,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BjkmKYWqTNewyygdHjo7Sw"],
-        "issued_at": "2018-08-06T16:55:49.247509Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XZi02ChEQE6t7poVRVOBuA"],
+        "issued_at": "2018-09-24T20:34:08.012249Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14042,15 +14140,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:49 GMT
+      - Mon, 24 Sep 2018 20:34:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b38fb76198be4331844071fccc0b4468
+      - '028e5051bdeb48fb8696ba378c8ffda0'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b6563445-0064-457f-ae13-b17207090c5d
+      - req-3a86bb93-bac7-4b9f-8dd8-e6fa87135ca6
       Content-Length:
       - '7278'
       Connection:
@@ -14062,7 +14160,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:49.563439Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:08.211216Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14141,10 +14239,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1_3emxHjQ6mY8us-Lp3oZA"],
-        "issued_at": "2018-08-06T16:55:49.563515Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xqOfnA8gQxC1W8G-RsOrxg"],
+        "issued_at": "2018-09-24T20:34:08.211235Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14162,15 +14260,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:49 GMT
+      - Mon, 24 Sep 2018 20:34:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ef07ee22b878413aa6a60ebaf21d3aab
+      - 832262755cbe4931a0fa7ccf1b56b198
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d024f3c1-2f7d-4ad7-95cc-9c60e0c75db1
+      - req-60cd7783-3395-4a0b-b866-d54ae48a8f9e
       Content-Length:
       - '7265'
       Connection:
@@ -14182,7 +14280,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:49.894801Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:08.420487Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14261,10 +14359,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sCE3A9CXTeuyiHI7yeMYtQ"],
-        "issued_at": "2018-08-06T16:55:49.894866Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7rRkFT66SU271xokpYTyyg"],
+        "issued_at": "2018-09-24T20:34:08.420506Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14282,15 +14380,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:50 GMT
+      - Mon, 24 Sep 2018 20:34:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e0b27c6528f0443695705755906cb023
+      - 4e582ba7eae049c68528a995b72f9aa4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-57100f62-f556-4b14-907f-74935990ae6b
+      - req-271fc8d7-bc6f-4ddd-9ead-76618607febe
       Content-Length:
       - '7278'
       Connection:
@@ -14302,7 +14400,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:50.233942Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:08.617079Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14381,10 +14479,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t8T9hObWSXejWk-9KP4eMw"],
-        "issued_at": "2018-08-06T16:55:50.234036Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OOBEeg--Q_i2EJTWrDJvXA"],
+        "issued_at": "2018-09-24T20:34:08.617098Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14402,15 +14500,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:50 GMT
+      - Mon, 24 Sep 2018 20:34:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-851fbf83-a292-4df6-a961-20ead69d8cce
+      - req-3f09836f-157a-4ffa-996f-cec0d72d5abe
       Content-Length:
       - '7278'
       Connection:
@@ -14422,7 +14520,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:50.608002Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:08.818915Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14501,10 +14599,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rPqcnUw7R5GKfuktCsaOLg"],
-        "issued_at": "2018-08-06T16:55:50.608082Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJ2e85TeR_etbTIj8K40Zw"],
+        "issued_at": "2018-09-24T20:34:08.818934Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -14519,27 +14617,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0e38e6f-a603-417e-a382-005b1fe13f7e
+      - req-2c30fa3d-ca3e-459b-84d6-da938f271ff4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d0e38e6f-a603-417e-a382-005b1fe13f7e
+      - req-2c30fa3d-ca3e-459b-84d6-da938f271ff4
       Date:
-      - Mon, 06 Aug 2018 16:55:50 GMT
+      - Mon, 24 Sep 2018 20:34:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14557,15 +14655,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:51 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d0ca1fef-ab59-4632-a256-d5b03acfd075
+      - req-741e54ef-12ed-4416-8bcb-4de06929a5da
       Content-Length:
       - '7278'
       Connection:
@@ -14577,7 +14675,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:51.276348Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:09.172045Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14656,10 +14754,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qGumuEQrQUyTQsXABKq_JA"],
-        "issued_at": "2018-08-06T16:55:51.276429Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ORG7ob2eTi6TCk1TJJG0QA"],
+        "issued_at": "2018-09-24T20:34:09.172066Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -14674,27 +14772,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4e1a8f7-578c-4daa-bffa-072e036e6163
+      - req-cc219667-0c45-46de-a92d-cbce4ffbd5e9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a4e1a8f7-578c-4daa-bffa-072e036e6163
+      - req-cc219667-0c45-46de-a92d-cbce4ffbd5e9
       Date:
-      - Mon, 06 Aug 2018 16:55:51 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14712,15 +14810,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:51 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdb1e659-8e80-432a-a913-c1e4c88c0cc0
+      - req-a46625c7-c9e2-4d8f-b083-5f7ca875d8ed
       Content-Length:
       - '7264'
       Connection:
@@ -14732,7 +14830,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:51.907475Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:09.508163Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14811,10 +14909,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AAiui3feRUaCR6jJ-kRKFw"],
-        "issued_at": "2018-08-06T16:55:51.907549Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UEDbtC2rTAWn5fo7E71oWA"],
+        "issued_at": "2018-09-24T20:34:09.508196Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -14829,22 +14927,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a7b84aa6-affa-4e2f-9c8b-0295268b2d55
+      - req-0ac61c1d-3a2a-4152-95e1-fc3411599c88
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-a7b84aa6-affa-4e2f-9c8b-0295268b2d55
+      - req-0ac61c1d-3a2a-4152-95e1-fc3411599c88
       Date:
-      - Mon, 06 Aug 2018 16:55:52 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -14877,7 +14975,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -14892,22 +14990,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc7ca1da-2b0e-4c73-9eb1-c9de28ee07e2
+      - req-de55081a-1930-4759-8478-decfbd8a6b69
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-cc7ca1da-2b0e-4c73-9eb1-c9de28ee07e2
+      - req-de55081a-1930-4759-8478-decfbd8a6b69
       Date:
-      - Mon, 06 Aug 2018 16:55:52 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -14948,7 +15046,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -14963,22 +15061,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e3b2ccc-31ce-40d9-89bb-a9575498d99d
+      - req-77a36eba-e197-4f6a-9a0b-d57eff20276d
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-0e3b2ccc-31ce-40d9-89bb-a9575498d99d
+      - req-77a36eba-e197-4f6a-9a0b-d57eff20276d
       Date:
-      - Mon, 06 Aug 2018 16:55:53 GMT
+      - Mon, 24 Sep 2018 20:34:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -15012,7 +15110,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -15027,27 +15125,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e0e5c42a-8e87-47c1-9995-786df4321a58
+      - req-b22f6b28-1451-4938-b570-caa29a7db5de
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e0e5c42a-8e87-47c1-9995-786df4321a58
+      - req-b22f6b28-1451-4938-b570-caa29a7db5de
       Date:
-      - Mon, 06 Aug 2018 16:55:53 GMT
+      - Mon, 24 Sep 2018 20:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15065,15 +15163,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:53 GMT
+      - Mon, 24 Sep 2018 20:34:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c19e0f4-d100-4fd0-b2df-548c50695093
+      - req-1b8ed6b8-8252-4512-87a3-59d87756e243
       Content-Length:
       - '7278'
       Connection:
@@ -15085,7 +15183,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:53.734364Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:10.394548Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15164,10 +15262,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WaA_5mqyQPitu5N76fyYGg"],
-        "issued_at": "2018-08-06T16:55:53.734438Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ozeywG3fTsW996bfxDY7cA"],
+        "issued_at": "2018-09-24T20:34:10.394568Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -15182,27 +15280,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-582febda-a64c-4942-a416-20e4d34eb1dc
+      - req-52a35128-c484-499e-ae8c-f978664af9c6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-582febda-a64c-4942-a416-20e4d34eb1dc
+      - req-52a35128-c484-499e-ae8c-f978664af9c6
       Date:
-      - Mon, 06 Aug 2018 16:55:54 GMT
+      - Mon, 24 Sep 2018 20:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -15217,27 +15315,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3eae4429-80f9-4e62-8c40-c346de01a101
+      - req-bdb3a4da-d55a-43bc-8220-8156a5df27d1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3eae4429-80f9-4e62-8c40-c346de01a101
+      - req-bdb3a4da-d55a-43bc-8220-8156a5df27d1
       Date:
-      - Mon, 06 Aug 2018 16:55:54 GMT
+      - Mon, 24 Sep 2018 20:34:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15255,15 +15353,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:54 GMT
+      - Mon, 24 Sep 2018 20:34:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9198728b-7609-438e-affa-3283bca0051e
+      - req-450fa2b9-0616-4a05-8434-009c8275d603
       Content-Length:
       - '7265'
       Connection:
@@ -15275,7 +15373,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:54.682188Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:10.858573Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15354,10 +15452,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vGD3z6AYTtSOrsEi_REHjw"],
-        "issued_at": "2018-08-06T16:55:54.682271Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gZ84WtYiRtmIU9f5WGE_gg"],
+        "issued_at": "2018-09-24T20:34:10.858593Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -15372,27 +15470,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3aa8fccc-5c20-4c81-85ba-549a53df6b7d
+      - req-6c301bf2-105d-4bea-b858-9659b2cf3058
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3aa8fccc-5c20-4c81-85ba-549a53df6b7d
+      - req-6c301bf2-105d-4bea-b858-9659b2cf3058
       Date:
-      - Mon, 06 Aug 2018 16:55:55 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15410,15 +15508,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:55:55 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e5f98e7a-482c-406a-8a71-f95da314e6fd
+      - req-cd62bfcf-f831-4755-807a-90d204137ce6
       Content-Length:
       - '7278'
       Connection:
@@ -15430,7 +15528,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:55:55.375382Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:11.189270Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15509,10 +15607,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O4D_b0tKSTeoAYBt8Za9OQ"],
-        "issued_at": "2018-08-06T16:55:55.375466Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RffiTSfyShGtQfgG23hbbA"],
+        "issued_at": "2018-09-24T20:34:11.189291Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -15527,27 +15625,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c2895541-5fa8-4907-84cc-a2083b716dea
+      - req-606e609f-6ada-4c55-ae13-775128eddc17
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c2895541-5fa8-4907-84cc-a2083b716dea
+      - req-606e609f-6ada-4c55-ae13-775128eddc17
       Date:
-      - Mon, 06 Aug 2018 16:55:55 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -15562,27 +15660,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2059a09c-9fa9-4a65-918a-c952a18e3b71
+      - req-68b2f032-5ec7-4451-a7ff-25f7b47c92e9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2059a09c-9fa9-4a65-918a-c952a18e3b71
+      - req-68b2f032-5ec7-4451-a7ff-25f7b47c92e9
       Date:
-      - Mon, 06 Aug 2018 16:55:55 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -15597,27 +15695,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e3aa08e-d5d0-40e5-bdcc-eefec2cf286d
+      - req-425d9140-4672-4320-9604-6fbcfb7b40b4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1e3aa08e-d5d0-40e5-bdcc-eefec2cf286d
+      - req-425d9140-4672-4320-9604-6fbcfb7b40b4
       Date:
-      - Mon, 06 Aug 2018 16:55:55 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -15632,27 +15730,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97aae816-4b11-40e4-b2f9-521005af166f
+      - req-08ae4b9e-7eb7-4313-8709-db492b4c41bc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-97aae816-4b11-40e4-b2f9-521005af166f
+      - req-08ae4b9e-7eb7-4313-8709-db492b4c41bc
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -15667,27 +15765,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9991a67-ae6f-4a07-a9b1-aa22b9cd7be1
+      - req-8e594559-d481-481c-8925-2e8c0fede055
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e9991a67-ae6f-4a07-a9b1-aa22b9cd7be1
+      - req-8e594559-d481-481c-8925-2e8c0fede055
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -15702,22 +15800,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7bfb8976-1c4e-4c81-b043-5da820439314
+      - req-bacc9bf3-88d2-4692-a930-d1eaf9541521
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7bfb8976-1c4e-4c81-b043-5da820439314
+      - req-bacc9bf3-88d2-4692-a930-d1eaf9541521
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15732,7 +15830,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -15747,22 +15845,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-184d8541-409e-496a-b420-9db94e9d13d0
+      - req-f7ebfa46-180e-455d-9e7a-2c9b62e0ab69
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-184d8541-409e-496a-b420-9db94e9d13d0
+      - req-f7ebfa46-180e-455d-9e7a-2c9b62e0ab69
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -15777,7 +15875,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -15792,27 +15890,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46fcfe47-7413-41f6-ad1a-ee2d4245a62f
+      - req-0c6b2a33-4d31-4a1f-baed-9a38923a6d81
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-46fcfe47-7413-41f6-ad1a-ee2d4245a62f
+      - req-0c6b2a33-4d31-4a1f-baed-9a38923a6d81
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -15827,27 +15925,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ed588f1-b759-410f-a101-f0babe4eb386
+      - req-69847a42-63bf-4279-ba39-4ca89e930865
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7ed588f1-b759-410f-a101-f0babe4eb386
+      - req-69847a42-63bf-4279-ba39-4ca89e930865
       Date:
-      - Mon, 06 Aug 2018 16:55:56 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -15862,27 +15960,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c24089c-32d1-4265-a2c6-c90923127ec4
+      - req-42ee9138-c63c-45ea-b16e-a85c39c0126f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7c24089c-32d1-4265-a2c6-c90923127ec4
+      - req-42ee9138-c63c-45ea-b16e-a85c39c0126f
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -15897,27 +15995,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b60b487-3fdd-4b72-9ae3-1454e3c0d26d
+      - req-d720903a-7943-43a2-ab14-ffb634723e55
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2b60b487-3fdd-4b72-9ae3-1454e3c0d26d
+      - req-d720903a-7943-43a2-ab14-ffb634723e55
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -15932,27 +16030,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c35f1169-8124-4f9a-95e3-061836f3e785
+      - req-7434ceb9-e5de-44c5-919b-4525c651540a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c35f1169-8124-4f9a-95e3-061836f3e785
+      - req-7434ceb9-e5de-44c5-919b-4525c651540a
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -15967,27 +16065,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7d5cbff-eeed-4a43-af78-084318658aa3
+      - req-186a4cb4-036d-4a84-923c-a062d021b806
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c7d5cbff-eeed-4a43-af78-084318658aa3
+      - req-186a4cb4-036d-4a84-923c-a062d021b806
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -16002,27 +16100,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-45950aee-18a1-40af-ade7-a358f8faa8f7
+      - req-80872d52-8273-4e70-a243-67c2bb8cc2d9
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-45950aee-18a1-40af-ade7-a358f8faa8f7
+      - req-80872d52-8273-4e70-a243-67c2bb8cc2d9
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -16037,27 +16135,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-619a230d-89da-45c2-973f-72d6f5ca4e15
+      - req-866ff2ad-1b04-43c9-9a97-6dbe7b046a29
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-619a230d-89da-45c2-973f-72d6f5ca4e15
+      - req-866ff2ad-1b04-43c9-9a97-6dbe7b046a29
       Date:
-      - Mon, 06 Aug 2018 16:55:57 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -16072,27 +16170,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3cb23f05-6b2e-43f7-b77e-2cf5af451d2c
+      - req-206e24a9-cce4-43ee-8372-35527327d582
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3cb23f05-6b2e-43f7-b77e-2cf5af451d2c
+      - req-206e24a9-cce4-43ee-8372-35527327d582
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -16107,27 +16205,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d442141-6f07-4e31-9af7-101fb7bb94d3
+      - req-ee40fc23-ee98-4fdc-af5c-8eed04e31287
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8d442141-6f07-4e31-9af7-101fb7bb94d3
+      - req-ee40fc23-ee98-4fdc-af5c-8eed04e31287
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -16142,27 +16240,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-347dac5a-1bd0-4c0b-8b2a-f3f513e22e04
+      - req-063b45c7-0f7c-49fb-8cef-0ee4fd00c82e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-347dac5a-1bd0-4c0b-8b2a-f3f513e22e04
+      - req-063b45c7-0f7c-49fb-8cef-0ee4fd00c82e
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -16177,27 +16275,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f0c5ac61-58e8-4743-9c93-b6ce9927ff7c
+      - req-c28ae033-d9db-49c4-a350-c9512927823f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f0c5ac61-58e8-4743-9c93-b6ce9927ff7c
+      - req-c28ae033-d9db-49c4-a350-c9512927823f
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -16212,27 +16310,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a85d9715-0c44-4743-bb05-923ae1be8498
+      - req-f63ceb6d-30ea-4400-b353-2f0c6a5db79e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a85d9715-0c44-4743-bb05-923ae1be8498
+      - req-f63ceb6d-30ea-4400-b353-2f0c6a5db79e
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -16247,27 +16345,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d08e6b21-1548-4e15-9a04-85410b246e07
+      - req-c3a04281-f757-456b-86a4-e23dbcc0768c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d08e6b21-1548-4e15-9a04-85410b246e07
+      - req-c3a04281-f757-456b-86a4-e23dbcc0768c
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -16282,27 +16380,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f322ea5d-a966-4f43-88ff-9a3993aeb8eb
+      - req-71481775-c556-4da9-b0d5-37554685fddb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f322ea5d-a966-4f43-88ff-9a3993aeb8eb
+      - req-71481775-c556-4da9-b0d5-37554685fddb
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -16317,27 +16415,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c3e1ef8-54e7-4dc5-a1d3-e9013adb6049
+      - req-c28e5a62-a562-4a9f-acaa-22e3dadfb924
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c3e1ef8-54e7-4dc5-a1d3-e9013adb6049
+      - req-c28e5a62-a562-4a9f-acaa-22e3dadfb924
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -16352,27 +16450,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c086e2c0-d1eb-44f0-9171-9003da5594b5
+      - req-131bf9e0-9e82-4387-a33a-a4d5b10aaed8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c086e2c0-d1eb-44f0-9171-9003da5594b5
+      - req-131bf9e0-9e82-4387-a33a-a4d5b10aaed8
       Date:
-      - Mon, 06 Aug 2018 16:55:58 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -16387,27 +16485,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fbb6528d-248d-460e-8ecc-13335d295fc3
+      - req-bd0fb13f-2af3-4420-97b5-3238db67f0c6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fbb6528d-248d-460e-8ecc-13335d295fc3
+      - req-bd0fb13f-2af3-4420-97b5-3238db67f0c6
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -16422,27 +16520,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4d0f405-3c80-46a1-8f78-9d0eed00f580
+      - req-b7b21f3f-eaf1-48ea-95d2-77b4b312009c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c4d0f405-3c80-46a1-8f78-9d0eed00f580
+      - req-b7b21f3f-eaf1-48ea-95d2-77b4b312009c
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -16457,27 +16555,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2361c0de-b2fc-48d3-a495-1621be365425
+      - req-4985a066-250a-4fd7-99fa-e2790d5538b9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2361c0de-b2fc-48d3-a495-1621be365425
+      - req-4985a066-250a-4fd7-99fa-e2790d5538b9
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -16492,27 +16590,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e690320-6124-49e6-b6f7-aeacc9462a96
+      - req-3ff312cb-54fb-4d50-b817-884d8e36b60f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2e690320-6124-49e6-b6f7-aeacc9462a96
+      - req-3ff312cb-54fb-4d50-b817-884d8e36b60f
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -16527,27 +16625,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-553bc65b-329e-4630-8517-e28fdd673262
+      - req-e550eb40-1fb3-43dc-8f6d-bf9d1072fea4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-553bc65b-329e-4630-8517-e28fdd673262
+      - req-e550eb40-1fb3-43dc-8f6d-bf9d1072fea4
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -16562,22 +16660,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e47ecaa-ee2b-461c-8705-db8728e2094b
+      - req-79214855-8531-42a5-80ab-a61df2a7c856
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0e47ecaa-ee2b-461c-8705-db8728e2094b
+      - req-79214855-8531-42a5-80ab-a61df2a7c856
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16589,7 +16687,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16604,22 +16702,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b795dd70ee1142c3a7f0f11e7524cd6b
+      - 92ddb1c4f6f8445584f27e274273757a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-46fde644-9a91-4734-a8ae-88ff51ef19ac
+      - req-d81f347e-d0b2-4d7c-b9e5-e4e2244444cf
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-46fde644-9a91-4734-a8ae-88ff51ef19ac
+      - req-d81f347e-d0b2-4d7c-b9e5-e4e2244444cf
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16631,7 +16729,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -16646,22 +16744,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7da1fa52-42ff-49bd-8a8c-918249703485
+      - req-f9b29aa5-407c-4bd7-a3c4-d7043a952903
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7da1fa52-42ff-49bd-8a8c-918249703485
+      - req-f9b29aa5-407c-4bd7-a3c4-d7043a952903
       Date:
-      - Mon, 06 Aug 2018 16:55:59 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16673,7 +16771,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:55:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16688,22 +16786,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 825cf74329eb4e2cb578a34f1bae69c1
+      - d7e0e54e87a941ad9b529970a95695b6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d5cdec4-d357-49ff-9c3c-89a448890643
+      - req-4107aec5-14c6-4031-9207-da23e572e262
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8d5cdec4-d357-49ff-9c3c-89a448890643
+      - req-4107aec5-14c6-4031-9207-da23e572e262
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16715,7 +16813,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -16730,22 +16828,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7db53982-3be0-4591-b485-a2a2fab912f9
+      - req-ab5272f4-0a7c-4b78-98f1-95b227ed5517
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7db53982-3be0-4591-b485-a2a2fab912f9
+      - req-ab5272f4-0a7c-4b78-98f1-95b227ed5517
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16757,7 +16855,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16772,22 +16870,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 21afc3be0884495ab311d6e550dee000
+      - f28c42a58e384b14ab8cc6fd40f59356
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-71ed0f1c-9eae-4b11-9fc0-d1c23bbe3e8b
+      - req-7c47c0b1-764e-43d7-b34a-c8ab034f3d42
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-71ed0f1c-9eae-4b11-9fc0-d1c23bbe3e8b
+      - req-7c47c0b1-764e-43d7-b34a-c8ab034f3d42
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16799,7 +16897,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -16814,22 +16912,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ef7e2dac-f8ff-422c-a2be-780da1d30aa3
+      - req-7e6c5d0c-f587-4476-b329-b0b0754fb988
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ef7e2dac-f8ff-422c-a2be-780da1d30aa3
+      - req-7e6c5d0c-f587-4476-b329-b0b0754fb988
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16841,7 +16939,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16856,22 +16954,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed5f37e2ae5941e39d363c5d6fbf384f
+      - f191031be62c443d821333a3a43c6466
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-89cd8eac-5768-469d-b280-530946fdb2d7
+      - req-456dd695-1929-4dfa-82be-6ca0ddc5d565
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-89cd8eac-5768-469d-b280-530946fdb2d7
+      - req-456dd695-1929-4dfa-82be-6ca0ddc5d565
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16883,7 +16981,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -16898,22 +16996,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-92ac25be-c183-4f90-91f9-22924e98b31c
+      - req-52990b9a-5c34-403e-b017-51be9350588f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-92ac25be-c183-4f90-91f9-22924e98b31c
+      - req-52990b9a-5c34-403e-b017-51be9350588f
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16925,7 +17023,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -16940,22 +17038,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 702f82d6ebc740ad8b94249f37699456
+      - 7130ab94ab5548f4bf64f2bd1b8a964e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65c9b489-3fb7-46e6-a790-1151d357c755
+      - req-32fb04a2-ec82-47a2-93d3-43da5cb8b9e0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-65c9b489-3fb7-46e6-a790-1151d357c755
+      - req-32fb04a2-ec82-47a2-93d3-43da5cb8b9e0
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16967,7 +17065,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -16982,22 +17080,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-797d47e5-02b2-493f-a305-a8616a76ef35
+      - req-72257cb8-ea5a-4ba6-b3af-2c1e92ca7a4a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-797d47e5-02b2-493f-a305-a8616a76ef35
+      - req-72257cb8-ea5a-4ba6-b3af-2c1e92ca7a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17009,7 +17107,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -17024,22 +17122,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1f73e95e7bc4b9ea2c5cdc5f85e2cbc
+      - b2f13332c13c4cc4900dd538eb83d3ed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-32fd0eac-d05f-4381-8f15-b1c98f3eb391
+      - req-6c13785b-c4e5-4f57-b22f-fa68f0874787
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-32fd0eac-d05f-4381-8f15-b1c98f3eb391
+      - req-6c13785b-c4e5-4f57-b22f-fa68f0874787
       Date:
-      - Mon, 06 Aug 2018 16:56:00 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17051,7 +17149,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -17066,22 +17164,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d83367d-9e96-418b-aaff-ea7b5dff27d1
+      - req-3caca147-6dcc-40ed-8b88-008b4951afa3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9d83367d-9e96-418b-aaff-ea7b5dff27d1
+      - req-3caca147-6dcc-40ed-8b88-008b4951afa3
       Date:
-      - Mon, 06 Aug 2018 16:56:01 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17093,7 +17191,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -17108,22 +17206,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a611dc3229141c08c4a69a9b0bc18ad
+      - 89d5a29d55b54b6886320ba9497930f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a1d1548-ceb4-4f0c-86c4-7bffa2754272
+      - req-931db50f-d6e3-4af1-88b3-b95dd257458a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-7a1d1548-ceb4-4f0c-86c4-7bffa2754272
+      - req-931db50f-d6e3-4af1-88b3-b95dd257458a
       Date:
-      - Mon, 06 Aug 2018 16:56:01 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17135,7 +17233,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17153,15 +17251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:01 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ea2b8f7a5ed442fa844c253bdd2e2e9c
+      - b023c41d39184d0ba4e6d6f74cef4dae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43014e4b-fee4-453a-9c2d-9c3cb183c047
+      - req-e58ce80f-a60c-41d2-8904-0a31991d6286
       Content-Length:
       - '7311'
       Connection:
@@ -17173,7 +17271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:56:01.624633Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:34:15.559095Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17252,10 +17350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bT8yKcJZTwiUEUACgiuj8g"],
-        "issued_at": "2018-08-06T16:56:01.624699Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["64cFiWo-QtKZBelfbEOJNQ"],
+        "issued_at": "2018-09-24T20:34:15.559115Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17273,15 +17371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:01 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - da2a10ab77f240fdb946d0d8a809bc63
+      - a204c1bf300e4b7eb52daa7006d86d52
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1f6aa80a-8b85-4e71-83c6-bcdf6a068966
+      - req-2c4a1298-00ec-4fa6-a672-166e7222e445
       Content-Length:
       - '7311'
       Connection:
@@ -17293,7 +17391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:56:01.969541Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:34:15.775707Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -17372,10 +17470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["68CsGWYnSbqvcvXogk0Y4g"],
-        "issued_at": "2018-08-06T16:56:01.969609Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FTfg_RNLQoGGtOD1vo5eHg"],
+        "issued_at": "2018-09-24T20:34:15.775725Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17393,15 +17491,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:02 GMT
+      - Mon, 24 Sep 2018 20:34:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 444e693c069c47b285bdf612e4706d17
+      - 421437926b7048efa0de0d584b5fcdaf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dbf22e71-be06-4f5c-a1af-7582b6911dc4
+      - req-da17baad-d121-43c7-a399-463683390720
       Content-Length:
       - '297'
       Connection:
@@ -17410,12 +17508,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:56:02.215053Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:34:15.934510Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z9TFsW2KSO6DtSo1G9CAIQ"],
-        "issued_at": "2018-08-06T16:56:02.215211Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CWWLDzg3RkOt5aP6hJlSgQ"],
+        "issued_at": "2018-09-24T20:34:15.934528Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:15 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -17430,20 +17528,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 444e693c069c47b285bdf612e4706d17
+      - 421437926b7048efa0de0d584b5fcdaf
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:02 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d0678a5-936b-4bd8-b850-7c9a95cf3f41
+      - req-b4e3b00c-7968-4a4a-a1c8-4120034f14e6
       Content-Length:
       - '2457'
       Connection:
@@ -17476,13 +17574,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"444e693c069c47b285bdf612e4706d17"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"421437926b7048efa0de0d584b5fcdaf"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17494,15 +17592,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:02 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7da36a16a30e44b483cb5b5685e38621
+      - 5ff6f4e64c9b41568b79c1aa0a601b64
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d437f47b-2e18-49ed-871d-e8eb9c20494e
+      - req-a9ac20a2-e414-4bd2-97ee-d795ef4d0450
       Content-Length:
       - '7313'
       Connection:
@@ -17514,7 +17612,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:02.215053Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:15.934510Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17593,10 +17691,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Z2cMsy4RTGa_wO6j__d0g",
-        "Z9TFsW2KSO6DtSo1G9CAIQ"], "issued_at": "2018-08-06T16:56:02.792525Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mrh72F1NQcu8oWe-FpCaUw",
+        "CWWLDzg3RkOt5aP6hJlSgQ"], "issued_at": "2018-09-24T20:34:16.231627Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -17611,20 +17709,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7da36a16a30e44b483cb5b5685e38621
+      - 5ff6f4e64c9b41568b79c1aa0a601b64
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:02 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-782a0ffd-2510-4d26-a1d8-3e0662d61922
+      - req-774012a7-872c-420b-8d95-85d1a154718d
       Content-Length:
       - '2179'
       Connection:
@@ -17657,7 +17755,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17675,15 +17773,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:03 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 41eb0b23cf05463e99182cd5b806454e
+      - b050ca35cf5e4f738922e28cd85fb660
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2275054c-a715-4871-9b90-4809cd1be7d4
+      - req-25d24f87-d0fc-492f-ac5b-821d29b01c62
       Content-Length:
       - '7278'
       Connection:
@@ -17695,7 +17793,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:03.277147Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:16.520695Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17774,10 +17872,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6hKzWlGSQDi3_vI9YzZiOg"],
-        "issued_at": "2018-08-06T16:56:03.277216Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EjmNt_ZsQjW_VVFWLpc8KQ"],
+        "issued_at": "2018-09-24T20:34:16.520713Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17795,15 +17893,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:03 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 166abb0ce464469ab2362bf1725060ca
+      - 8ccce2eddd2240deb554a79df684a93b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-896c0522-e989-49e7-8ba9-23316036bd24
+      - req-7adc5309-c17b-4b4a-9fbd-0a358a3c56a3
       Content-Length:
       - '7278'
       Connection:
@@ -17815,7 +17913,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:03.611961Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:16.714127Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -17894,10 +17992,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qdqp5OrdTmy4gZEO3VfoSA"],
-        "issued_at": "2018-08-06T16:56:03.612026Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Lq7dz5LRSpu4r98M-48Yyw"],
+        "issued_at": "2018-09-24T20:34:16.714148Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -17915,15 +18013,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:03 GMT
+      - Mon, 24 Sep 2018 20:34:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e74a4c58149547ada66a2ad161907fe4
+      - 790e1fa345954694b69e3f527721c46f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f53fdd33-f714-45b5-bfea-9195a01be312
+      - req-78b38dfd-2c04-4829-895d-fd11a943873b
       Content-Length:
       - '7264'
       Connection:
@@ -17935,7 +18033,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:03.943514Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:16.903659Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18014,10 +18112,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-HUzqtpXT7OinB12Zcp0Tg"],
-        "issued_at": "2018-08-06T16:56:03.943580Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eberKqcjQK-F5g55AheB0Q"],
+        "issued_at": "2018-09-24T20:34:16.903677Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18035,15 +18133,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:04 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a7fd5b89a81248878a61b0dc26a07e84
+      - 203b5f04e2004ffa99257d6afcb2171d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-48a0c514-baa4-4a53-8942-99cac444dc22
+      - req-752957f3-6b54-4e7e-a84d-0ecf48e0e918
       Content-Length:
       - '7278'
       Connection:
@@ -18055,7 +18153,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:04.297743Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:17.122154Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18134,10 +18232,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rn57vNl1RpCZKJJMu7PR0g"],
-        "issued_at": "2018-08-06T16:56:04.297825Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-UpconS4Sma_ds4jZUTN-Q"],
+        "issued_at": "2018-09-24T20:34:17.122178Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18155,15 +18253,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:04 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f80efebdef7944919fe863aec7a38dfb
+      - 28eaa335427a4517a49773d11f25dadc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c43cc009-3831-4c23-a84b-b1e8f4016ad8
+      - req-17a2c4f4-6e98-4f7a-9c17-3a576f7e02c2
       Content-Length:
       - '7265'
       Connection:
@@ -18175,7 +18273,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:04.665380Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:17.325693Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18254,10 +18352,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gHgrjv4GRtmDqWVvpRZG9Q"],
-        "issued_at": "2018-08-06T16:56:04.665464Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8xFenW3eREqzIifWptt6lg"],
+        "issued_at": "2018-09-24T20:34:17.325712Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18275,15 +18373,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:04 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c6d9285c53184ffeba880c03117b451a
+      - baac6d406564414480e01d9cf3f4c053
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc55d699-8fac-4faa-84ae-1b033efc7544
+      - req-04656dba-0786-4ae1-b58a-21d814f17911
       Content-Length:
       - '7278'
       Connection:
@@ -18295,7 +18393,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:05.032829Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:17.517923Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18374,10 +18472,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SR4Y2LHITDGcPGdZ6-e09A"],
-        "issued_at": "2018-08-06T16:56:05.032917Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fzAjHDDVRuCvfGQBJVw1-g"],
+        "issued_at": "2018-09-24T20:34:17.517941Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18395,15 +18493,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:05 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7c686ac46db948f9bec09b71dff5d67d
+      - 58be4464d67a40839c4196149b1c1337
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e9059cbb-7740-4c71-93a4-6a3e29d12eb6
+      - req-548688fc-af69-451a-9ce8-6c41c7312b01
       Content-Length:
       - '7278'
       Connection:
@@ -18415,7 +18513,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:05.360589Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:17.715877Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18494,10 +18592,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w2IQEWtBS8C4xK9HJR8J0g"],
-        "issued_at": "2018-08-06T16:56:05.360655Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A_A05x7oSiimmbjUJU6XiQ"],
+        "issued_at": "2018-09-24T20:34:17.715895Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -18512,7 +18610,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7c686ac46db948f9bec09b71dff5d67d
+      - 58be4464d67a40839c4196149b1c1337
   response:
     status:
       code: 200
@@ -18525,22 +18623,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574565.56854'
+      - '1537821257.83491'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574565.56854'
+      - '1537821257.83491'
       X-Trans-Id:
-      - txe3dc9b3e404949078cf62-005b687da5
+      - tx4be20a81e1f041ada6a4c-005ba94a49
       Date:
-      - Mon, 06 Aug 2018 16:56:05 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18558,15 +18656,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:05 GMT
+      - Mon, 24 Sep 2018 20:34:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 452d230d4ea74e25a08200377ebf30bf
+      - fa621f71dfdd4187ad9a0a738d8ce5d3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-308c2350-bd8b-4c31-880f-a4401c2ac022
+      - req-5a2e749e-c711-4da8-8a0b-d59d0131f233
       Content-Length:
       - '7278'
       Connection:
@@ -18578,7 +18676,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:05.913546Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:18.015643Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -18657,10 +18755,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tOJqQcmnSWWHCCq7aS71PA"],
-        "issued_at": "2018-08-06T16:56:05.913614Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zwc5tlHFSPuh3d6uOzawuw"],
+        "issued_at": "2018-09-24T20:34:18.015663Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -18675,7 +18773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 452d230d4ea74e25a08200377ebf30bf
+      - fa621f71dfdd4187ad9a0a738d8ce5d3
   response:
     status:
       code: 200
@@ -18688,22 +18786,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574566.11765'
+      - '1537821258.14061'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574566.11765'
+      - '1537821258.14061'
       X-Trans-Id:
-      - tx6028e1c3f45f4b1ca3e8c-005b687da6
+      - tx781d1540b4f04836ba781-005ba94a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:06 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18721,15 +18819,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:06 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-224fc2b0-4bf3-4fa0-9763-4eea0339c152
+      - req-42bab7ce-d5e4-4b65-813b-cf2ebd53ec28
       Content-Length:
       - '7264'
       Connection:
@@ -18741,7 +18839,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:06.454305Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:18.332946Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -18820,10 +18918,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["adqLBEhXR4KPOGirLddfIg"],
-        "issued_at": "2018-08-06T16:56:06.454391Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FeqtFimiTFGXcY0Ony0ccg"],
+        "issued_at": "2018-09-24T20:34:18.332965Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -18838,7 +18936,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
   response:
     status:
       code: 200
@@ -18867,15 +18965,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx3d2f39eb49cc4b4480ecb-005b687da6
+      - tx1b087c2291364422a6a58-005ba94a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:06 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -18890,7 +18988,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
   response:
     status:
       code: 200
@@ -18919,14 +19017,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx817425db07194ee2bd389-005b687da6
+      - tx778f39348a0e4d8797e38-005ba94a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:06 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -18944,15 +19042,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:06 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ece3318f39a741718b2d52053aecdb1f
+      - 26bc4ffbaa9d485bae892443e71184cf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dffe389a-bd79-4835-b653-80923bd14a02
+      - req-1e1fcc94-256a-4c00-9972-85572af7bd9c
       Content-Length:
       - '7278'
       Connection:
@@ -18964,7 +19062,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:07.118387Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:18.768292Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19043,10 +19141,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GcdzgIV2Q--C9hDIQ-9yBw"],
-        "issued_at": "2018-08-06T16:56:07.118456Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kekXxlyIRcWBlXutQ5AvrA"],
+        "issued_at": "2018-09-24T20:34:18.768318Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -19061,7 +19159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ece3318f39a741718b2d52053aecdb1f
+      - 26bc4ffbaa9d485bae892443e71184cf
   response:
     status:
       code: 200
@@ -19074,22 +19172,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574567.31890'
+      - '1537821258.88723'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574567.31890'
+      - '1537821258.88723'
       X-Trans-Id:
-      - tx7ea7f4667bf748d7ab052-005b687da7
+      - tx5c16c5b3631347e699dfa-005ba94a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:07 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -19104,7 +19202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - da2a10ab77f240fdb946d0d8a809bc63
+      - a204c1bf300e4b7eb52daa7006d86d52
   response:
     status:
       code: 200
@@ -19117,22 +19215,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574567.48760'
+      - '1537821258.99464'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574567.48760'
+      - '1537821258.99464'
       X-Trans-Id:
-      - txdb99eac86e1944b8b1655-005b687da7
+      - tx3386663df0984375a7e07-005ba94a4a
       Date:
-      - Mon, 06 Aug 2018 16:56:07 GMT
+      - Mon, 24 Sep 2018 20:34:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -19150,15 +19248,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:07 GMT
+      - Mon, 24 Sep 2018 20:34:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b352ff2c3734975b7b5790c63b724ae
+      - 21b71227bee84096a17cf537d326a917
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-73c13d95-e833-45bd-974c-486ab16287be
+      - req-78cb0fef-71c1-4c7b-b77f-2b11da6e021c
       Content-Length:
       - '7265'
       Connection:
@@ -19170,7 +19268,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:07.804384Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:19.406401Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -19249,10 +19347,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WbfNVDRIQRadhh8T2JQD3w"],
-        "issued_at": "2018-08-06T16:56:07.804453Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KnnlqcXQQdCUroxbLKdCZg"],
+        "issued_at": "2018-09-24T20:34:19.406421Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -19267,7 +19365,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b352ff2c3734975b7b5790c63b724ae
+      - 21b71227bee84096a17cf537d326a917
   response:
     status:
       code: 200
@@ -19280,22 +19378,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574568.01378'
+      - '1537821259.52772'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574568.01378'
+      - '1537821259.52772'
       X-Trans-Id:
-      - txc67fc6c37c774e87aecc3-005b687da7
+      - txc2ec8f0eedc04df2a4e30-005ba94a4b
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -19313,15 +19411,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71ec82192321436198ca521bdbd3f542
+      - defd7dc24fac4aaf923be2c25947a7bb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fc2a66b9-0756-46eb-b17b-e83891ac22b7
+      - req-a15dadc9-6db1-43f2-8aff-a9f880eeaf3d
       Content-Length:
       - '7278'
       Connection:
@@ -19333,7 +19431,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:56:08.323383Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:34:19.709733Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -19412,10 +19510,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["B1OKHoLxTySI8rBUuydqgg"],
-        "issued_at": "2018-08-06T16:56:08.323449Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Xy5hY-fUTQiWst_a0L3hdQ"],
+        "issued_at": "2018-09-24T20:34:19.709753Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -19430,7 +19528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71ec82192321436198ca521bdbd3f542
+      - defd7dc24fac4aaf923be2c25947a7bb
   response:
     status:
       code: 200
@@ -19443,22 +19541,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574568.53497'
+      - '1537821259.83520'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574568.53497'
+      - '1537821259.83520'
       X-Trans-Id:
-      - txacf23e771b6f4c8cb8fe1-005b687da8
+      - tx0d7a229dad754861bb5e0-005ba94a4b
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -19473,7 +19571,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
   response:
     status:
       code: 200
@@ -19494,9 +19592,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx598f0ae131894df084ada-005b687da8
+      - tx0bfc7cc115264cd583759-005ba94a4b
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -19506,7 +19604,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -19521,7 +19619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
   response:
     status:
       code: 200
@@ -19542,14 +19640,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx4e5f0bb571f34cc58913d-005b687da8
+      - tx08a36ee9a29d419592064-005ba94a4b
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -19564,7 +19662,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0607f50d78e14c16b0be97c64c047c15
+      - 5b51d979501c475db8fc73116be152d8
   response:
     status:
       code: 200
@@ -19585,12 +19683,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx9573bb5b13224d0ea1d86-005b687da8
+      - tx37fc76fa17164e5097ea2-005ba94a4c
       Date:
-      - Mon, 06 Aug 2018 16:56:08 GMT
+      - Mon, 24 Sep 2018 20:34:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:34:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:14 GMT
+      - Mon, 24 Sep 2018 20:32:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ad07e002-6ab5-4f00-8b76-f23f7b765a3e
+      - req-9fb24dd1-d1cd-4c05-a88a-e35b32d47e0b
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:14.998560Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:48.561757Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["55ouX-L0Q3ux4AVKBelf4Q"],
-        "issued_at": "2018-08-06T16:51:14.998641Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["i_RNxquGSZ6VU4WyhR5uMA"],
+        "issued_at": "2018-09-24T20:32:48.561777Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:15 GMT
+      - Mon, 24 Sep 2018 20:32:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:15 GMT
+      - Mon, 24 Sep 2018 20:32:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5afb80388c364351920a8c00059d383b
+      - a20c2d8353cb41ec9ca3c403377dc9c4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c155979-de97-4990-8897-61b11de811ff
+      - req-bc9e2437-e44a-4206-ae77-d81c7f2b6096
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:15.642461Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:48.826875Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["u6czasPKT9CxTXzcx2cr9A"],
-        "issued_at": "2018-08-06T16:51:15.642525Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dmjU9W9cTsaCX0USKDbzxQ"],
+        "issued_at": "2018-09-24T20:32:48.826894Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/
@@ -289,7 +289,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5afb80388c364351920a8c00059d383b
+      - a20c2d8353cb41ec9ca3c403377dc9c4
   response:
     status:
       code: 200
@@ -300,13 +300,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:51:15 GMT
+      - Mon, 24 Sep 2018 20:32:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.206:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -324,15 +324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:15 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4cae24d6a26c43c3b94e549ae08a2bfa
+      - ce7df5b6f38e48879d587918904cc70d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35991ce6-9a62-4cb5-8dca-f70f1d590d7f
+      - req-faa51c28-74c0-4055-b166-9d655695afb5
       Content-Length:
       - '7311'
       Connection:
@@ -344,7 +344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.093507Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:49.105961Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -423,16 +423,16 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vpyGr2OfQOKCuAfsFLW3Tg"],
-        "issued_at": "2018-08-06T16:51:16.093575Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xvVoHR0-RfeWO1kvmYM4XQ"],
+        "issued_at": "2018-09-24T20:32:49.105983Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"4cae24d6a26c43c3b94e549ae08a2bfa"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"ce7df5b6f38e48879d587918904cc70d"}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -444,15 +444,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:16 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4edb5cdba6d744a48a952a4b9d69ca46
+      - 51f858ff8c6b4763a8cda9c350c1b9ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-072c17be-a042-4b6f-af53-6623d787b044
+      - req-f4f76e4b-92af-4e09-ba6f-1ad4277ffcb4
       Content-Length:
       - '7346'
       Connection:
@@ -464,7 +464,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.093507Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:49.105961Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -543,10 +543,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aHyHuV8OQaW3HVgcFzWIpA",
-        "vpyGr2OfQOKCuAfsFLW3Tg"], "issued_at": "2018-08-06T16:51:16.422477Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BHFlStu1T5epjVN0onou6w",
+        "xvVoHR0-RfeWO1kvmYM4XQ"], "issued_at": "2018-09-24T20:32:49.282785Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -564,15 +564,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:16 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a29989ca-c637-45f4-915f-e99d397f8d2c
+      - req-af68a5dc-9d41-487a-9928-1ae93018d9a4
       Content-Length:
       - '7311'
       Connection:
@@ -584,7 +584,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:16.845856Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:49.474562Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -663,10 +663,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iIxfhJbGSsqjF1bTkBB6MQ"],
-        "issued_at": "2018-08-06T16:51:16.845922Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yIzbM-c7TpinUudkjurHrw"],
+        "issued_at": "2018-09-24T20:32:49.474580Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/
@@ -681,7 +681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 300
@@ -692,7 +692,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:51:16 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -705,7 +705,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.206:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -723,15 +723,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:17 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2eb09bb5278346cab6250bfeb145eeef
+      - b0ce9c559351420fa4f00cfaf5c1b6ee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1c02cccc-f41f-4c1e-929d-0ed394b0525a
+      - req-2c36fdbc-b6db-4263-a8df-36dc89facb90
       Content-Length:
       - '7311'
       Connection:
@@ -743,7 +743,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:17.469757Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:49.742852Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -822,10 +822,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WtUsZOoJQKqt98XCQ5TX-Q"],
-        "issued_at": "2018-08-06T16:51:17.469821Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0aS-GoffRy6f4AEvCEsNSg"],
+        "issued_at": "2018-09-24T20:32:49.742870Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -843,15 +843,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:17 GMT
+      - Mon, 24 Sep 2018 20:32:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8597692d218248faa2ba406a9bd1d598
+      - e5bf99ac9021479f92a9642ac9c3eeb9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-87ff927f-acba-4b9d-80cb-f1818a8ba1ed
+      - req-57e9851c-b840-490f-baf0-f5be8e424634
       Content-Length:
       - '7311'
       Connection:
@@ -863,7 +863,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:17.867590Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:49.941632Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -942,10 +942,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BdvsIuDBQN-Qr6cqTkVuCg"],
-        "issued_at": "2018-08-06T16:51:17.867662Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8cRmVOW9RuK1z9JhcCvqOQ"],
+        "issued_at": "2018-09-24T20:32:49.941650Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -963,15 +963,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:18 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e4613e4a1e294c9e971e337bb9c8ce9e
+      - f6b69295c85e4580a254273c95b6dcee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-60fca623-879b-4155-9e04-f5db94e15097
+      - req-7a58a53e-e686-4768-8814-b49cb27fef99
       Content-Length:
       - '7311'
       Connection:
@@ -983,7 +983,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:18.352039Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:50.143210Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1062,10 +1062,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f8DXWbGyQVWfCkIcW7LbrQ"],
-        "issued_at": "2018-08-06T16:51:18.352165Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["V2CIJbtEQCCeBijxNI1U0w"],
+        "issued_at": "2018-09-24T20:32:50.143229Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1083,15 +1083,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:18 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ffeb21de6dfd45cd832ee12507701c88
+      - be9d57997d4248b4b8d2ca21b9378dcd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9932913c-7d3c-4a18-aa67-0ced771114ce
+      - req-fb3729f0-840d-4d71-8e31-3a9fc3739f38
       Content-Length:
       - '7311'
       Connection:
@@ -1103,7 +1103,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:51:18.782918Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:32:50.334020Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1182,10 +1182,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-WOluu-XSWyf9v2mFR2yXw"],
-        "issued_at": "2018-08-06T16:51:18.783008Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jg2eoqoQSHe9pP_jMZeZXg"],
+        "issued_at": "2018-09-24T20:32:50.334038Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1203,15 +1203,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:18 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ea85a452fb3e43d6a6369aef1b9062ed
+      - 772c934f747c45b8886538a677b2f535
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-17b5dbaf-4f1a-4480-b7db-34b72ea57782
+      - req-1845fa14-3666-4e0b-a89d-776a141a01ce
       Content-Length:
       - '297'
       Connection:
@@ -1220,12 +1220,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:51:19.017244Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:32:50.504445Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JXM0rdp3S_KGKjxJLwsm9Q"],
-        "issued_at": "2018-08-06T16:51:19.017307Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Zq6oFjuQ5W8scZmngLmfQ"],
+        "issued_at": "2018-09-24T20:32:50.504463Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -1240,20 +1240,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea85a452fb3e43d6a6369aef1b9062ed
+      - 772c934f747c45b8886538a677b2f535
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:19 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-957b390f-6b63-43b7-9e86-c96e00aba4ce
+      - req-88d84037-6b9b-427e-9c1e-2ef4024df9f8
       Content-Length:
       - '2457'
       Connection:
@@ -1286,13 +1286,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"ea85a452fb3e43d6a6369aef1b9062ed"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"772c934f747c45b8886538a677b2f535"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -1304,15 +1304,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:19 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 793543e083c3462bab0104088b572fcc
+      - 75a5e3bdd47347f9980ba28c93929afc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a944c98e-4aea-414b-9e85-10b2f39aff6a
+      - req-07d228d0-8271-4c77-8265-e5188c35a15f
       Content-Length:
       - '7313'
       Connection:
@@ -1324,7 +1324,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:19.017244Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:50.504445Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1403,10 +1403,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ceWI7pmvSjSIc3d1Ue_IRw",
-        "JXM0rdp3S_KGKjxJLwsm9Q"], "issued_at": "2018-08-06T16:51:19.491249Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["x9VvWrhBS-iNiW06nKBouw",
+        "8Zq6oFjuQ5W8scZmngLmfQ"], "issued_at": "2018-09-24T20:32:50.844047Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1421,20 +1421,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 793543e083c3462bab0104088b572fcc
+      - 75a5e3bdd47347f9980ba28c93929afc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:19 GMT
+      - Mon, 24 Sep 2018 20:32:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ef361b4-106a-48bd-b507-29bbabb3fb15
+      - req-dfe4ed02-3745-4523-8013-2028ed36543f
       Content-Length:
       - '2179'
       Connection:
@@ -1467,7 +1467,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1485,15 +1485,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:19 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b10e4202d1df463c9dcb4b68f1281197
+      - 5083872fa7784d279384f878a6b555d9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b0784049-f3a3-4652-8691-1d611c131c6a
+      - req-b22c154c-241f-4923-a0fe-8ab98a5a8882
       Content-Length:
       - '7278'
       Connection:
@@ -1505,7 +1505,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:19.994747Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:51.150303Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1584,10 +1584,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XJH-8RZ-SCWDJXcx87vDqA"],
-        "issued_at": "2018-08-06T16:51:19.994810Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8T8zKLS1RlCBr6RfaiF1uw"],
+        "issued_at": "2018-09-24T20:32:51.150326Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1602,7 +1602,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b10e4202d1df463c9dcb4b68f1281197
+      - 5083872fa7784d279384f878a6b555d9
   response:
     status:
       code: 200
@@ -1613,7 +1613,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:20 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1622,7 +1622,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1640,15 +1640,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:20 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 431d46868c6c4bb1a94a329391f76758
+      - 41316c464a4d4bdfb691a6a3136d85ff
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-374ebd38-d7d5-46c7-8a22-4aaab73970a4
+      - req-d07ea0e6-003c-4caf-8154-067967fedc92
       Content-Length:
       - '7278'
       Connection:
@@ -1660,7 +1660,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:20.581437Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:51.431590Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1739,10 +1739,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M8pJDR9AQR-_pDVavo1NMg"],
-        "issued_at": "2018-08-06T16:51:20.581538Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MQ478P_gQS-DMYpKMA0nLg"],
+        "issued_at": "2018-09-24T20:32:51.431610Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1757,7 +1757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 431d46868c6c4bb1a94a329391f76758
+      - 41316c464a4d4bdfb691a6a3136d85ff
   response:
     status:
       code: 200
@@ -1768,7 +1768,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:20 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1777,7 +1777,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1795,15 +1795,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:20 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 01be2b6f849f4487bf2b238975d34eb8
+      - 506b95b63c3d4908ba4676a0840097e1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c82be32d-9797-4f27-91f5-0c0270452ece
+      - req-06bc7b6a-4348-4b3c-89d3-da98844a1f02
       Content-Length:
       - '7264'
       Connection:
@@ -1815,7 +1815,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:21.124217Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:51.706445Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1894,10 +1894,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VVLNGjeVT2K3JWyKhWBcPQ"],
-        "issued_at": "2018-08-06T16:51:21.124279Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GBE8FVsvTUevF2Y9GUERtg"],
+        "issued_at": "2018-09-24T20:32:51.706465Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1912,7 +1912,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 01be2b6f849f4487bf2b238975d34eb8
+      - 506b95b63c3d4908ba4676a0840097e1
   response:
     status:
       code: 200
@@ -1923,7 +1923,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:21 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1932,7 +1932,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1950,15 +1950,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:21 GMT
+      - Mon, 24 Sep 2018 20:32:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 49e5a5b8957a4b079338f21d6ceadc7d
+      - 403e644dd8bf4aeb8fa32434824b4f1a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-33681612-662b-4df7-b15f-f7c334ad7c00
+      - req-4ff4b816-005e-4b68-b353-8a8c27ba12a5
       Content-Length:
       - '7278'
       Connection:
@@ -1970,7 +1970,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:21.529142Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:51.987729Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2049,10 +2049,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WB8NxrKmTSutEoijPT9c2w"],
-        "issued_at": "2018-08-06T16:51:21.529213Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bj4wclGMSsKBvBz0eiVuXQ"],
+        "issued_at": "2018-09-24T20:32:51.987750Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2067,7 +2067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49e5a5b8957a4b079338f21d6ceadc7d
+      - 403e644dd8bf4aeb8fa32434824b4f1a
   response:
     status:
       code: 200
@@ -2078,7 +2078,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:21 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2087,7 +2087,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2105,15 +2105,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:21 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ca54f20a8a2245a8b4b76f044dbd12c7
+      - b9037ad91d054d1dbb2eb12e78fb466c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d2bc4dad-e0cd-4627-bc1f-caca3e3c2540
+      - req-529f04f3-99fa-4db8-8cb2-cdc4e2e11d0d
       Content-Length:
       - '7265'
       Connection:
@@ -2125,7 +2125,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:21.963994Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:52.262722Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2204,10 +2204,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pCjc1bWDQgeRsbRB7c0Zzg"],
-        "issued_at": "2018-08-06T16:51:21.964063Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Au3PLLzsQEO-VZtUOSzLtA"],
+        "issued_at": "2018-09-24T20:32:52.262741Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2222,7 +2222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca54f20a8a2245a8b4b76f044dbd12c7
+      - b9037ad91d054d1dbb2eb12e78fb466c
   response:
     status:
       code: 200
@@ -2233,7 +2233,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:22 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2242,7 +2242,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2260,15 +2260,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:22 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 38e58f1ba0c546aeb33bb2b73b3d8380
+      - 58d891d4424146328b6b346a8bfed489
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-deb1a021-7b86-4ce3-ac9b-3c903707ad8c
+      - req-844e4fbb-8940-4e14-9508-67fb9ad691f2
       Content-Length:
       - '7278'
       Connection:
@@ -2280,7 +2280,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:22.394069Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:52.548326Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2359,10 +2359,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L9hzpvFZSu2wwXqU7v7y_Q"],
-        "issued_at": "2018-08-06T16:51:22.394176Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fFIJVKgHRsanFl5-bb-uqw"],
+        "issued_at": "2018-09-24T20:32:52.548347Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2377,7 +2377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e58f1ba0c546aeb33bb2b73b3d8380
+      - 58d891d4424146328b6b346a8bfed489
   response:
     status:
       code: 200
@@ -2388,7 +2388,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:51:22 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2397,7 +2397,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2412,7 +2412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2425,9 +2425,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-047499bb-bf52-4a09-9505-71845c2ce9a3
+      - req-b0f2c769-44d4-44c1-9aa6-26b123f3d9dc
       Date:
-      - Mon, 06 Aug 2018 16:51:22 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2441,7 +2441,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2456,7 +2456,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2469,9 +2469,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-1d33bd09-9461-470e-8bbd-60839a2e74e5
+      - req-9dcbb930-ec48-4c9a-b9b1-bdda85944be5
       Date:
-      - Mon, 06 Aug 2018 16:51:23 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2485,7 +2485,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2500,7 +2500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2513,9 +2513,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-b9cf88ee-b44a-4dc3-a5e0-a24977a34d1c
+      - req-45e852eb-9c9c-4a78-8260-b2d53620a3d9
       Date:
-      - Mon, 06 Aug 2018 16:51:23 GMT
+      - Mon, 24 Sep 2018 20:32:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2530,7 +2530,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2545,7 +2545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2558,9 +2558,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-fa4077ea-c6bc-4544-80fb-ff6a992ba022
+      - req-7c51c0d8-94b6-4019-afe4-ebb73a1f4859
       Date:
-      - Mon, 06 Aug 2018 16:51:23 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2570,7 +2570,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2585,7 +2585,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2598,15 +2598,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-eefa8448-89f9-461d-8795-cfefd0bdc708
+      - req-4afeb835-af16-4834-8eb4-a94aa0ca644d
       Date:
-      - Mon, 06 Aug 2018 16:51:23 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2634,15 +2634,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-16d86395-7a52-4070-b51b-5a9aa2e19339
+      - req-fab7cd0b-1f6e-4c28-b252-17776f2c5644
       Date:
-      - Mon, 06 Aug 2018 16:51:23 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -2657,28 +2657,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eb09bb5278346cab6250bfeb145eeef
+      - b0ce9c559351420fa4f00cfaf5c1b6ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b9d12d9-b377-44e2-b744-6b58f1ae2ee2
+      - req-ca37b8fa-60e7-4904-9068-87c7d0257fea
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-0b9d12d9-b377-44e2-b744-6b58f1ae2ee2
+      - req-ca37b8fa-60e7-4904-9068-87c7d0257fea
       Date:
-      - Mon, 06 Aug 2018 16:51:24 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -2693,7 +2693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2706,14 +2706,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-2537d33f-2359-4643-a700-de261e248037
+      - req-f39332f7-074b-46ea-b93a-a2076b519c5a
       Date:
-      - Mon, 06 Aug 2018 16:51:24 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2728,7 +2728,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b10e4202d1df463c9dcb4b68f1281197
+      - 5083872fa7784d279384f878a6b555d9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2741,9 +2741,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-de760479-cee5-4952-8f57-6786e765dbbe
+      - req-e58b3316-d99f-4e9d-aeed-6f729984b68c
       Date:
-      - Mon, 06 Aug 2018 16:51:24 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2752,7 +2752,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2767,7 +2767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 431d46868c6c4bb1a94a329391f76758
+      - 41316c464a4d4bdfb691a6a3136d85ff
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2780,9 +2780,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c8b88a25-d541-46f5-8b97-84b3c909b515
+      - req-9c4a88c0-c5b2-4126-b41c-35cc98ee176b
       Date:
-      - Mon, 06 Aug 2018 16:51:24 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2791,7 +2791,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2806,7 +2806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 01be2b6f849f4487bf2b238975d34eb8
+      - 506b95b63c3d4908ba4676a0840097e1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2819,9 +2819,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-c4d8d08c-e850-4274-b0b2-cab352e17d38
+      - req-0890f0cf-e4e6-48f5-8432-0fb280788e1e
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2830,7 +2830,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2845,7 +2845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49e5a5b8957a4b079338f21d6ceadc7d
+      - 403e644dd8bf4aeb8fa32434824b4f1a
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2858,9 +2858,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d727f997-d7dd-4400-bca3-7c3e6e724c27
+      - req-a9882873-fdef-46a8-83ed-6527d7ea0d3f
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2869,7 +2869,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2897,9 +2897,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-aaba1991-9809-4187-a7c3-b41545c59e0c
+      - req-89a2c9f1-be9f-4af0-8aff-0281ab471929
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2908,7 +2908,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2923,7 +2923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca54f20a8a2245a8b4b76f044dbd12c7
+      - b9037ad91d054d1dbb2eb12e78fb466c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2936,9 +2936,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-96c0c00e-ee81-4115-8830-bdf7eca7701d
+      - req-75d86f4c-8a06-46d7-9062-425779b2c2dc
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2947,7 +2947,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2962,7 +2962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 38e58f1ba0c546aeb33bb2b73b3d8380
+      - 58d891d4424146328b6b346a8bfed489
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2975,9 +2975,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-961538ee-8b1f-4588-9e65-185844d96ef6
+      - req-0020c8ee-193b-4978-a924-6306806bff63
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2986,7 +2986,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3004,15 +3004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:25 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9f904fa7d6994c83a96abd2aec46ffa6
+      - 784e31e735c641e787a0b299bdf884d7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-581e2436-2092-45a6-82dd-4739c1aba520
+      - req-c078dbda-5d37-42b1-84c7-34383fad8f01
       Content-Length:
       - '7278'
       Connection:
@@ -3024,7 +3024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:26.143872Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:54.415233Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3103,10 +3103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UIRzInrIQ7SaIN7rQVI0eQ"],
-        "issued_at": "2018-08-06T16:51:26.143936Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k1II43M1S5yN9kS_-n3x1A"],
+        "issued_at": "2018-09-24T20:32:54.415254Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3121,22 +3121,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f904fa7d6994c83a96abd2aec46ffa6
+      - 784e31e735c641e787a0b299bdf884d7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81a1c7e9-a82f-476d-bd45-4dfc4ba1737c
+      - req-e8d233fd-73cf-4b97-b9f1-a6477e9b7689
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-81a1c7e9-a82f-476d-bd45-4dfc4ba1737c
+      - req-e8d233fd-73cf-4b97-b9f1-a6477e9b7689
       Date:
-      - Mon, 06 Aug 2018 16:51:27 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3146,7 +3146,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3164,15 +3164,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:27 GMT
+      - Mon, 24 Sep 2018 20:32:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e23869c87f9b4e60bddfa0e89bf2432f
+      - c6fcfadafaf1426aa64dcff14707972a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df77790c-1d5c-4155-acfa-1d168531bdb4
+      - req-7bafd999-dfea-413b-8272-f0a459111765
       Content-Length:
       - '7278'
       Connection:
@@ -3184,7 +3184,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:27.326235Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:54.857354Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3263,10 +3263,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M_qfJ6GvR0qpREoZgCfJIQ"],
-        "issued_at": "2018-08-06T16:51:27.326287Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vCzKiL8IRkqUI8Ur0qXidA"],
+        "issued_at": "2018-09-24T20:32:54.857374Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3281,22 +3281,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e23869c87f9b4e60bddfa0e89bf2432f
+      - c6fcfadafaf1426aa64dcff14707972a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a621ad06-47c4-4a1e-96eb-665842be471b
+      - req-18197678-7200-41fe-aa38-2dd25ccb9223
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a621ad06-47c4-4a1e-96eb-665842be471b
+      - req-18197678-7200-41fe-aa38-2dd25ccb9223
       Date:
-      - Mon, 06 Aug 2018 16:51:28 GMT
+      - Mon, 24 Sep 2018 20:32:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3306,7 +3306,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3324,15 +3324,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:28 GMT
+      - Mon, 24 Sep 2018 20:32:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b75cefcbbb74a3ebf73bd11adadece5
+      - 9783124e54e74b318936a6554f8f8f42
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-189a9729-164f-4dd7-a02d-5ea45688b349
+      - req-d3694371-b072-467c-bb0f-d9855e193b70
       Content-Length:
       - '7264'
       Connection:
@@ -3344,7 +3344,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:28.456815Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:55.324007Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3423,10 +3423,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KRDXWG_bTDi_I5pxQf9CtA"],
-        "issued_at": "2018-08-06T16:51:28.456856Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2Z6WKQEVTS6B9TtiWOx8-w"],
+        "issued_at": "2018-09-24T20:32:55.324028Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3441,22 +3441,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b75cefcbbb74a3ebf73bd11adadece5
+      - 9783124e54e74b318936a6554f8f8f42
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b13f903-a007-4000-a29e-76b1dbf44c6c
+      - req-e0edabb3-8e15-4a20-831b-58146951bb4b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1b13f903-a007-4000-a29e-76b1dbf44c6c
+      - req-e0edabb3-8e15-4a20-831b-58146951bb4b
       Date:
-      - Mon, 06 Aug 2018 16:51:29 GMT
+      - Mon, 24 Sep 2018 20:32:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3466,7 +3466,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3484,15 +3484,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:29 GMT
+      - Mon, 24 Sep 2018 20:32:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e4ed6de5c79147a9bc382766c6abbefe
+      - 833b43a1688f44fb8eb8437b8f9c47b7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e94f037b-47a5-42d3-af14-db27570806b0
+      - req-d7f076ca-15b6-419b-a743-a0906241eda1
       Content-Length:
       - '7278'
       Connection:
@@ -3504,7 +3504,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:29.428748Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:55.752145Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3583,10 +3583,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m9LCNLQ7R4e82VYr4oBYCw"],
-        "issued_at": "2018-08-06T16:51:29.428811Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EXbO3wezRcykLJuwk9QeXQ"],
+        "issued_at": "2018-09-24T20:32:55.752165Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3601,22 +3601,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e4ed6de5c79147a9bc382766c6abbefe
+      - 833b43a1688f44fb8eb8437b8f9c47b7
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-533339df-0554-41b5-bec5-1b24ec2d74a9
+      - req-9804f124-1606-463b-bf5a-4091a7eb20d2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-533339df-0554-41b5-bec5-1b24ec2d74a9
+      - req-9804f124-1606-463b-bf5a-4091a7eb20d2
       Date:
-      - Mon, 06 Aug 2018 16:51:30 GMT
+      - Mon, 24 Sep 2018 20:32:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3626,7 +3626,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3641,22 +3641,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eb09bb5278346cab6250bfeb145eeef
+      - b0ce9c559351420fa4f00cfaf5c1b6ee
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9a7e139c-05f4-401e-95c3-604ca84bfadc
+      - req-937dbc98-6396-412f-863e-a6708d2b20df
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-9a7e139c-05f4-401e-95c3-604ca84bfadc
+      - req-937dbc98-6396-412f-863e-a6708d2b20df
       Date:
-      - Mon, 06 Aug 2018 16:51:30 GMT
+      - Mon, 24 Sep 2018 20:32:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3666,7 +3666,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3684,15 +3684,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:31 GMT
+      - Mon, 24 Sep 2018 20:32:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be37f9becf2a45ea8c468e42649f1e85
+      - b4b3f31a64da431f9c128ca5a6f170e6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6d4e9712-b8b6-4e04-bc48-758b5b8fea0a
+      - req-74062f6b-46ea-40a7-b68a-f873bebf487e
       Content-Length:
       - '7265'
       Connection:
@@ -3704,7 +3704,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:31.228312Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:56.394623Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3783,10 +3783,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6C-Zh-dDQYGYzQznxWQh8g"],
-        "issued_at": "2018-08-06T16:51:31.228373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xHKHdlhNQemV_nPL8GTC0g"],
+        "issued_at": "2018-09-24T20:32:56.394642Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3801,22 +3801,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be37f9becf2a45ea8c468e42649f1e85
+      - b4b3f31a64da431f9c128ca5a6f170e6
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7e6da9c-e522-4e30-97b4-14f7bf00a9d6
+      - req-645cdaee-d7d2-4777-9696-66c7ecbd8141
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d7e6da9c-e522-4e30-97b4-14f7bf00a9d6
+      - req-645cdaee-d7d2-4777-9696-66c7ecbd8141
       Date:
-      - Mon, 06 Aug 2018 16:51:31 GMT
+      - Mon, 24 Sep 2018 20:32:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3826,7 +3826,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3844,15 +3844,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:32 GMT
+      - Mon, 24 Sep 2018 20:32:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c06e33d2d3c041fbad524b8187423614
+      - ccfee9729d754c89843851d6a1ccb846
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-06ea22e3-2c06-41f3-942b-e051c4c1f5c7
+      - req-9953d406-621f-4311-972c-e971d6456dac
       Content-Length:
       - '7278'
       Connection:
@@ -3864,7 +3864,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:32.195562Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:56.823055Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3943,10 +3943,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dnInQTygRDyj4UW4DDz2YQ"],
-        "issued_at": "2018-08-06T16:51:32.195621Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o1Dyy08IQlyu2RjW_gPXBA"],
+        "issued_at": "2018-09-24T20:32:56.823075Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3961,22 +3961,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c06e33d2d3c041fbad524b8187423614
+      - ccfee9729d754c89843851d6a1ccb846
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab027094-b071-4529-9a73-dff41ef2a35a
+      - req-d1f1152c-41a3-46c1-a902-394dc57f9b45
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ab027094-b071-4529-9a73-dff41ef2a35a
+      - req-d1f1152c-41a3-46c1-a902-394dc57f9b45
       Date:
-      - Mon, 06 Aug 2018 16:51:32 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3986,7 +3986,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4004,15 +4004,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:33 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4110357d3664748ad216dc8d38efb37
+      - 10f7d6954d4447c383fd555eedba3777
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7f51d211-f861-4a53-91b9-74aad5928fca
+      - req-c554f6c4-68c8-4e36-a51b-1d5394fda2b4
       Content-Length:
       - '7278'
       Connection:
@@ -4024,7 +4024,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:33.318791Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:57.268979Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4103,10 +4103,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SS4pBJoRT3C2Uk-zH3E8Rw"],
-        "issued_at": "2018-08-06T16:51:33.318855Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CmjzglwXRHyiiKIGvRLg4A"],
+        "issued_at": "2018-09-24T20:32:57.269012Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4121,7 +4121,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4110357d3664748ad216dc8d38efb37
+      - 10f7d6954d4447c383fd555eedba3777
   response:
     status:
       code: 200
@@ -4132,16 +4132,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8269964e-953c-49df-b97e-e4a65c7781ec
+      - req-29eca4a0-d696-409d-afd0-3e730059e3cd
       Date:
-      - Mon, 06 Aug 2018 16:51:33 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4159,15 +4159,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:33 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 62e474d28339400b809b8e4b159e3b3c
+      - 2c1c1f90040b4fc19353ecf24ea3634e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d22fe3f1-2a1f-4ca8-bc65-d24cc4ca724d
+      - req-64d46232-7c7d-41ab-8869-05010b086c4c
       Content-Length:
       - '7278'
       Connection:
@@ -4179,7 +4179,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:33.855775Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:57.574281Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4258,10 +4258,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dobKwiZsTemm61GnJf-p_g"],
-        "issued_at": "2018-08-06T16:51:33.855846Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dQ9DUUV4RpqL7vPNeYJx8Q"],
+        "issued_at": "2018-09-24T20:32:57.574302Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4276,7 +4276,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62e474d28339400b809b8e4b159e3b3c
+      - 2c1c1f90040b4fc19353ecf24ea3634e
   response:
     status:
       code: 200
@@ -4287,16 +4287,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-2e59daeb-04ec-4eaa-a44e-c79f04d2e599
+      - req-9695feb7-0618-4961-9b26-67ffd3fde474
       Date:
-      - Mon, 06 Aug 2018 16:51:34 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4314,15 +4314,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:34 GMT
+      - Mon, 24 Sep 2018 20:32:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c5c1919867084e7fa25f34b88b6677a9
+      - 9059d6a8876d471da145ffe2a9833533
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5e8c871-b13c-4ee4-95fb-85c8d12488ae
+      - req-5d80a8e0-604f-4cc0-b889-747d9b90fb07
       Content-Length:
       - '7264'
       Connection:
@@ -4334,7 +4334,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:34.377028Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:57.895220Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4413,10 +4413,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Jr5RGH1TQpG0me-BMk2PMw"],
-        "issued_at": "2018-08-06T16:51:34.377147Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_-1SRhWxQE2wPJ5xAmXjyw"],
+        "issued_at": "2018-09-24T20:32:57.895244Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:57 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4431,7 +4431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5c1919867084e7fa25f34b88b6677a9
+      - 9059d6a8876d471da145ffe2a9833533
   response:
     status:
       code: 200
@@ -4442,16 +4442,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-34bfce99-e04b-420c-bd92-5d1bb824a103
+      - req-632e335d-b58d-4bef-95da-b5f9a3ee9969
       Date:
-      - Mon, 06 Aug 2018 16:51:34 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4469,15 +4469,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:34 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 290afa4732bb4380a6d1161cfbd44698
+      - dc8749a00bae4c82b60e5afcedaee2be
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-936ec931-79f2-46a5-bee0-1c5ac1039b7b
+      - req-a8196be8-403b-4721-9fdc-d352c94aad9e
       Content-Length:
       - '7278'
       Connection:
@@ -4489,7 +4489,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:34.962942Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:58.213151Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4568,10 +4568,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cNe_YDr5RiOP0YyUCAnV8A"],
-        "issued_at": "2018-08-06T16:51:34.963029Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jeDPKEO4R6yZRY-hyODvyw"],
+        "issued_at": "2018-09-24T20:32:58.213176Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4586,7 +4586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 290afa4732bb4380a6d1161cfbd44698
+      - dc8749a00bae4c82b60e5afcedaee2be
   response:
     status:
       code: 200
@@ -4597,16 +4597,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-bde51391-2871-4ba0-91e2-b2f2881fd094
+      - req-1dac2196-bbab-44b4-9a61-c2a5ed1f2b3d
       Date:
-      - Mon, 06 Aug 2018 16:51:35 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4621,7 +4621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5afb80388c364351920a8c00059d383b
+      - a20c2d8353cb41ec9ca3c403377dc9c4
   response:
     status:
       code: 200
@@ -4632,16 +4632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-341977ea-e469-40da-a23f-56be052a03d6
+      - req-50b8e4fc-1f04-49a6-95f6-1c1fdbe5a02e
       Date:
-      - Mon, 06 Aug 2018 16:51:35 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4659,15 +4659,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:35 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c2406e14f2c44e42a28b83248a086b37
+      - 0d163e6231604576abbb2061c695fb86
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64af0ae9-fd1d-465a-b6bd-a21e5f4e0a8a
+      - req-5b1918ae-9bf4-4b78-a24b-68e92a2688c6
       Content-Length:
       - '7265'
       Connection:
@@ -4679,7 +4679,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:35.666889Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:58.627554Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4758,10 +4758,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GwsbhYcEQxKsshQtliMWDQ"],
-        "issued_at": "2018-08-06T16:51:35.666972Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QL-Fr8UFRluVuh1Xsfe_6w"],
+        "issued_at": "2018-09-24T20:32:58.627573Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c2406e14f2c44e42a28b83248a086b37
+      - 0d163e6231604576abbb2061c695fb86
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0a104bdb-bf68-4154-882c-8bbe2630c152
+      - req-8e6740ce-7afc-4839-b0ea-e54e8a097ba4
       Date:
-      - Mon, 06 Aug 2018 16:51:35 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4814,15 +4814,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:36 GMT
+      - Mon, 24 Sep 2018 20:32:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1db5e4ffdfbc43b5848fba63c4dcab94
+      - d68f204e3866471dba2416f12353ea9b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf71bf30-b813-4d02-88a1-14c4a7e0ce0c
+      - req-d8623c63-5369-4eca-b353-1499bd50f21e
       Content-Length:
       - '7278'
       Connection:
@@ -4834,7 +4834,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:36.221884Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:58.921220Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4913,10 +4913,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["os07ppsfS0mdlO5-32-KFw"],
-        "issued_at": "2018-08-06T16:51:36.222007Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TxE0oDSfSjWmzUtn5NsyFw"],
+        "issued_at": "2018-09-24T20:32:58.921240Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:58 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4931,7 +4931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1db5e4ffdfbc43b5848fba63c4dcab94
+      - d68f204e3866471dba2416f12353ea9b
   response:
     status:
       code: 200
@@ -4942,16 +4942,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-89dddf39-ef36-479d-acf5-a4964823439d
+      - req-5731b811-3f17-4af9-8fcd-26fbb914fdbf
       Date:
-      - Mon, 06 Aug 2018 16:51:36 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4966,7 +4966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4979,9 +4979,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-751f8977-2d82-43dd-9fab-a280836d2a38
+      - req-4f6e798b-d9f7-4272-8397-6144e6d12ecc
       Date:
-      - Mon, 06 Aug 2018 16:51:36 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4991,7 +4991,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5006,7 +5006,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5019,9 +5019,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-9806d495-5dc1-4607-b426-50fb3c2a8b88
+      - req-3257040e-99ae-4513-b04e-b21b8601957f
       Date:
-      - Mon, 06 Aug 2018 16:51:36 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -5031,7 +5031,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5049,15 +5049,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:36 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ccefa67982f4fc0a557b977ab3db8b7
+      - 1d5caf017714408197bc3fc06b931c28
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8e668668-f150-4228-aaa5-adbfe90efa15
+      - req-2bf0ad16-6361-44bc-8afc-f665f835372d
       Content-Length:
       - '7278'
       Connection:
@@ -5069,7 +5069,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:36.942370Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:59.392283Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5148,10 +5148,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h5hUEAGOTL-o4L7HX_ZCxg"],
-        "issued_at": "2018-08-06T16:51:36.942433Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ro_cBtxKQ9mZNR4ykjvn6Q"],
+        "issued_at": "2018-09-24T20:32:59.392303Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5166,7 +5166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0ccefa67982f4fc0a557b977ab3db8b7
+      - 1d5caf017714408197bc3fc06b931c28
   response:
     status:
       code: 200
@@ -5177,14 +5177,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-12ea4ca9-1792-4102-a1e7-b07655588aa1
+      - req-d5ea170e-b255-4327-9d58-26f369fd3fce
       Date:
-      - Mon, 06 Aug 2018 16:51:37 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5202,15 +5202,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:37 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6ab1aa65bd144492a98e2d0b39dd5262
+      - 6b12cee44c254a26978891041f5ea7d0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df8e8ae6-c7a8-4f59-9e6e-c6484d243a3e
+      - req-56e639c8-ef8c-46c2-baa8-6dbc46e61667
       Content-Length:
       - '7278'
       Connection:
@@ -5222,7 +5222,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:37.720845Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:32:59.709571Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5301,10 +5301,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r3Oz1RJ6QHmU6mcb2wVnIg"],
-        "issued_at": "2018-08-06T16:51:37.720910Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Xvqjg_n0R6invPkI56TmAA"],
+        "issued_at": "2018-09-24T20:32:59.709591Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5319,7 +5319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6ab1aa65bd144492a98e2d0b39dd5262
+      - 6b12cee44c254a26978891041f5ea7d0
   response:
     status:
       code: 200
@@ -5330,14 +5330,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6dd4ce75-4536-408b-9c15-938311fe0445
+      - req-28a96d20-b5c6-48a8-89c5-f29c94cd0f56
       Date:
-      - Mon, 06 Aug 2018 16:51:37 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:32:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5355,15 +5355,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:38 GMT
+      - Mon, 24 Sep 2018 20:32:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-622c394b-58ea-46ce-95cf-df6dbdb90079
+      - req-8558f1c3-e314-4386-9eb3-01a120b6b6f4
       Content-Length:
       - '7264'
       Connection:
@@ -5375,7 +5375,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:38.389848Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:00.022478Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5454,10 +5454,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w5URE9ZsQwmzDSeGYv1UIw"],
-        "issued_at": "2018-08-06T16:51:38.389930Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["464mY2niSLaZBfdS29Py_g"],
+        "issued_at": "2018-09-24T20:33:00.022499Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5472,7 +5472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -5483,9 +5483,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-c1de4878-cf57-470a-9b7b-211eb1b7ead7
+      - req-27c405d2-3de0-4865-aa6c-a7c0d0a05ae7
       Date:
-      - Mon, 06 Aug 2018 16:51:38 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5519,7 +5519,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5534,7 +5534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -5545,14 +5545,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cb212502-179f-46d8-b625-1ddd0e91d56d
+      - req-320ade95-11cd-42df-9420-30a9135a2567
       Date:
-      - Mon, 06 Aug 2018 16:51:38 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5570,15 +5570,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:39 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9a1e6f4b9af84f5690d103a4ed7661a6
+      - a9adc83cb9814375abc0d0677aa36098
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3953e6ff-1e6e-41ca-aa14-62a3c16eda77
+      - req-30d3f4f5-e753-4932-bfb7-c7d53f08afb9
       Content-Length:
       - '7278'
       Connection:
@@ -5590,7 +5590,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:39.236829Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:00.485944Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5669,10 +5669,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UvmlI7TJR7Kzt9Bu5gL4eA"],
-        "issued_at": "2018-08-06T16:51:39.236893Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mHut2Qq4TaCbpmOb44hcHA"],
+        "issued_at": "2018-09-24T20:33:00.485977Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9a1e6f4b9af84f5690d103a4ed7661a6
+      - a9adc83cb9814375abc0d0677aa36098
   response:
     status:
       code: 200
@@ -5698,14 +5698,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ea8cb772-534b-4c6f-b785-64be18a5152c
+      - req-c2db25ea-6b99-49d9-9fc3-eb2e70cbcb8a
       Date:
-      - Mon, 06 Aug 2018 16:51:39 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5720,7 +5720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ffeb21de6dfd45cd832ee12507701c88
+      - be9d57997d4248b4b8d2ca21b9378dcd
   response:
     status:
       code: 200
@@ -5731,14 +5731,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8f5e277a-6bf3-4227-99db-c03ec7e71628
+      - req-0d3e7239-4486-4fa8-a0dd-f6e9a9c0f246
       Date:
-      - Mon, 06 Aug 2018 16:51:39 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5756,15 +5756,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:39 GMT
+      - Mon, 24 Sep 2018 20:33:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 532b12047d5a4e0aa7a8ba39c5244fba
+      - d5ca16394996406aa0dd4febb449b6de
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-da792dca-f8e4-408d-861d-b6cfadf9ec27
+      - req-9ae3fbc8-ccd5-4aad-b3f7-33f3990a30eb
       Content-Length:
       - '7265'
       Connection:
@@ -5776,7 +5776,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:39.969404Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:00.912558Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5855,10 +5855,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["b60GEdvoS1KR4W17dE7R3Q"],
-        "issued_at": "2018-08-06T16:51:39.969471Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yBVYwM8CSa6arHQsKa4QfQ"],
+        "issued_at": "2018-09-24T20:33:00.912580Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5873,7 +5873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 532b12047d5a4e0aa7a8ba39c5244fba
+      - d5ca16394996406aa0dd4febb449b6de
   response:
     status:
       code: 200
@@ -5884,14 +5884,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4d559e8a-9828-4101-a043-aab4f6c69434
+      - req-e16af037-64de-4294-a9da-b3539d02cc2f
       Date:
-      - Mon, 06 Aug 2018 16:51:40 GMT
+      - Mon, 24 Sep 2018 20:33:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5909,15 +5909,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:51:40 GMT
+      - Mon, 24 Sep 2018 20:33:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9c0da6759bbd4dc28ac914a63c807d1e
+      - 7b643266296041a1b7a9aba4ef0f21f1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80cb9bc3-ea57-47b7-8856-83d3195547d2
+      - req-dfd67507-9437-4799-9ae9-dee869c4ba57
       Content-Length:
       - '7278'
       Connection:
@@ -5929,7 +5929,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:51:40.577098Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:01.216808Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6008,10 +6008,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PtEyDJnTRcSC23i9gvkycw"],
-        "issued_at": "2018-08-06T16:51:40.577222Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HdhKCrhtR-WIVuXa1eh_UA"],
+        "issued_at": "2018-09-24T20:33:01.216829Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -6026,7 +6026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9c0da6759bbd4dc28ac914a63c807d1e
+      - 7b643266296041a1b7a9aba4ef0f21f1
   response:
     status:
       code: 200
@@ -6037,14 +6037,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-81910c6e-d1c0-4037-81dc-348a3e90185e
+      - req-d7fdedce-f482-41c7-83f8-3b67a134cd35
       Date:
-      - Mon, 06 Aug 2018 16:51:40 GMT
+      - Mon, 24 Sep 2018 20:33:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -6059,7 +6059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6070,9 +6070,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d2bd73f6-093b-46c1-be99-8e8550712032
+      - req-7c5a5ea6-2955-4b85-a084-741518f45958
       Date:
-      - Mon, 06 Aug 2018 16:51:45 GMT
+      - Mon, 24 Sep 2018 20:33:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6099,7 +6099,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -6114,7 +6114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6125,9 +6125,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-0998f22e-4f3d-469b-9f5c-375527246edd
+      - req-f69b7cd2-3659-435e-9664-2c8fedb7a186
       Date:
-      - Mon, 06 Aug 2018 16:51:46 GMT
+      - Mon, 24 Sep 2018 20:33:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6154,7 +6154,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -6169,7 +6169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6180,9 +6180,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9f8eeb01-d4b3-41b1-aad4-166d28b8cd95
+      - req-ab1bcd29-a18f-4c1d-9862-e2a457775f4c
       Date:
-      - Mon, 06 Aug 2018 16:51:47 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6209,7 +6209,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6235,9 +6235,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-9260fe88-ed12-409f-bc1f-e952728b68ed
+      - req-a6b6b90e-18cd-4b20-bddf-eccd1a612d3a
       Date:
-      - Mon, 06 Aug 2018 16:51:47 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6249,7 +6249,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -6264,7 +6264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6275,9 +6275,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d0427ce1-0829-48be-90e1-8d1c85f2686e
+      - req-49cd5bbf-cc5f-40a0-b0ba-a3ab31c5c53d
       Date:
-      - Mon, 06 Aug 2018 16:51:47 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6333,7 +6333,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6348,7 +6348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6359,9 +6359,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1a5a407b-94af-4d8c-890a-0394ff86fbea
+      - req-5df489f5-8770-41c7-9131-5d9eee8a2b7b
       Date:
-      - Mon, 06 Aug 2018 16:51:47 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6373,7 +6373,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6388,7 +6388,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6399,9 +6399,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7ad1eb5a-7f20-45a1-94c1-5d4791cb90de
+      - req-88bb5f09-579f-4f30-8334-62ef9e1940a8
       Date:
-      - Mon, 06 Aug 2018 16:51:48 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6457,7 +6457,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6472,7 +6472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6483,9 +6483,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7454ea07-616a-433e-8537-b404e6919725
+      - req-39ab1381-fb31-46ef-9138-f0c91fa67c99
       Date:
-      - Mon, 06 Aug 2018 16:51:49 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6497,7 +6497,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6512,7 +6512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63a9fa8c296447bc92c4166e9b932d83
+      - c229f1f752254e11b9e8f1b831b190b0
   response:
     status:
       code: 200
@@ -6523,9 +6523,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-6094e7ce-8861-4004-a28e-a5a2a56a33dc
+      - req-f0776a26-7df2-4e46-bb5e-ee5baa66fd0d
       Date:
-      - Mon, 06 Aug 2018 16:51:49 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6581,7 +6581,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6596,7 +6596,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6607,14 +6607,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4eedd2eb-8512-4b39-8976-fdef4421d630
+      - req-b57cbdf2-98e6-4d74-ae48-93462a02309d
       Date:
-      - Mon, 06 Aug 2018 16:51:49 GMT
+      - Mon, 24 Sep 2018 20:33:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6629,7 +6629,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6640,9 +6640,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1b51cfee-60bc-485f-9391-2ea66ee96072
+      - req-05355299-5684-4f9b-94d5-e71598c35a40
       Date:
-      - Mon, 06 Aug 2018 16:51:49 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6684,7 +6684,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6699,7 +6699,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6710,14 +6710,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-828cac20-f8da-4a89-9b4b-4d23bf1baf64
+      - req-dde81d80-ec55-40d8-8c60-1284f4a9e173
       Date:
-      - Mon, 06 Aug 2018 16:51:50 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6732,7 +6732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6743,14 +6743,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-da83d015-94fe-4106-acef-2bbf5ec28d02
+      - req-e783ba26-8bb0-472c-bf95-a984dab3181b
       Date:
-      - Mon, 06 Aug 2018 16:51:50 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6765,7 +6765,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6776,14 +6776,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0d93543f-8b59-4a7b-a415-9e9ff68317e2
+      - req-f568e36e-9e45-4f8b-9fdc-a24b13741f27
       Date:
-      - Mon, 06 Aug 2018 16:51:50 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6798,7 +6798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a568efa0cc0473e97f05ff5679c3a92
+      - 2ecd586093bf46e0823df4794114dedc
   response:
     status:
       code: 200
@@ -6809,14 +6809,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0333ad11-de2b-4f82-9a05-aa1aa147eef0
+      - req-ebc6c5bd-2840-46fd-a9c2-3a4f0b1fa687
       Date:
-      - Mon, 06 Aug 2018 16:51:50 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6831,7 +6831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6844,13 +6844,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-e76fce9f-eba7-4130-8d96-64f3217540be
+      - req-367e5a9a-aa07-4f8c-b6d9-686d1f3f227e
       Date:
-      - Mon, 06 Aug 2018 16:51:51 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:23Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:08Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:2d:99:87", "version": 4, "addr": "192.168.1.7",
@@ -6892,7 +6892,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6907,7 +6907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6920,9 +6920,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-75467e34-39b3-4ae2-b987-ca5b3d00e4e0
+      - req-a72e777c-11a7-4fe0-ace9-175caaf87b62
       Date:
-      - Mon, 06 Aug 2018 16:51:52 GMT
+      - Mon, 24 Sep 2018 20:33:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6946,7 +6946,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-08-19T08:38:38Z", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:57:56Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:26:33Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:f6:82:4e", "version": 4, "addr": "192.168.0.5",
@@ -6968,7 +6968,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6983,7 +6983,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6996,13 +6996,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-9100033f-0d8b-425d-b048-496090b31e28
+      - req-b63846bd-d754-4c29-b10c-bfef9a7b181a
       Date:
-      - Mon, 06 Aug 2018 16:51:52 GMT
+      - Mon, 24 Sep 2018 20:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:58:19Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:26:22Z",
         "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b2:ca:85", "version": 4, "addr": "192.168.3.3",
@@ -7023,7 +7023,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:46:48Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:26:28Z", "hostId": "086f0f1bb7119e04a9943b8f3666415d52e8e389ca452e3dbd23b190",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:61:a5:87", "version": 4, "addr": "192.168.1.4", "OS-EXT-IPS:type":
@@ -7046,7 +7046,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -7061,7 +7061,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7074,9 +7074,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-87304f61-5a6e-4273-b3f7-9b4c2f6f306a
+      - req-49315b11-056c-4ed8-b825-ed34485dec63
       Date:
-      - Mon, 06 Aug 2018 16:51:53 GMT
+      - Mon, 24 Sep 2018 20:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -7118,7 +7118,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -7133,7 +7133,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7146,9 +7146,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-284f01e9-67d6-4c52-900c-fa4cff3e7218
+      - req-f4a5e041-c2ff-4166-b2bd-b169652f64ff
       Date:
-      - Mon, 06 Aug 2018 16:51:53 GMT
+      - Mon, 24 Sep 2018 20:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -7171,7 +7171,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7186,7 +7186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7199,14 +7199,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6056b383-0ac4-4cd7-bb89-29d1e415f76c
+      - req-dfe42b94-d416-4ddc-814e-94472d6efeca
       Date:
-      - Mon, 06 Aug 2018 16:51:54 GMT
+      - Mon, 24 Sep 2018 20:33:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7221,7 +7221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7234,14 +7234,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-fc8af774-dded-4637-93ab-4d95b3402408
+      - req-f0bb9093-ec6a-4908-b270-0ec4d64b37c8
       Date:
-      - Mon, 06 Aug 2018 16:51:54 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7256,7 +7256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7269,14 +7269,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-5a95f940-5e38-4c1c-9639-a66618fd05cf
+      - req-2235c6db-a25c-4c11-9d7e-d5a2d8e52050
       Date:
-      - Mon, 06 Aug 2018 16:51:54 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7291,7 +7291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7304,14 +7304,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-91b3c8b2-a0cc-4ea1-92a5-9fc526a83d20
+      - req-82c77326-5cc6-42dc-a196-9fe2a4c43d93
       Date:
-      - Mon, 06 Aug 2018 16:51:54 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7326,7 +7326,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7339,14 +7339,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ae9f19c1-b125-4cc2-8e2d-161dbb3bd924
+      - req-140aa64b-26e9-4504-9cc5-81024b0fc123
       Date:
-      - Mon, 06 Aug 2018 16:51:55 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7361,7 +7361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7374,14 +7374,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7e51f541-c0e9-41d0-99e8-a7fb6d0c26d6
+      - req-033d59e5-3862-4624-b3e8-9469361ce16e
       Date:
-      - Mon, 06 Aug 2018 16:51:55 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7396,7 +7396,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7409,14 +7409,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-314c19db-1b8e-453e-8ad6-3628edbb267c
+      - req-6a95cd72-2194-41f7-9ffe-9269cba3c405
       Date:
-      - Mon, 06 Aug 2018 16:51:55 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7431,7 +7431,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7444,14 +7444,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-656f8afc-36dc-45ba-84a0-090901552923
+      - req-ace240c9-5936-427a-bf8d-8b4c264651dc
       Date:
-      - Mon, 06 Aug 2018 16:51:56 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7466,7 +7466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7479,14 +7479,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0e7fa7d3-8f2b-43d8-b5e6-36c13ab57810
+      - req-11dfc089-2a4b-4c25-8cc8-4ff56465fa2e
       Date:
-      - Mon, 06 Aug 2018 16:51:56 GMT
+      - Mon, 24 Sep 2018 20:33:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7501,7 +7501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7514,26 +7514,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-66921e59-0f34-4526-ae94-560fac4ed43d
+      - req-08496dbe-54bd-4160-af83-8b388ca0d929
       Date:
-      - Mon, 06 Aug 2018 16:51:56 GMT
+      - Mon, 24 Sep 2018 20:33:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:51:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:33:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:51:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:33:04.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:51:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:33:04.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:51:48.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:33:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:51:48.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:33:04.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7548,7 +7548,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f7873263d6df437f9b29a17e90463fdb
+      - 46c4bc2f728146b987064d8ac1296d56
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7561,26 +7561,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d64fefca-3957-4992-9c01-8b14f4b95320
+      - req-dba91c97-be8a-4fac-9cda-0a4a385d86fc
       Date:
-      - Mon, 06 Aug 2018 16:51:56 GMT
+      - Mon, 24 Sep 2018 20:33:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:51:55.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:33:04.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:51:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:33:04.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:51:55.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:33:04.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2018-08-06T16:51:48.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:33:04.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-08-06T16:51:48.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2018-09-24T20:33:04.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:51:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7598,15 +7598,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:01 GMT
+      - Mon, 24 Sep 2018 20:33:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 15523f98a0374352911c4a41e0dfa078
+      - e1fe7d9df62f4711963896561f7e81e5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6b5587de-38df-4e21-b061-bc2f931635fa
+      - req-152dcd58-aa13-4cb5-a768-5e9480bd90e1
       Content-Length:
       - '7311'
       Connection:
@@ -7618,7 +7618,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:01.609231Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:07.494306Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7697,10 +7697,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lxXGAJkPTCKcOJ935xcWTg"],
-        "issued_at": "2018-08-06T16:52:01.609299Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9rHgSzH0QDC70B5wbxJ7sQ"],
+        "issued_at": "2018-09-24T20:33:07.494327Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7718,15 +7718,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:01 GMT
+      - Mon, 24 Sep 2018 20:33:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7f16d4a6-a1d7-49ea-a58a-fcbaa6179693
+      - req-21c2f713-be7c-4bea-a2f8-e9d3754d0f7e
       Content-Length:
       - '7311'
       Connection:
@@ -7738,7 +7738,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:01.959742Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:07.687144Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7817,10 +7817,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0uPZnlh6QPOsZ41del4z8g"],
-        "issued_at": "2018-08-06T16:52:01.959810Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["828F0tjqQ7CgwFzXz1ts6w"],
+        "issued_at": "2018-09-24T20:33:07.687179Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7835,7 +7835,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -7846,9 +7846,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-aa2a3c22-b6ca-4203-8466-472d6675fc07
+      - req-8b3cfe87-eceb-4a18-91c0-8a91bbf4a983
       Date:
-      - Mon, 06 Aug 2018 16:52:02 GMT
+      - Mon, 24 Sep 2018 20:33:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7883,7 +7883,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7898,7 +7898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -7909,9 +7909,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-cc254b16-9b58-4e0b-a9fc-22fb8da4918d
+      - req-76cc2cce-bb7c-4613-a530-4fe09ccf1e3f
       Date:
-      - Mon, 06 Aug 2018 16:52:02 GMT
+      - Mon, 24 Sep 2018 20:33:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7954,7 +7954,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7969,7 +7969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -7980,9 +7980,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-e8e039d8-abfe-4ad3-80a1-39e8fb38e22c
+      - req-b72d05ee-3e1e-4641-9be2-5eed12e44438
       Date:
-      - Mon, 06 Aug 2018 16:52:02 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -8025,7 +8025,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -8040,7 +8040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8051,9 +8051,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-7113e72b-6d5c-4057-a8ce-9382a65e6844
+      - req-b355521c-ba4a-4bbe-ae0a-60a225d32422
       Date:
-      - Mon, 06 Aug 2018 16:52:02 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -8160,7 +8160,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -8175,7 +8175,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8186,9 +8186,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-66df0057-983b-485f-b5f7-ee52da92b35e
+      - req-2707a08c-d6a3-4b25-adc7-252e43db6f88
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -8230,7 +8230,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -8245,7 +8245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8256,15 +8256,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-034e131f-5f23-4e99-96cf-8bda6e2272bc
+      - req-11e6e885-942d-4cbe-b670-2fabf35640d9
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -8279,7 +8279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8290,22 +8290,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-0643ae1f-d72d-4dc6-8900-1e6fedc0000e
+      - req-25adad23-ab04-4c0c-863d-67248fc2e186
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -8315,7 +8305,12 @@ http_interactions:
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
         false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "c2ab9441-dd1c-4acc-a3a6-753f1a582291"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
+        59}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
@@ -8355,14 +8350,19 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8377,7 +8377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8388,13 +8388,78 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-829e947a-355b-440f-b99d-f1483c9e4e75
+      - req-ead98329-7bd9-4cf6-b078-5238dc73d2c3
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp": false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.18.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2",
+        "end": "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "9801267c-cd57-437a-a852-b46640cb4332",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -8410,91 +8475,26 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -8509,7 +8509,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8520,13 +8520,78 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a536d0ef-c05b-4004-83f8-986d30795827
+      - req-12843647-04fb-403d-b8bc-b45677d688a5
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -8537,6 +8602,62 @@ http_interactions:
         "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a15eb64df81f476c8d359558e47c4486
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6972ff37-c4f1-4e13-87b7-618fb9f587f0
+      Date:
+      - Mon, 24 Sep 2018 20:33:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
         false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
@@ -8613,20 +8734,31 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8641,7 +8773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8652,9 +8784,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2f4a7272-b519-440c-850b-051c1617252d
+      - req-0f969af0-fb4a-40ff-b704-a7cc816fbaed
       Date:
-      - Mon, 06 Aug 2018 16:52:03 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8686,7 +8818,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8701,7 +8833,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8712,9 +8844,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-3738d89a-ccb6-4f8a-a25f-6ef630042f16
+      - req-e80eab33-9c24-4883-8bd5-a52cf9df1776
       Date:
-      - Mon, 06 Aug 2018 16:52:04 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8746,7 +8878,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8761,7 +8893,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -8772,9 +8904,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5dbd8ff8-5d54-4a41-9f96-ed65cf24cae4
+      - req-04cedd3f-5a02-4d94-b990-577e0283dcb1
       Date:
-      - Mon, 06 Aug 2018 16:52:04 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9177,7 +9309,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9192,7 +9324,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -9203,9 +9335,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-c8549ca2-6fcf-40c4-9562-883e1ce788ac
+      - req-4980958f-9d39-4c08-b0f5-2b3d29c9acbe
       Date:
-      - Mon, 06 Aug 2018 16:52:04 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9608,7 +9740,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9623,7 +9755,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -9634,9 +9766,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6a85074c-4b16-4eaa-b01f-bb2afb60f5c2
+      - req-9e0314e8-b519-4f13-a30f-172a802ded54
       Date:
-      - Mon, 06 Aug 2018 16:52:04 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9678,7 +9810,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9693,7 +9825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af2456753a34051ab830b15b62cfab5
+      - a15eb64df81f476c8d359558e47c4486
   response:
     status:
       code: 200
@@ -9704,9 +9836,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-28974418-f79f-4f18-9929-3fb5d6d189ad
+      - req-23bf8e39-c0be-44e2-9273-87643ac42def
       Date:
-      - Mon, 06 Aug 2018 16:52:05 GMT
+      - Mon, 24 Sep 2018 20:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9748,7 +9880,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9766,15 +9898,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:06 GMT
+      - Mon, 24 Sep 2018 20:33:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 66df1714399143038749d7cdf4b60272
+      - 4f9b945a71784591bb711f62f8f93f27
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdc51ca1-8ad4-4a1c-9c75-18258e8a732f
+      - req-9c25ebd8-8363-4e00-b040-d63579742adf
       Content-Length:
       - '7311'
       Connection:
@@ -9786,7 +9918,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:06.670899Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:10.578412Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9865,10 +9997,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UhNyFah8Q42NO1m799hGcw"],
-        "issued_at": "2018-08-06T16:52:06.670982Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M8Fa1mFZTH61Nfa7HU0jIQ"],
+        "issued_at": "2018-09-24T20:33:10.578432Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9886,15 +10018,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:06 GMT
+      - Mon, 24 Sep 2018 20:33:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-84ad5844-477c-43f4-935e-0b860aef2fc1
+      - req-fd9a56b8-0a55-4d72-bd84-786e0ad4c0d9
       Content-Length:
       - '7311'
       Connection:
@@ -9906,7 +10038,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:07.028832Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:10.767965Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9985,10 +10117,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["18UuaCOYTf6mLRtYtpchlg"],
-        "issued_at": "2018-08-06T16:52:07.028896Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yi456TG8TFa_tEuLdrWmoA"],
+        "issued_at": "2018-09-24T20:33:10.767984Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10006,15 +10138,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:07 GMT
+      - Mon, 24 Sep 2018 20:33:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aa82b495017d44c6a7579e523942e37e
+      - d8cf0856a5c74d718184bcdb4ff10d79
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6c958dc4-a68b-4ab5-9106-92636b64de1e
+      - req-461597f5-350f-42d7-b07d-d3916dd87959
       Content-Length:
       - '297'
       Connection:
@@ -10023,12 +10155,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:07.289668Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:33:10.925411Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kX-wJR1JTn2tkYvoBWr2vA"],
-        "issued_at": "2018-08-06T16:52:07.289731Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Jo8XazNSWWWNC1glBSV9A"],
+        "issued_at": "2018-09-24T20:33:10.925429Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -10043,20 +10175,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa82b495017d44c6a7579e523942e37e
+      - d8cf0856a5c74d718184bcdb4ff10d79
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:07 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d826cbcc-1a9f-4011-98d7-b7ec044d86af
+      - req-296a7d6c-945e-4af5-904f-e509ef3681d2
       Content-Length:
       - '2457'
       Connection:
@@ -10089,13 +10221,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"aa82b495017d44c6a7579e523942e37e"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"d8cf0856a5c74d718184bcdb4ff10d79"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -10107,15 +10239,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:07 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5786841e9b744ad7a9b96cdb0d51bc48
+      - 9744b7ec5b21423181ba63b32737c92f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-505890a2-75af-47db-8765-3d11e650124e
+      - req-08a5e320-4d76-4127-b88d-a40a91b7e6cf
       Content-Length:
       - '7313'
       Connection:
@@ -10127,7 +10259,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:07.289668Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:10.925411Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10206,10 +10338,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v95VpXNjSomSFUqGHssbLg",
-        "kX-wJR1JTn2tkYvoBWr2vA"], "issued_at": "2018-08-06T16:52:07.731624Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FXXEdGylQpSjO1KUesgctA",
+        "8Jo8XazNSWWWNC1glBSV9A"], "issued_at": "2018-09-24T20:33:11.238099Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -10224,20 +10356,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5786841e9b744ad7a9b96cdb0d51bc48
+      - 9744b7ec5b21423181ba63b32737c92f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:07 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5ca71d86-4325-4758-9c41-1f167897fc61
+      - req-8df0a4ff-f797-4013-a1c3-b0600913370b
       Content-Length:
       - '2179'
       Connection:
@@ -10270,7 +10402,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10288,15 +10420,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:08 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d5f5317d53b5499ba8a4b0872f791fa3
+      - 351d9567920a4b808efbedb257c2cc61
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9399010a-73e6-4d22-af7b-ebf2c9b97496
+      - req-dcb58256-0994-4e90-980e-be34ce327ca8
       Content-Length:
       - '7278'
       Connection:
@@ -10308,7 +10440,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:08.209275Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:11.546628Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10387,10 +10519,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8cWzwyJMS4qgJ5E-0uvtHg"],
-        "issued_at": "2018-08-06T16:52:08.209357Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zRccF8_WSY6cQVwrS8Vr2Q"],
+        "issued_at": "2018-09-24T20:33:11.546657Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10408,15 +10540,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:08 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5c415779d5d04b5abdc5f90dd4d987d8
+      - 52beaa32c31f4d4c864289e6bb9df16e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c88e34e1-c937-4b10-b893-584e7b388dc4
+      - req-dae10ff1-9908-4d74-b317-d36287a913e9
       Content-Length:
       - '7278'
       Connection:
@@ -10428,7 +10560,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:08.653371Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:11.755051Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10507,10 +10639,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e-6Xvm7sRfGdR90XbVlDMw"],
-        "issued_at": "2018-08-06T16:52:08.653452Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-IaUp1uVSkm9iSQH-SAZZg"],
+        "issued_at": "2018-09-24T20:33:11.755074Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10528,15 +10660,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:08 GMT
+      - Mon, 24 Sep 2018 20:33:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d45509c9ba06457b81c9f4718da53429
+      - 8357e943197f4d64acfdcad3b4d02f89
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2bd01763-eccf-4d4b-b288-725bc7e55736
+      - req-aeb7e025-762e-4de4-998a-892b2ee1a984
       Content-Length:
       - '7264'
       Connection:
@@ -10548,7 +10680,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:09.031777Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:11.966244Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10627,10 +10759,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OOyew8IfQOyRWS-t_nse1w"],
-        "issued_at": "2018-08-06T16:52:09.031842Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sk97aue9SHyet-l1p02R3Q"],
+        "issued_at": "2018-09-24T20:33:11.966265Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10648,15 +10780,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:09 GMT
+      - Mon, 24 Sep 2018 20:33:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 108bcda74ba74b5f96c9866780041ef1
+      - add3df0c15254eceaddf44e693c06a0a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8a7e1489-3ade-4dfb-bca7-b1b15adb232b
+      - req-35f3bbd5-56e0-49be-b80c-dd2094573109
       Content-Length:
       - '7278'
       Connection:
@@ -10668,7 +10800,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:09.364059Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:12.172247Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10747,10 +10879,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Lfo7a-H0RxOBi3x2ORIgLA"],
-        "issued_at": "2018-08-06T16:52:09.364178Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["i3W0kjz-S2e3_jnivqv3Uw"],
+        "issued_at": "2018-09-24T20:33:12.172270Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10768,15 +10900,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:09 GMT
+      - Mon, 24 Sep 2018 20:33:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6228b4120c494d7ca2decaa0daf2dd48
+      - 1bc3ff54c9a346b8a414aef34e8d2ccd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-536e68de-48c7-4968-acd4-a0fbf42bdbe2
+      - req-5faa123e-694c-467c-8dae-8fbcba7c88c7
       Content-Length:
       - '7265'
       Connection:
@@ -10788,7 +10920,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:09.709861Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:12.374201Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10867,10 +10999,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gdVcHc84SQq9xvuVHTkUuA"],
-        "issued_at": "2018-08-06T16:52:09.709926Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fAGWKWKQQE2k1SNg5587yA"],
+        "issued_at": "2018-09-24T20:33:12.374226Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10888,15 +11020,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:09 GMT
+      - Mon, 24 Sep 2018 20:33:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b7053bf492eb43cb8bfecefe6f383754
+      - 6934cdd8df434e35b20ff9b07f02cffd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2ff3d885-80ae-40dd-84b6-597d8da731d3
+      - req-e13bebb0-5c85-44fa-89dd-9f3840aec08c
       Content-Length:
       - '7278'
       Connection:
@@ -10908,7 +11040,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:10.038743Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:12.581376Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10987,10 +11119,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IaGrMEnAQviW1yD6YfZlwQ"],
-        "issued_at": "2018-08-06T16:52:10.038807Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uPZ5jF22QAGnhJVj0qDssQ"],
+        "issued_at": "2018-09-24T20:33:12.581400Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11008,15 +11140,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:10 GMT
+      - Mon, 24 Sep 2018 20:33:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa42b330-6f3e-4333-9539-dcace3579c7b
+      - req-e5b2e86e-7b74-4bff-8857-81a00e3a4ec3
       Content-Length:
       - '7278'
       Connection:
@@ -11028,7 +11160,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:10.364792Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:12.779594Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11107,10 +11239,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pr826tVVTNiAXahdEXQiHw"],
-        "issued_at": "2018-08-06T16:52:10.364874Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rgCTwM6yQGqpmgoqCXlu7g"],
+        "issued_at": "2018-09-24T20:33:12.779614Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -11125,27 +11257,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-519e8b9d-70af-4eee-aa1c-7aa5ce620670
+      - req-a033d50d-3430-4092-b7b6-3074716e95a9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-519e8b9d-70af-4eee-aa1c-7aa5ce620670
+      - req-a033d50d-3430-4092-b7b6-3074716e95a9
       Date:
-      - Mon, 06 Aug 2018 16:52:10 GMT
+      - Mon, 24 Sep 2018 20:33:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11163,15 +11295,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:10 GMT
+      - Mon, 24 Sep 2018 20:33:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fcf35f34-532d-44af-a1f1-438653164854
+      - req-a8206f6c-48f0-4580-a5df-bc248acde9e6
       Content-Length:
       - '7278'
       Connection:
@@ -11183,7 +11315,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:11.080511Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:13.139868Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11262,10 +11394,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1fY3xYSySa-z2uTTZ5yQDA"],
-        "issued_at": "2018-08-06T16:52:11.080579Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Nd8-oySiSXmefzsbMIBZpA"],
+        "issued_at": "2018-09-24T20:33:13.139889Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -11280,27 +11412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6336dec-e732-4c0c-ab65-2ddcd0db2be8
+      - req-996d357d-ec79-4bdc-b5a4-68eca09c2a5d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c6336dec-e732-4c0c-ab65-2ddcd0db2be8
+      - req-996d357d-ec79-4bdc-b5a4-68eca09c2a5d
       Date:
-      - Mon, 06 Aug 2018 16:52:11 GMT
+      - Mon, 24 Sep 2018 20:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11318,15 +11450,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:11 GMT
+      - Mon, 24 Sep 2018 20:33:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-347e6dcc-1a83-4bad-8484-2e567a400228
+      - req-07cafe6b-90c8-4ad4-8c3d-18e9a4ed1272
       Content-Length:
       - '7264'
       Connection:
@@ -11338,7 +11470,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:11.686400Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:13.484001Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11417,10 +11549,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wu8uH0jXR5e9nVRuqqx0lw"],
-        "issued_at": "2018-08-06T16:52:11.686464Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["c6SsjHprQM-Bwrgq_SoLfQ"],
+        "issued_at": "2018-09-24T20:33:13.484033Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -11435,22 +11567,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e391cf9b-fffe-46ad-97e6-7de3c37d669d
+      - req-662d8633-2496-4c9b-b761-d11393d0cd00
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-e391cf9b-fffe-46ad-97e6-7de3c37d669d
+      - req-662d8633-2496-4c9b-b761-d11393d0cd00
       Date:
-      - Mon, 06 Aug 2018 16:52:12 GMT
+      - Mon, 24 Sep 2018 20:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -11483,7 +11615,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -11498,22 +11630,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97694de3-ac96-4e04-8996-40bcd8503dea
+      - req-b3e65005-4e93-4e21-8f88-103927b8cb0e
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-97694de3-ac96-4e04-8996-40bcd8503dea
+      - req-b3e65005-4e93-4e21-8f88-103927b8cb0e
       Date:
-      - Mon, 06 Aug 2018 16:52:12 GMT
+      - Mon, 24 Sep 2018 20:33:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -11554,7 +11686,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -11569,22 +11701,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-baa3f566-aa17-4cb6-beb5-2cc86fbe4d2c
+      - req-f78bcbd8-7571-48ea-999d-835b76e8b0f9
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-baa3f566-aa17-4cb6-beb5-2cc86fbe4d2c
+      - req-f78bcbd8-7571-48ea-999d-835b76e8b0f9
       Date:
-      - Mon, 06 Aug 2018 16:52:13 GMT
+      - Mon, 24 Sep 2018 20:33:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -11618,7 +11750,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -11633,27 +11765,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5fa3a30b-3b5b-4ecb-8c06-532ed633a1ea
+      - req-22ee4404-bf26-43ec-bcb8-6d323f7e99dd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5fa3a30b-3b5b-4ecb-8c06-532ed633a1ea
+      - req-22ee4404-bf26-43ec-bcb8-6d323f7e99dd
       Date:
-      - Mon, 06 Aug 2018 16:52:13 GMT
+      - Mon, 24 Sep 2018 20:33:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11671,15 +11803,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:13 GMT
+      - Mon, 24 Sep 2018 20:33:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-24f1186a-5940-4b16-ac6b-75e096d21cd5
+      - req-83e97649-ca05-4d5e-9e37-dda086040c1f
       Content-Length:
       - '7278'
       Connection:
@@ -11691,7 +11823,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:13.583019Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:14.776785Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11770,10 +11902,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AZvmHlwtQ16ZiEUqtY1Ouw"],
-        "issued_at": "2018-08-06T16:52:13.583083Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8xECHcl6SZmQncLXL_Ouvw"],
+        "issued_at": "2018-09-24T20:33:14.776805Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -11788,27 +11920,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65415d85-3e40-4d6b-9ac3-479715044593
+      - req-f9b44b31-0127-401f-a7ac-38350a443e82
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-65415d85-3e40-4d6b-9ac3-479715044593
+      - req-f9b44b31-0127-401f-a7ac-38350a443e82
       Date:
-      - Mon, 06 Aug 2018 16:52:13 GMT
+      - Mon, 24 Sep 2018 20:33:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -11823,27 +11955,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c780c966-31a1-4d9e-a8f5-7ab76e3a2823
+      - req-3b8393b1-2a58-431e-a707-a8fc73abf25f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c780c966-31a1-4d9e-a8f5-7ab76e3a2823
+      - req-3b8393b1-2a58-431e-a707-a8fc73abf25f
       Date:
-      - Mon, 06 Aug 2018 16:52:14 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11861,15 +11993,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:14 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7277e9d3-f558-4a20-aff9-55ba3caf9069
+      - req-0346b0d8-492d-4aa2-87d3-77f09c18ba91
       Content-Length:
       - '7265'
       Connection:
@@ -11881,7 +12013,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:14.440256Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:15.263439Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11960,10 +12092,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iGLEj9fLTeiv54EheZ4YPQ"],
-        "issued_at": "2018-08-06T16:52:14.440328Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WJvGtU1HTLa8NFMBGxt0ww"],
+        "issued_at": "2018-09-24T20:33:15.263465Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -11978,27 +12110,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3a09aa28-3fba-4036-b73b-53f54b9b6127
+      - req-cdbd1d5b-0f0f-4f25-a2bc-9b5e5f18a28e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3a09aa28-3fba-4036-b73b-53f54b9b6127
+      - req-cdbd1d5b-0f0f-4f25-a2bc-9b5e5f18a28e
       Date:
-      - Mon, 06 Aug 2018 16:52:14 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12016,15 +12148,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:14 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f2ec099a-f6bd-472e-b1da-93f121e56c88
+      - req-a8c5950a-54e8-46c3-a1b2-72e6e3415ca5
       Content-Length:
       - '7278'
       Connection:
@@ -12036,7 +12168,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:15.225848Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:15.588266Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12115,10 +12247,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DJzt640SSP29-Nav4daUWQ"],
-        "issued_at": "2018-08-06T16:52:15.225925Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1olbH8OjS86X4FlPuvJK7g"],
+        "issued_at": "2018-09-24T20:33:15.588285Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -12133,27 +12265,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8d571db3-76ba-458d-950a-0b0fe3feff6b
+      - req-537a0737-4247-4480-a597-26898fcabc2c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8d571db3-76ba-458d-950a-0b0fe3feff6b
+      - req-537a0737-4247-4480-a597-26898fcabc2c
       Date:
-      - Mon, 06 Aug 2018 16:52:15 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -12168,27 +12300,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-47ba9cf1-826b-4b68-acb0-ed3c11f031df
+      - req-012ddb54-5ad5-4088-8dd2-175487a228ad
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-47ba9cf1-826b-4b68-acb0-ed3c11f031df
+      - req-012ddb54-5ad5-4088-8dd2-175487a228ad
       Date:
-      - Mon, 06 Aug 2018 16:52:15 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -12203,27 +12335,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd667826-5d51-4a72-88e1-d67be2d82436
+      - req-5e0f869e-560b-4289-91aa-2b547f90ff5a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dd667826-5d51-4a72-88e1-d67be2d82436
+      - req-5e0f869e-560b-4289-91aa-2b547f90ff5a
       Date:
-      - Mon, 06 Aug 2018 16:52:17 GMT
+      - Mon, 24 Sep 2018 20:33:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -12238,27 +12370,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a212f713-da79-443d-aad1-ce7bd4e87f08
+      - req-e49e1493-e46a-411e-b12e-91ad9f7e5d14
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a212f713-da79-443d-aad1-ce7bd4e87f08
+      - req-e49e1493-e46a-411e-b12e-91ad9f7e5d14
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -12273,27 +12405,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b80d35ae-a0ae-44f0-aabb-8367b9e37bc5
+      - req-506550da-058c-447b-ac87-13cc9af9128a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b80d35ae-a0ae-44f0-aabb-8367b9e37bc5
+      - req-506550da-058c-447b-ac87-13cc9af9128a
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12308,22 +12440,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b537b6ea-0a19-4607-abad-3103360e94e9
+      - req-220e36e2-1975-42d5-95f9-0df85927bf0f
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b537b6ea-0a19-4607-abad-3103360e94e9
+      - req-220e36e2-1975-42d5-95f9-0df85927bf0f
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12338,7 +12470,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12353,22 +12485,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-97c8d892-475e-488f-8523-0a4d68081ff3
+      - req-3d115008-88a0-41f0-a179-d0ec8e8848f6
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-97c8d892-475e-488f-8523-0a4d68081ff3
+      - req-3d115008-88a0-41f0-a179-d0ec8e8848f6
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12383,7 +12515,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12398,27 +12530,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65e32e67-8853-47a4-b1f8-5950bf686063
+      - req-d899d56f-e5bd-4e26-ad8e-4dfa5a8f71e2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-65e32e67-8853-47a4-b1f8-5950bf686063
+      - req-d899d56f-e5bd-4e26-ad8e-4dfa5a8f71e2
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12433,27 +12565,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b3ade5d-9b9c-452d-9c18-83bda22273cb
+      - req-372f1c22-17c0-4638-987f-789d7a3bd0d3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2b3ade5d-9b9c-452d-9c18-83bda22273cb
+      - req-372f1c22-17c0-4638-987f-789d7a3bd0d3
       Date:
-      - Mon, 06 Aug 2018 16:52:18 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12468,27 +12600,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39917fd9-587d-4f74-9ad2-d1960fe78e55
+      - req-13159d3a-6bd7-4caf-a23e-9c071979103a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-39917fd9-587d-4f74-9ad2-d1960fe78e55
+      - req-13159d3a-6bd7-4caf-a23e-9c071979103a
       Date:
-      - Mon, 06 Aug 2018 16:52:19 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12503,27 +12635,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ecc46a8-1a99-4cb4-84e8-48456dd51013
+      - req-c791ad9c-29ee-4d5a-aa0c-958be841184d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4ecc46a8-1a99-4cb4-84e8-48456dd51013
+      - req-c791ad9c-29ee-4d5a-aa0c-958be841184d
       Date:
-      - Mon, 06 Aug 2018 16:52:19 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12538,27 +12670,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e1eb4d1-a2d4-4aa7-8993-f339405982c8
+      - req-243114b0-2088-43ae-bfdf-e650bc91f450
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4e1eb4d1-a2d4-4aa7-8993-f339405982c8
+      - req-243114b0-2088-43ae-bfdf-e650bc91f450
       Date:
-      - Mon, 06 Aug 2018 16:52:19 GMT
+      - Mon, 24 Sep 2018 20:33:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12573,27 +12705,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-72faf593-cacc-4e56-9099-e1bc4d901079
+      - req-7ea74e76-f953-4871-bc39-36f274e2855c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-72faf593-cacc-4e56-9099-e1bc4d901079
+      - req-7ea74e76-f953-4871-bc39-36f274e2855c
       Date:
-      - Mon, 06 Aug 2018 16:52:19 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12608,27 +12740,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7234c564-83d7-47fa-9894-f109dc415f9a
+      - req-a6fbd3c8-ec6a-4277-a482-17821f584b14
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7234c564-83d7-47fa-9894-f109dc415f9a
+      - req-a6fbd3c8-ec6a-4277-a482-17821f584b14
       Date:
-      - Mon, 06 Aug 2018 16:52:19 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12643,27 +12775,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-898c26f8-b2ab-4ad6-a4d7-b8a02e0e89ae
+      - req-e14082c9-3ee3-4f7c-998c-b58bbd78eea7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-898c26f8-b2ab-4ad6-a4d7-b8a02e0e89ae
+      - req-e14082c9-3ee3-4f7c-998c-b58bbd78eea7
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12678,27 +12810,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-98f62d61-c37e-4ed1-8841-0db1a73b8a21
+      - req-6a8507b3-b873-4245-8e10-e366a57fee90
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-98f62d61-c37e-4ed1-8841-0db1a73b8a21
+      - req-6a8507b3-b873-4245-8e10-e366a57fee90
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -12713,27 +12845,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-867f3c74-f81c-4a9a-ac62-80e5b1196cdf
+      - req-0f38e6d6-ab73-47cc-9bd1-83947b1e944b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-867f3c74-f81c-4a9a-ac62-80e5b1196cdf
+      - req-0f38e6d6-ab73-47cc-9bd1-83947b1e944b
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -12748,27 +12880,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4c763c45-b05d-45ab-ba87-71dd6cf857ed
+      - req-6564f7c9-ad74-4b5f-b5c6-0d47e6d97196
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4c763c45-b05d-45ab-ba87-71dd6cf857ed
+      - req-6564f7c9-ad74-4b5f-b5c6-0d47e6d97196
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -12783,27 +12915,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-77627871-fb68-4eb2-ac82-22eb9bad08c4
+      - req-b81eaac9-4699-4662-9870-d6db729e5fd2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-77627871-fb68-4eb2-ac82-22eb9bad08c4
+      - req-b81eaac9-4699-4662-9870-d6db729e5fd2
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -12818,27 +12950,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16a7f231-95d2-48bf-a429-a6ea618202bd
+      - req-bb66b24a-15a5-496f-80b7-ae11a9e75cca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-16a7f231-95d2-48bf-a429-a6ea618202bd
+      - req-bb66b24a-15a5-496f-80b7-ae11a9e75cca
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -12853,27 +12985,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f35f9f4f-1945-4c09-8dba-770b817e4497
+      - req-61923da1-ecb7-48f9-a075-1e78a99bf8ff
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f35f9f4f-1945-4c09-8dba-770b817e4497
+      - req-61923da1-ecb7-48f9-a075-1e78a99bf8ff
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -12888,27 +13020,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-13ad7b6e-a29c-48a0-a0b2-6f55f486dc51
+      - req-1cac2732-f7ae-44bf-a11a-183291ffe8f4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-13ad7b6e-a29c-48a0-a0b2-6f55f486dc51
+      - req-1cac2732-f7ae-44bf-a11a-183291ffe8f4
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -12923,27 +13055,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8166d54c-41d3-426c-8101-de38d0f867ea
+      - req-7adf38a8-2f46-4f27-93b5-a27d85b39604
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8166d54c-41d3-426c-8101-de38d0f867ea
+      - req-7adf38a8-2f46-4f27-93b5-a27d85b39604
       Date:
-      - Mon, 06 Aug 2018 16:52:20 GMT
+      - Mon, 24 Sep 2018 20:33:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -12958,27 +13090,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ba1a77e-bd8b-4073-a49b-91e3511b2031
+      - req-0f70ebcb-7167-49dc-a591-ee359637a411
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4ba1a77e-bd8b-4073-a49b-91e3511b2031
+      - req-0f70ebcb-7167-49dc-a591-ee359637a411
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -12993,27 +13125,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-41ab7cb6-d655-4638-a042-8629091b3a3e
+      - req-5cd21946-561f-4563-b9dd-795f18365235
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-41ab7cb6-d655-4638-a042-8629091b3a3e
+      - req-5cd21946-561f-4563-b9dd-795f18365235
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -13028,27 +13160,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ec445f8f-8938-4385-98d1-5c2be6bfc334
+      - req-66517ef0-4f79-4092-b8bc-b5181a135652
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ec445f8f-8938-4385-98d1-5c2be6bfc334
+      - req-66517ef0-4f79-4092-b8bc-b5181a135652
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -13063,27 +13195,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-960a103b-02b4-4803-97a9-e3c294bb5e12
+      - req-153ba3ba-89bf-47c2-8c23-f6edd9e977cf
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-960a103b-02b4-4803-97a9-e3c294bb5e12
+      - req-153ba3ba-89bf-47c2-8c23-f6edd9e977cf
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -13098,27 +13230,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-772f5fd3-337d-4dc6-be0e-4f1d11c8e47c
+      - req-65e200d2-6926-4fe3-9e0b-2d9408310ddb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-772f5fd3-337d-4dc6-be0e-4f1d11c8e47c
+      - req-65e200d2-6926-4fe3-9e0b-2d9408310ddb
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -13133,27 +13265,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7269ff3d-fea7-4ad5-af61-628ab602850d
+      - req-0ff73900-1b65-4e12-90f2-64c3fb0bc51b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7269ff3d-fea7-4ad5-af61-628ab602850d
+      - req-0ff73900-1b65-4e12-90f2-64c3fb0bc51b
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -13168,22 +13300,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1600a5ae-c444-48d5-af6f-6ef6d9cd2f50
+      - req-9af78bed-63a8-4900-9504-c12efd55e0b8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1600a5ae-c444-48d5-af6f-6ef6d9cd2f50
+      - req-9af78bed-63a8-4900-9504-c12efd55e0b8
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13195,7 +13327,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13210,22 +13342,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 941aa8c8560b4777b00d7cd3b42f6b20
+      - 4c2edea03a4148179ba2e35b70eab0eb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-985032b9-77d5-4341-a839-f79fa02810f9
+      - req-0ba97fa9-ac76-4c06-8bd5-d4713ded0110
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-985032b9-77d5-4341-a839-f79fa02810f9
+      - req-0ba97fa9-ac76-4c06-8bd5-d4713ded0110
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13237,7 +13369,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -13252,22 +13384,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00ce4e97-8373-41ad-bc15-c0016be84505
+      - req-236a6852-db0e-44f6-a581-8867785a5c8c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-00ce4e97-8373-41ad-bc15-c0016be84505
+      - req-236a6852-db0e-44f6-a581-8867785a5c8c
       Date:
-      - Mon, 06 Aug 2018 16:52:21 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13279,7 +13411,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13294,22 +13426,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d1c4cdf6f930444d99d8b5e1bbf7ba51
+      - df4605f938d84aeaaddf61200f6034dd
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0352811a-ed3f-4c1e-98a8-ed00014de5c0
+      - req-dba8d9fa-a9e5-4238-8738-397801317616
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0352811a-ed3f-4c1e-98a8-ed00014de5c0
+      - req-dba8d9fa-a9e5-4238-8738-397801317616
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13321,7 +13453,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -13336,22 +13468,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b0ebe32-daf1-45e5-b577-56f85628111b
+      - req-c48da2fa-40dc-4dd7-8250-700112033b02
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6b0ebe32-daf1-45e5-b577-56f85628111b
+      - req-c48da2fa-40dc-4dd7-8250-700112033b02
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13363,7 +13495,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13378,22 +13510,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 48f522786c194f4d89e4f8b7acdc7389
+      - 5ca3a094f9254a4ea4b9e8df97f5c805
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e513773-e92d-463f-87cf-08df562b2af3
+      - req-b10aa530-a62a-4446-8f74-2f6165490a52
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6e513773-e92d-463f-87cf-08df562b2af3
+      - req-b10aa530-a62a-4446-8f74-2f6165490a52
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13405,7 +13537,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -13420,22 +13552,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-54c1593f-8c68-41f1-8513-eba3bd8398de
+      - req-43f55948-9abd-45ad-bc27-70d322ad0078
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-54c1593f-8c68-41f1-8513-eba3bd8398de
+      - req-43f55948-9abd-45ad-bc27-70d322ad0078
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13447,7 +13579,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13462,22 +13594,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42c29441bce94751bfd1383bc543b7ab
+      - 7826f461abd848e493d8b6af55085e74
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-992fc9af-1345-40f5-a86a-ae97de75b2aa
+      - req-ee4af73a-ce34-4727-8e0d-12802655877a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-992fc9af-1345-40f5-a86a-ae97de75b2aa
+      - req-ee4af73a-ce34-4727-8e0d-12802655877a
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13489,7 +13621,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -13504,22 +13636,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-59e30d26-4d9b-4127-a444-9e4235b2e204
+      - req-afe478b2-750e-4962-affb-ffd86e82f5fd
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-59e30d26-4d9b-4127-a444-9e4235b2e204
+      - req-afe478b2-750e-4962-affb-ffd86e82f5fd
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13531,7 +13663,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13546,22 +13678,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb0da74022e54c56909945f366edff91
+      - 1a21041d470941ee947151209568fe21
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5870264e-15fb-45a9-9121-e2136c8db350
+      - req-a6f4c879-3c03-498b-b805-42977b8a1236
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5870264e-15fb-45a9-9121-e2136c8db350
+      - req-a6f4c879-3c03-498b-b805-42977b8a1236
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13573,7 +13705,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13588,22 +13720,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4f0c8677-70cd-4e8d-97ec-433b34ceb752
+      - req-5e5fb525-b6ed-483a-a229-f876cabeb2a3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4f0c8677-70cd-4e8d-97ec-433b34ceb752
+      - req-5e5fb525-b6ed-483a-a229-f876cabeb2a3
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13615,7 +13747,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13630,22 +13762,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 978a124780744bdcb84b40efe817293d
+      - e7606488dcab4c5d8ed359cd273226fb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-088a1cc0-a01e-47f4-99b5-3ef83e45ef89
+      - req-4f086253-48fb-42e0-b096-0ebd6a72e475
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-088a1cc0-a01e-47f4-99b5-3ef83e45ef89
+      - req-4f086253-48fb-42e0-b096-0ebd6a72e475
       Date:
-      - Mon, 06 Aug 2018 16:52:22 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13657,7 +13789,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13672,22 +13804,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-280429da-c085-4a19-a76b-996348227772
+      - req-049e645a-d5c5-45dc-a2a4-a153d1e7de37
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-280429da-c085-4a19-a76b-996348227772
+      - req-049e645a-d5c5-45dc-a2a4-a153d1e7de37
       Date:
-      - Mon, 06 Aug 2018 16:52:23 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13699,7 +13831,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13714,22 +13846,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1033914dc9034f5eb1033e94c44e98ce
+      - 96d15c04522a44fe9cc00eecb1347c67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b6b1e31b-4acc-42b6-bda5-ec74629929ae
+      - req-38760478-ddb0-44e3-bcf9-4286d1abe159
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b6b1e31b-4acc-42b6-bda5-ec74629929ae
+      - req-38760478-ddb0-44e3-bcf9-4286d1abe159
       Date:
-      - Mon, 06 Aug 2018 16:52:23 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13741,7 +13873,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13759,15 +13891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:23 GMT
+      - Mon, 24 Sep 2018 20:33:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c3e93ae97b0540939c0e3acfceecde27
+      - f339b6371cd146468fd4b957079a6a4e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cfd49c81-f0a4-4c05-913c-9bb69b7da4ce
+      - req-86cbd97e-aa6d-4172-808b-5656067b3db9
       Content-Length:
       - '7311'
       Connection:
@@ -13779,7 +13911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:24.123252Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:19.987583Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13858,10 +13990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BqTdMzaUT_2R5GvnsglG7w"],
-        "issued_at": "2018-08-06T16:52:24.123330Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["43uRW_jTRQ2P3V3YEEAKtA"],
+        "issued_at": "2018-09-24T20:33:19.987603Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13879,15 +14011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:24 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 25ac68b239ab410897568559652e6fd3
+      - f1c812c89f4a4b5fbd29769ddfae50cd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca89e27f-197d-4d53-9def-3242d1b97471
+      - req-b7a4ab20-36b7-4eb2-9d62-37492b1cfdc5
       Content-Length:
       - '7311'
       Connection:
@@ -13899,7 +14031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2018-08-06T17:52:24.485418Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2018-09-24T21:33:20.183602Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13978,10 +14110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FbzU0fTiST2s7_NhayB9tQ"],
-        "issued_at": "2018-08-06T16:52:24.485500Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xdhjrv1AQ3eoJOfTBgmO2g"],
+        "issued_at": "2018-09-24T20:33:20.183620Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13999,15 +14131,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:24 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9f3482e3d4b94d8aaa782b554af427ef
+      - 576e4f23472f41f3a7bca36578a9e8e2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0d07b18f-cc78-4f7f-ae62-31451fb3cc19
+      - req-227c55c9-a293-4ea3-9c15-dcf8e205d695
       Content-Length:
       - '297'
       Connection:
@@ -14016,12 +14148,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2018-08-06T17:52:24.794505Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2018-09-24T21:33:20.346102Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KmGrj7rwSDGJ_xoIKInf4w"],
-        "issued_at": "2018-08-06T16:52:24.794660Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Zilzi-EYRb6z6OakwKERyQ"],
+        "issued_at": "2018-09-24T20:33:20.346129Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects
@@ -14036,20 +14168,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9f3482e3d4b94d8aaa782b554af427ef
+      - 576e4f23472f41f3a7bca36578a9e8e2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:24 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d6ddf3dd-90da-4ac3-8c6d-1702d53f0a32
+      - req-0a4bc2c7-d28e-4816-bc98-429f483ad662
       Content-Length:
       - '2457'
       Connection:
@@ -14082,13 +14214,13 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"9f3482e3d4b94d8aaa782b554af427ef"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
+      string: '{"auth":{"identity":{"methods":["token"],"token":{"id":"576e4f23472f41f3a7bca36578a9e8e2"}},"scope":{"project":{"id":"0098405163cd4c9dbb42c2cb43eb6fd3"}}}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -14100,15 +14232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:25 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 439076a415d7494f83ce1a691d29db03
+      - 4186ac0c185e49e9a27f4d10e73ed602
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d42dd8a2-24d8-4eb1-8b8f-2306d485ddd3
+      - req-b5f2b9b0-357c-4ee5-94db-6844914d8e73
       Content-Length:
       - '7313'
       Connection:
@@ -14120,7 +14252,7 @@ http_interactions:
       string: '{"token": {"methods": ["token", "password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:24.794505Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:20.346102Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14199,10 +14331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LzpvJBk5SQCi3Hxr9xbBpw",
-        "KmGrj7rwSDGJ_xoIKInf4w"], "issued_at": "2018-08-06T16:52:25.316500Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dnbgttAkSDyzWZ9mVP-IcA",
+        "Zilzi-EYRb6z6OakwKERyQ"], "issued_at": "2018-09-24T20:33:20.633919Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -14217,20 +14349,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 439076a415d7494f83ce1a691d29db03
+      - 4186ac0c185e49e9a27f4d10e73ed602
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:25 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02b1bd72-25e6-4cd5-a57b-63d59ca01f87
+      - req-2f356e1e-532b-4225-b4bd-5b59c568d4a6
       Content-Length:
       - '2179'
       Connection:
@@ -14263,7 +14395,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14281,15 +14413,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:25 GMT
+      - Mon, 24 Sep 2018 20:33:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4146989584574c08abcc91a11cf87dd2
+      - 635c74fbbadd4840bf1ccd8cbb95658a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-210b52f1-5bd1-4f18-bb89-36218534c355
+      - req-e3e28f8f-4a09-4f30-947e-cbac3e32a642
       Content-Length:
       - '7278'
       Connection:
@@ -14301,7 +14433,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:25.904275Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:20.919019Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14380,10 +14512,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["C_mFZ_gfQky8cVw4FZ2Vww"],
-        "issued_at": "2018-08-06T16:52:25.904371Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qMS7iKC_QIyAkJwYN1l8HA"],
+        "issued_at": "2018-09-24T20:33:20.919038Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14401,15 +14533,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:26 GMT
+      - Mon, 24 Sep 2018 20:33:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5a93d1b9dfa240f1b19915b30c67601a
+      - 3841708ee5ea42558ae6dd2e698dd479
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64e073aa-ec24-49e2-a7bb-70cb8f5da151
+      - req-0da0c346-6428-45f6-ace9-d836ca9f2d52
       Content-Length:
       - '7278'
       Connection:
@@ -14421,7 +14553,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:26.389477Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:21.122434Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14500,10 +14632,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UiKM2NDBSDS1M83lglYDSg"],
-        "issued_at": "2018-08-06T16:52:26.389573Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w9KB9JydSWS2ayo3SsRhqA"],
+        "issued_at": "2018-09-24T20:33:21.122455Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14521,15 +14653,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:26 GMT
+      - Mon, 24 Sep 2018 20:33:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c4fd9442c78649998ecd08e39c1a511b
+      - b474582ed8404e6184009600afd92867
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2bc1ed55-48dc-465e-8693-09cfb6eb86d9
+      - req-f8050e13-1cd5-455c-83b0-17906e2a3c16
       Content-Length:
       - '7264'
       Connection:
@@ -14541,7 +14673,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:26.901756Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:21.320809Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14620,10 +14752,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3A8GdwkwQUGdUGfriAhcpw"],
-        "issued_at": "2018-08-06T16:52:26.901840Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uSog5ZsRQB-xqbr5c6-2uA"],
+        "issued_at": "2018-09-24T20:33:21.320828Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14641,15 +14773,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:27 GMT
+      - Mon, 24 Sep 2018 20:33:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1c1ac1da945c4fd79dd5002ff986e71c
+      - 389081dd4ef94426ae5e75e4f659445d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-34655849-239b-48e2-bdad-772ce5da6bf2
+      - req-b28d5915-2959-4564-9d63-1268925dddb1
       Content-Length:
       - '7278'
       Connection:
@@ -14661,7 +14793,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:27.282256Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:21.508768Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14740,10 +14872,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gZ8ysRZJQMC0wmFazYV-jg"],
-        "issued_at": "2018-08-06T16:52:27.282309Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JxaTjiT0RZeUpvobBByNhg"],
+        "issued_at": "2018-09-24T20:33:21.508786Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14761,15 +14893,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:27 GMT
+      - Mon, 24 Sep 2018 20:33:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 82189fc28666405080748f1d907c28f9
+      - e50612ec656247c79079d422f182fe0b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1e7b73a8-90e7-4d46-b7b6-aa8200f8aa78
+      - req-4a930e74-3bf5-4507-a2e3-8e631ad29686
       Content-Length:
       - '7265'
       Connection:
@@ -14781,7 +14913,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:27.612981Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:21.697628Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14860,10 +14992,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZaVum7qxQmKX72e6CCfGRQ"],
-        "issued_at": "2018-08-06T16:52:27.613047Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4tLyCJHxSz-JAHVZDQpKIA"],
+        "issued_at": "2018-09-24T20:33:21.697647Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14881,15 +15013,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:27 GMT
+      - Mon, 24 Sep 2018 20:33:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9d0b822192b4b3eb4dd4a1887c2cf1b
+      - f354dd9681a54e4fb97abdc72421bc00
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e96b9d36-d706-400d-ab85-6adbcdfacabc
+      - req-eff5ca08-a734-40df-af4f-4db32fac88f8
       Content-Length:
       - '7278'
       Connection:
@@ -14901,7 +15033,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:27.978258Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:21.926225Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14980,10 +15112,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MLfwjhZuR963PQR_RHxPgg"],
-        "issued_at": "2018-08-06T16:52:27.978324Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["58Sgk1cSRT2gAOBz2iS7bw"],
+        "issued_at": "2018-09-24T20:33:21.926251Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15001,15 +15133,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:28 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d3869643e261478b8298cdcaa4712714
+      - d5ec1cb881d74c598e87eaeaa5cc6800
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-329b8ce1-5b3a-45db-8408-7ceac85e286e
+      - req-1f0555f1-328b-4d73-8153-d9b71e833254
       Content-Length:
       - '7278'
       Connection:
@@ -15021,7 +15153,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:28.366299Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:22.121936Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15100,10 +15232,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hXAH4G42Sw6e9YM2VEfZCg"],
-        "issued_at": "2018-08-06T16:52:28.366381Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yYLtRdaYT8KC2SGFPh2OnQ"],
+        "issued_at": "2018-09-24T20:33:22.121955Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -15118,7 +15250,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3869643e261478b8298cdcaa4712714
+      - d5ec1cb881d74c598e87eaeaa5cc6800
   response:
     status:
       code: 200
@@ -15131,22 +15263,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574348.96323'
+      - '1537821202.24511'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574348.96323'
+      - '1537821202.24511'
       X-Trans-Id:
-      - txe81c51d7c024453fbf86e-005b687ccc
+      - txfbcc9d2f37b1408e845b6-005ba94a12
       Date:
-      - Mon, 06 Aug 2018 16:52:28 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15164,15 +15296,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:29 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 55f549d41b74473a97aa4f888a854492
+      - b8954ad838f1471193f7191c511ecf3e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9e2e21fa-35ef-4e32-8c4c-fbafa7784597
+      - req-913f813f-e69b-4b8f-9106-bf70dbec4c3d
       Content-Length:
       - '7278'
       Connection:
@@ -15184,7 +15316,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:29.202965Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:22.471650Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15263,10 +15395,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jU2kZJfFQJyMLH5HbxvXLg"],
-        "issued_at": "2018-08-06T16:52:29.202998Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JRrLXZC2SiqDeQNCRqIZsA"],
+        "issued_at": "2018-09-24T20:33:22.471673Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -15281,7 +15413,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 55f549d41b74473a97aa4f888a854492
+      - b8954ad838f1471193f7191c511ecf3e
   response:
     status:
       code: 200
@@ -15294,22 +15426,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574349.35920'
+      - '1537821202.65534'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574349.35920'
+      - '1537821202.65534'
       X-Trans-Id:
-      - txbc32ba3d66a04d33bd95a-005b687ccd
+      - tx67607218ea734b2fa1d4d-005ba94a12
       Date:
-      - Mon, 06 Aug 2018 16:52:29 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15327,15 +15459,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:29 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4eeab5b2-869a-4ada-b834-633d55ae2e7a
+      - req-b2b908a3-fc21-4a45-9bbb-eaf32babac62
       Content-Length:
       - '7264'
       Connection:
@@ -15347,7 +15479,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:29.679645Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:22.861833Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15426,10 +15558,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rruV4CN-SKSkDZvzFGRxxw"],
-        "issued_at": "2018-08-06T16:52:29.679712Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nGFHqNl1QqW4pnxWprSNig"],
+        "issued_at": "2018-09-24T20:33:22.861854Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -15444,7 +15576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
   response:
     status:
       code: 200
@@ -15473,15 +15605,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx5fbf10835d5b4217b7598-005b687ccd
+      - tx91d92077679c44ed93de8-005ba94a12
       Date:
-      - Mon, 06 Aug 2018 16:52:29 GMT
+      - Mon, 24 Sep 2018 20:33:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -15496,7 +15628,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
   response:
     status:
       code: 200
@@ -15525,14 +15657,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx34c69dda6c4e4dbcb3edf-005b687ccd
+      - tx2d628000acb341349fac3-005ba94a13
       Date:
-      - Mon, 06 Aug 2018 16:52:29 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15550,15 +15682,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:30 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b6f7186ccc4417e87629b0f52801674
+      - fe5d7d9626b84b60a92762fd9a04ce6d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7a5142d6-67c6-4053-983b-fc89b7de6abc
+      - req-577767a7-83d8-4a25-8687-e1eab88677dc
       Content-Length:
       - '7278'
       Connection:
@@ -15570,7 +15702,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:30.311713Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:23.257392Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15649,10 +15781,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZMX5kPryToKwnfzVU6SpcA"],
-        "issued_at": "2018-08-06T16:52:30.311782Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fuQmrOBYSzySi1r6XuDRKA"],
+        "issued_at": "2018-09-24T20:33:23.257414Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -15667,7 +15799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b6f7186ccc4417e87629b0f52801674
+      - fe5d7d9626b84b60a92762fd9a04ce6d
   response:
     status:
       code: 200
@@ -15680,22 +15812,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574350.80327'
+      - '1537821203.38066'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574350.80327'
+      - '1537821203.38066'
       X-Trans-Id:
-      - tx1d6db1a8ec9c420a8ef00-005b687cce
+      - txa5a62be1218b423693ef2-005ba94a13
       Date:
-      - Mon, 06 Aug 2018 16:52:30 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -15710,7 +15842,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25ac68b239ab410897568559652e6fd3
+      - f1c812c89f4a4b5fbd29769ddfae50cd
   response:
     status:
       code: 200
@@ -15723,22 +15855,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574350.97355'
+      - '1537821203.48851'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574350.97355'
+      - '1537821203.48851'
       X-Trans-Id:
-      - txef94f7c5ec944daf8c9d8-005b687cce
+      - txeee497f59f6c47d5853b4-005ba94a13
       Date:
-      - Mon, 06 Aug 2018 16:52:30 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15756,15 +15888,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:31 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3ce7358b1beb47bc919ff2456362f682
+      - 040734dacf1e4ab99698671f646e4bda
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-02d493e9-8609-4592-9ba8-a46b2854560f
+      - req-e57e1f55-4c73-4d03-805c-8eada617f5cc
       Content-Length:
       - '7265'
       Connection:
@@ -15776,7 +15908,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:31.260465Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:23.670908Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -15855,10 +15987,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3QluEPG0Rp2Exl06kiWn3A"],
-        "issued_at": "2018-08-06T16:52:31.260528Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FZythYMvRvqd9BaiwcvmVQ"],
+        "issued_at": "2018-09-24T20:33:23.670929Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -15873,7 +16005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3ce7358b1beb47bc919ff2456362f682
+      - 040734dacf1e4ab99698671f646e4bda
   response:
     status:
       code: 200
@@ -15886,22 +16018,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574351.45556'
+      - '1537821203.79582'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574351.45556'
+      - '1537821203.79582'
       X-Trans-Id:
-      - txec901d86dc3146d887b6e-005b687ccf
+      - tx2fc421dc8d3649178e1a3-005ba94a13
       Date:
-      - Mon, 06 Aug 2018 16:52:31 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15919,15 +16051,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:52:31 GMT
+      - Mon, 24 Sep 2018 20:33:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6dd35e9b739e4c3bab52905c19b8a1bd
+      - 6a3466203b0043ff83bf8945891b2333
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2a8053c0-bb81-48f2-8806-1265bc624be4
+      - req-839e3439-f6e9-4dd0-a81c-e8572099184b
       Content-Length:
       - '7278'
       Connection:
@@ -15939,7 +16071,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2018-08-06T17:52:31.792310Z", "project": {"domain": {"id":
+        "expires_at": "2018-09-24T21:33:23.976247Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -16018,10 +16150,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2YM2-oxuRcmZX77MVvNFxQ"],
-        "issued_at": "2018-08-06T16:52:31.792380Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5kmIhUbfTkSRFcSv1VNStA"],
+        "issued_at": "2018-09-24T20:33:23.976267Z"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -16036,7 +16168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6dd35e9b739e4c3bab52905c19b8a1bd
+      - 6a3466203b0043ff83bf8945891b2333
   response:
     status:
       code: 200
@@ -16049,22 +16181,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574352.01231'
+      - '1537821204.10185'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574352.01231'
+      - '1537821204.10185'
       X-Trans-Id:
-      - txe5ff98c329704168a207b-005b687ccf
+      - txfb98df18c1db4f7db75f6-005ba94a14
       Date:
-      - Mon, 06 Aug 2018 16:52:32 GMT
+      - Mon, 24 Sep 2018 20:33:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -16079,7 +16211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
   response:
     status:
       code: 200
@@ -16100,9 +16232,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txc8f6a21e6acd42d3a17fe-005b687cd0
+      - tx6d0b04eb253746f1834e3-005ba94a14
       Date:
-      - Mon, 06 Aug 2018 16:52:32 GMT
+      - Mon, 24 Sep 2018 20:33:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -16112,7 +16244,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -16127,7 +16259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
   response:
     status:
       code: 200
@@ -16148,14 +16280,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx7b9d094560b94f0f90020-005b687cd0
+      - tx413642b92c5e41f490a7e-005ba94a14
       Date:
-      - Mon, 06 Aug 2018 16:52:32 GMT
+      - Mon, 24 Sep 2018 20:33:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:24 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -16170,7 +16302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc357a5fcf334fcf90081ac35b384131
+      - 782e5eef2178459893b2476475a142e3
   response:
     status:
       code: 200
@@ -16191,12 +16323,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txdfa47248dd58437a9f8c4-005b687cd0
+      - tx47ef979d88b84cfa89851-005ba94a14
       Date:
-      - Mon, 06 Aug 2018 16:52:32 GMT
+      - Mon, 24 Sep 2018 20:33:24 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:52:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:33:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:13 GMT
+      - Mon, 24 Sep 2018 20:28:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-574e8dff-6246-46ce-9597-87b327babf79
+      - req-d17a6a3e-d908-4afc-a0e6-a49160566100
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:14.221904", "expires":
-        "2018-08-06T17:56:14Z", "id": "0a1c251a0a53413d860cc9c5dad0829c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:36.850610", "expires":
+        "2018-09-24T21:28:36Z", "id": "b8a82fc22fd04194a1b5da0a145fa969", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["wrJYdAM0RuGVAMDQkG-lUg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["J-ILAa8gQsuSA6GB-AXF0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:56:14 GMT
+      - Mon, 24 Sep 2018 20:28:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:14 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f18ae6e9-1aa6-4358-808a-6c8d67791d97
+      - req-6ad862e0-5e38-4ac3-b4be-7915ee1c372b
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:14.608558", "expires":
-        "2018-08-06T17:56:14Z", "id": "3862a3a06e9047739c1cf95f9679d56b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:37.114733", "expires":
+        "2018-09-24T21:28:37Z", "id": "d5639fc018464c61b9eb1b172939d3f9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["EtSFsSEBSnWCWpNIZ1re0A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ngLjOHZjSReHSri08UJvvQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3862a3a06e9047739c1cf95f9679d56b
+      - d5639fc018464c61b9eb1b172939d3f9
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:56:14 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:14 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47a7fcf6-3637-40fc-8bcb-f20ee128c0d1
+      - req-d1e6cd3d-1485-4bf3-a9df-d3c37feafc75
       Content-Length:
       - '4170'
       Connection:
@@ -261,10 +261,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.178644", "expires":
-        "2018-08-06T17:56:15Z", "id": "c4aff8dc8ab747b78d59efc1939932c8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:37.373664", "expires":
+        "2018-09-24T21:28:37Z", "id": "44e4e08e917947e48c4e8a1831ac9bf9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Pbs7uwuUT3KuOVHoECrU8w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4mO7_DwlSVWoQDZI1g8FCA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -309,13 +309,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"c4aff8dc8ab747b78d59efc1939932c8"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"44e4e08e917947e48c4e8a1831ac9bf9"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -327,13 +327,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:15 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6d6f20df-ea61-4f19-901c-491fcc83d7b1
+      - req-80a27b9e-b5b1-4997-bb5d-096793fc566d
       Content-Length:
       - '4196'
       Connection:
@@ -342,10 +342,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.458543", "expires":
-        "2018-08-06T17:56:15Z", "id": "ca75336b6a60407bbb6e84831eb5f0fa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:37.561041", "expires":
+        "2018-09-24T21:28:37Z", "id": "914f5d88a735469fbc9fc96ceabb4f25", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Xu3qDGEFTbC3isSvn3XKOA", "Pbs7uwuUT3KuOVHoECrU8w"]},
+        "name": "admin"}, "audit_ids": ["VwaD0aLJRYql3ssB4kbA9A", "4mO7_DwlSVWoQDZI1g8FCA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -390,7 +390,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -408,13 +408,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:15 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-40518fac-75ce-4893-a772-ed514bb08f2d
+      - req-8449a743-cd49-4ff7-910e-d87117ecc74d
       Content-Length:
       - '4170'
       Connection:
@@ -423,10 +423,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:15.716568", "expires":
-        "2018-08-06T17:56:15Z", "id": "c54b89e03477463abe9a6a86d7c2931f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:37.737498", "expires":
+        "2018-09-24T21:28:37Z", "id": "c2853b43099940a2bdb6abe4d13d355d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zOqNN1N2TxuSm8MIQIwtKA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ys8VDrGMTd6HMBjwrHMjYg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -471,7 +471,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -486,7 +486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 300
@@ -497,7 +497,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:56:15 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -510,7 +510,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:15 GMT
+      - Mon, 24 Sep 2018 20:28:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-63d07123-687b-48e7-8755-00a0223a0de4
+      - req-1b267be0-f9c3-405e-8a22-1bddf08f0f31
       Content-Length:
       - '4170'
       Connection:
@@ -543,10 +543,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.066697", "expires":
-        "2018-08-06T17:56:16Z", "id": "5b88b8db6550473b983d820ddfa10fe2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:38.000639", "expires":
+        "2018-09-24T21:28:37Z", "id": "c7259919180d48c1be59b0381d44f1bb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2MHkPVA_S4GY0KE9nD0Qrw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["M3GA6-3tRMe2gqxvC_J4LA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -591,7 +591,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -609,13 +609,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:16 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-02c66512-4048-47f6-a7da-ad0562342ae7
+      - req-7af85f48-ec9b-4950-8be9-5cf211607e26
       Content-Length:
       - '4170'
       Connection:
@@ -624,10 +624,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.352435", "expires":
-        "2018-08-06T17:56:16Z", "id": "4db9e3de52b64fe6b9f75231e3c18989", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:38.192743", "expires":
+        "2018-09-24T21:28:38Z", "id": "3e71dcb6af234555860dcb3154ae2461", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["TBLLtuLVQzWab_d3ZYeQNg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["aoZyhtzFQbKywjXjpZyaxQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -672,7 +672,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -690,13 +690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:16 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29702310-45d2-4779-a859-8ccb9b64200c
+      - req-905a67e8-4245-4ef3-a516-3d5fd753c7b7
       Content-Length:
       - '4170'
       Connection:
@@ -705,10 +705,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:16.758306", "expires":
-        "2018-08-06T17:56:16Z", "id": "6efb20d8e15a42a9afa2416469cf6a2f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:38.373055", "expires":
+        "2018-09-24T21:28:38Z", "id": "5551de20c8d140439d24691b00bdd5b6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rap5m-aVRMOpsu4v9PZvDA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vv3Jhn0XRbWiBMuAfzTGEg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -753,7 +753,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -771,13 +771,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:16 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b5d87fa3-108f-4991-b931-8c8766b28301
+      - req-b92d95b7-dae8-4222-a402-f976d0cc370a
       Content-Length:
       - '4170'
       Connection:
@@ -786,10 +786,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.107166", "expires":
-        "2018-08-06T17:56:17Z", "id": "205ecc32b3af4bcc81803ca4c4f52a76", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:38.554884", "expires":
+        "2018-09-24T21:28:38Z", "id": "5de6f662ab5443198538f9f2f5346aa6", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["wEPLiSEtS7GixARNESZugA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PCaYTYGESCK2PuGwp2FzlA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -834,7 +834,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -852,13 +852,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:17 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c8f079bb-9087-4d62-8359-ee9e44a69280
+      - req-8e0dbf0b-0cfc-4282-8b74-486e6d41939c
       Content-Length:
       - '370'
       Connection:
@@ -867,13 +867,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.302499", "expires":
-        "2018-08-06T17:56:17Z", "id": "50ccf52529f44392aa9d0aa0dbe6618f", "audit_ids":
-        ["k47DKPNDRTCPrxSQuFVmiA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:38.718055", "expires":
+        "2018-09-24T21:28:38Z", "id": "6a5492399cee4505a05f4775c14b5b81", "audit_ids":
+        ["rpiPMmrBTs2SV7lCV87lxQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -888,20 +888,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50ccf52529f44392aa9d0aa0dbe6618f
+      - 6a5492399cee4505a05f4775c14b5b81
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:17 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7c196760-f557-4b0a-b9a9-67d53eab9432
+      - req-510bbf62-5e82-44b1-a19e-c002cead8fa7
       Content-Length:
       - '500'
       Connection:
@@ -918,13 +918,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"50ccf52529f44392aa9d0aa0dbe6618f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"6a5492399cee4505a05f4775c14b5b81"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -936,13 +936,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:17 GMT
+      - Mon, 24 Sep 2018 20:28:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e788d5da-ddc4-4537-b129-e53da2f2e023
+      - req-856a3efc-e05a-4f8e-a494-acf92ae8a502
       Content-Length:
       - '4143'
       Connection:
@@ -951,11 +951,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:17.715285", "expires":
-        "2018-08-06T17:56:17Z", "id": "7c713406d636412593ed99b535664778", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:39.013404", "expires":
+        "2018-09-24T21:28:38Z", "id": "938f6ea451bc44cb8d0cb89ccff86ca0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["NDm2ZrUdQFyb5dytgl9j-A",
-        "k47DKPNDRTCPrxSQuFVmiA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["esMT8yFTTUeXq3kygPU7Tw",
+        "rpiPMmrBTs2SV7lCV87lxQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -999,7 +999,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1014,20 +1014,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50ccf52529f44392aa9d0aa0dbe6618f
+      - 6a5492399cee4505a05f4775c14b5b81
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:17 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-20ec89df-8a3d-4533-b59a-4f6a93501351
+      - req-e7af6e3e-a3a3-45a3-904e-6ae0ed823ddc
       Content-Length:
       - '500'
       Connection:
@@ -1044,7 +1044,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1062,13 +1062,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:17 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-58f3b92d-4999-4db5-905f-b188b2b34e61
+      - req-41a3e710-852b-4975-a450-4dfdcea163d4
       Content-Length:
       - '4117'
       Connection:
@@ -1077,10 +1077,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.155722", "expires":
-        "2018-08-06T17:56:18Z", "id": "881a1cf149d840a1ae7b08cac9ebb411", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:39.329703", "expires":
+        "2018-09-24T21:28:39Z", "id": "4e2b75e5ad184100966cae9fe6acb1af", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fiEBHIZwTDmPFVWNFq6nmw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["kAGTFBcqRf-dG3KpP9_8IA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1124,7 +1124,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1139,7 +1139,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881a1cf149d840a1ae7b08cac9ebb411
+      - 4e2b75e5ad184100966cae9fe6acb1af
   response:
     status:
       code: 200
@@ -1150,7 +1150,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:56:18 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1159,7 +1159,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1177,13 +1177,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:18 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-de7a2d5c-c755-4c44-8913-266d2885fb2b
+      - req-a7f7c229-b87f-48e7-88e4-bcb74d1fef95
       Content-Length:
       - '4131'
       Connection:
@@ -1192,10 +1192,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.505734", "expires":
-        "2018-08-06T17:56:18Z", "id": "1145d419d34e4a81821bbc0e14581dba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:39.593434", "expires":
+        "2018-09-24T21:28:39Z", "id": "8fb7b2b0605648568e10a9dfd20862a5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["T8a2afxESvuP-iJ0d19oRw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Tm5pxuuyTaSdMYIY5hqTMA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1239,7 +1239,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1254,7 +1254,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1145d419d34e4a81821bbc0e14581dba
+      - 8fb7b2b0605648568e10a9dfd20862a5
   response:
     status:
       code: 200
@@ -1265,7 +1265,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:56:18 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1274,7 +1274,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1292,13 +1292,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:18 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3a3bab12-f007-4877-9430-37a6acb287b5
+      - req-80914559-f21b-4ba0-85e7-e5fab866e70f
       Content-Length:
       - '4118'
       Connection:
@@ -1307,10 +1307,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:18.881163", "expires":
-        "2018-08-06T17:56:18Z", "id": "3702476a21494fc48a21e6378c0a9856", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:39.853705", "expires":
+        "2018-09-24T21:28:39Z", "id": "0b52b1c88fa64f349cd406a7062965a7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["79aztpQCSj-fXPD5PAQlAg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["slndICaqRxekX5dyciLiVA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1354,7 +1354,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1369,7 +1369,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3702476a21494fc48a21e6378c0a9856
+      - 0b52b1c88fa64f349cd406a7062965a7
   response:
     status:
       code: 200
@@ -1380,7 +1380,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:56:18 GMT
+      - Mon, 24 Sep 2018 20:28:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1389,7 +1389,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1404,7 +1404,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1417,9 +1417,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-2f901f4e-1541-46a4-be93-949eaa633f2d
+      - req-c7fe1837-44b2-4bc9-8f2e-c29983286349
       Date:
-      - Mon, 06 Aug 2018 16:56:19 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1433,7 +1433,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1448,7 +1448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1461,9 +1461,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-a814a803-a443-476d-8536-c5d625db9fbf
+      - req-1f8c47f7-48be-40a5-82ee-2a18be4d3279
       Date:
-      - Mon, 06 Aug 2018 16:56:19 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1477,7 +1477,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1492,7 +1492,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1505,9 +1505,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-b987e4fa-0dde-4c1f-aead-d418a3c340ea
+      - req-59d62b59-c088-4ff9-92cf-369c120632be
       Date:
-      - Mon, 06 Aug 2018 16:56:19 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1522,7 +1522,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1537,7 +1537,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1550,9 +1550,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-221feb4d-ebfa-408c-872e-dc45299c6803
+      - req-b4855a6a-4b6f-42da-859f-9cc1847439b6
       Date:
-      - Mon, 06 Aug 2018 16:56:20 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1562,7 +1562,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1577,7 +1577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1590,15 +1590,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-b57e365e-b78c-407d-a374-93768c91f63c
+      - req-a2423dbb-d0bc-45d1-a0c2-2f6792394d0b
       Date:
-      - Mon, 06 Aug 2018 16:56:20 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -1613,7 +1613,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1626,15 +1626,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-f7867229-8588-473f-96e7-20d2f60c8d79
+      - req-9df2af38-3e41-4d5a-9e53-157da9724c24
       Date:
-      - Mon, 06 Aug 2018 16:56:20 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1649,28 +1649,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b88b8db6550473b983d820ddfa10fe2
+      - c7259919180d48c1be59b0381d44f1bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-392d519d-f883-421a-9b57-57b9d5c93e5f
+      - req-3b052172-235f-436b-a893-475582cb8889
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-392d519d-f883-421a-9b57-57b9d5c93e5f
+      - req-3b052172-235f-436b-a893-475582cb8889
       Date:
-      - Mon, 06 Aug 2018 16:56:21 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1685,7 +1685,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1698,14 +1698,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-900559fb-4bdb-4124-af42-093441bf08ce
+      - req-3fcc47ef-bfbd-454e-be89-f1d6c3195f3d
       Date:
-      - Mon, 06 Aug 2018 16:56:21 GMT
+      - Mon, 24 Sep 2018 20:28:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1720,7 +1720,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 881a1cf149d840a1ae7b08cac9ebb411
+      - 4e2b75e5ad184100966cae9fe6acb1af
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1733,9 +1733,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a6f1d15b-cc6b-460e-ba4e-ce66c66b476e
+      - req-b2b4b1ee-39c1-4b13-8d5b-b2979d93c2e5
       Date:
-      - Mon, 06 Aug 2018 16:56:21 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1744,7 +1744,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1759,7 +1759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1145d419d34e4a81821bbc0e14581dba
+      - 8fb7b2b0605648568e10a9dfd20862a5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1772,9 +1772,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f179412e-9587-480e-b1ce-fb1ee991ef1b
+      - req-b0db5f34-721c-4165-bf8c-44ca42a467b1
       Date:
-      - Mon, 06 Aug 2018 16:56:21 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1783,7 +1783,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1798,7 +1798,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1811,9 +1811,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7a8df9f0-e743-4632-a445-59b48ded306e
+      - req-756c8cf3-8e36-41e1-bae5-2b758cff13a2
       Date:
-      - Mon, 06 Aug 2018 16:56:22 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1822,7 +1822,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1837,7 +1837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3702476a21494fc48a21e6378c0a9856
+      - 0b52b1c88fa64f349cd406a7062965a7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1850,9 +1850,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-964061b9-e000-4f07-8d91-deb4fe8f46c3
+      - req-216e7719-2fbc-49f4-813b-dc83bc64df1f
       Date:
-      - Mon, 06 Aug 2018 16:56:22 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1861,7 +1861,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1879,13 +1879,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:22 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fe56bc4b-b119-494a-8726-44a8e1ff1d6e
+      - req-8c23de66-31f8-4dc2-b75b-8200b873f6af
       Content-Length:
       - '4117'
       Connection:
@@ -1894,10 +1894,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:22.654971", "expires":
-        "2018-08-06T17:56:22Z", "id": "6e5d42e1e0244ca8898fc13a04d8d0ae", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:41.565839", "expires":
+        "2018-09-24T21:28:41Z", "id": "2506832f77474e9f99562b2674e35e6b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9FjhQYBZRAyhSob1Ld9EMw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sCHOZVjbRoyo18Itkyesdg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1941,7 +1941,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1956,22 +1956,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e5d42e1e0244ca8898fc13a04d8d0ae
+      - 2506832f77474e9f99562b2674e35e6b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-818ff1c5-71d1-48cd-9ff9-43eb594d01c0
+      - req-0750c359-7705-4a63-83d6-34d5c91c6422
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-818ff1c5-71d1-48cd-9ff9-43eb594d01c0
+      - req-0750c359-7705-4a63-83d6-34d5c91c6422
       Date:
-      - Mon, 06 Aug 2018 16:56:23 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1981,7 +1981,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1999,13 +1999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:23 GMT
+      - Mon, 24 Sep 2018 20:28:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc5b3b42-03d1-4a5f-af1e-98dd37b36cf7
+      - req-19d25508-40f9-4b24-9dde-8ddc64aae051
       Content-Length:
       - '4131'
       Connection:
@@ -2014,10 +2014,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:23.972216", "expires":
-        "2018-08-06T17:56:23Z", "id": "2ef6d42a81de4eda86c3f0788cccac3e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:42.019395", "expires":
+        "2018-09-24T21:28:42Z", "id": "0a9b4a990a24439097e126540e1b2148", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LA3iHMW4QZKQJtDRPaWF8A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SqY_K_rDTfWA0KjJ4X0N3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2061,7 +2061,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2076,22 +2076,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ef6d42a81de4eda86c3f0788cccac3e
+      - 0a9b4a990a24439097e126540e1b2148
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a0bcd97d-17f3-4226-bb38-3b9dbc5c82a1
+      - req-e05d7587-0452-4917-bd51-e25e26e1aca1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a0bcd97d-17f3-4226-bb38-3b9dbc5c82a1
+      - req-e05d7587-0452-4917-bd51-e25e26e1aca1
       Date:
-      - Mon, 06 Aug 2018 16:56:24 GMT
+      - Mon, 24 Sep 2018 20:28:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2101,7 +2101,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2116,22 +2116,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b88b8db6550473b983d820ddfa10fe2
+      - c7259919180d48c1be59b0381d44f1bb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b379f742-8b78-42cc-93c2-1627919a9575
+      - req-13c4b874-cb60-4244-819a-76e9f5c53ec2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b379f742-8b78-42cc-93c2-1627919a9575
+      - req-13c4b874-cb60-4244-819a-76e9f5c53ec2
       Date:
-      - Mon, 06 Aug 2018 16:56:25 GMT
+      - Mon, 24 Sep 2018 20:28:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2141,7 +2141,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2159,13 +2159,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:25 GMT
+      - Mon, 24 Sep 2018 20:28:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29d80e03-ef0b-4446-9fa6-07e36ddd7f00
+      - req-ed219d5e-3e1f-4af3-8087-f578af66b496
       Content-Length:
       - '4118'
       Connection:
@@ -2174,10 +2174,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:25.385736", "expires":
-        "2018-08-06T17:56:25Z", "id": "ef629047ae834d218a3877ef380e67d0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:43.781175", "expires":
+        "2018-09-24T21:28:43Z", "id": "8d01a5608bd245af81a671f9f076c106", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0RiE_jzETpmtH23-gxlOLw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["et-ov896SNuv7nGYHRo7KQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2221,7 +2221,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2236,22 +2236,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef629047ae834d218a3877ef380e67d0
+      - 8d01a5608bd245af81a671f9f076c106
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffce3195-1037-4ea1-8e53-f21b3cbded90
+      - req-d2a597e4-8138-4f8a-8886-104fd9260e27
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ffce3195-1037-4ea1-8e53-f21b3cbded90
+      - req-d2a597e4-8138-4f8a-8886-104fd9260e27
       Date:
-      - Mon, 06 Aug 2018 16:56:25 GMT
+      - Mon, 24 Sep 2018 20:28:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -2261,7 +2261,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2279,13 +2279,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:25 GMT
+      - Mon, 24 Sep 2018 20:28:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a2b7236b-e704-48b9-b578-36c8d6b10b4b
+      - req-21d54676-03b1-4057-b440-f4d665a8aef1
       Content-Length:
       - '4117'
       Connection:
@@ -2294,10 +2294,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:26.034194", "expires":
-        "2018-08-06T17:56:26Z", "id": "1e2cb570c56f4116b4da740a2aa589e2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:44.504485", "expires":
+        "2018-09-24T21:28:44Z", "id": "97308f37dd734e2b9325a5d919745e6e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tRDLwEjrTyOOvdJqVf932g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mnINDGWQTe-AKa2snoCtiw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2341,7 +2341,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1e2cb570c56f4116b4da740a2aa589e2
+      - 97308f37dd734e2b9325a5d919745e6e
   response:
     status:
       code: 200
@@ -2367,16 +2367,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-790be193-93b0-4b7f-bab3-2909c1f277dc
+      - req-5a054267-e5fa-42e9-856e-8f50c65e4315
       Date:
-      - Mon, 06 Aug 2018 16:56:26 GMT
+      - Mon, 24 Sep 2018 20:28:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2394,13 +2394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:26 GMT
+      - Mon, 24 Sep 2018 20:28:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-af104d62-aff9-4274-bebc-aa792784466a
+      - req-20df997b-55c0-481b-8d35-4f65c3f8376e
       Content-Length:
       - '4131'
       Connection:
@@ -2409,10 +2409,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:26.466517", "expires":
-        "2018-08-06T17:56:26Z", "id": "e8cbefb71e204c3a8ac73a2961d69584", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:44.820629", "expires":
+        "2018-09-24T21:28:44Z", "id": "6ed8d13882834923b89eea862e111ab3", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["p6uo2xYMRrK3hEYGhOz2xw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7UyaPS_cRcO3-TfTH-3HmQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2456,7 +2456,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2471,7 +2471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8cbefb71e204c3a8ac73a2961d69584
+      - 6ed8d13882834923b89eea862e111ab3
   response:
     status:
       code: 200
@@ -2482,16 +2482,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-f16d2c13-807d-4e78-8a0a-8c947038c052
+      - req-bf047f82-39cf-4379-98ee-6bd0e53b1d6b
       Date:
-      - Mon, 06 Aug 2018 16:56:26 GMT
+      - Mon, 24 Sep 2018 20:28:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2506,7 +2506,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3862a3a06e9047739c1cf95f9679d56b
+      - d5639fc018464c61b9eb1b172939d3f9
   response:
     status:
       code: 200
@@ -2517,16 +2517,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a73f7bef-194d-45d3-83e8-9f50902297c3
+      - req-1bc0bd5d-6408-4145-88c3-248a9a69b337
       Date:
-      - Mon, 06 Aug 2018 16:56:26 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2544,13 +2544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:27 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-917fc6cb-6a36-4dcd-bd15-1ed260a3a3e4
+      - req-8ca8bb85-f459-4160-993f-d3a87d8480b7
       Content-Length:
       - '4118'
       Connection:
@@ -2559,10 +2559,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:27.192292", "expires":
-        "2018-08-06T17:56:27Z", "id": "ba09d12a155c46e59314ab4c239c8db2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:45.308266", "expires":
+        "2018-09-24T21:28:45Z", "id": "3e691939c45e4380957e1fa90ad4f9f2", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1TGmcJdHREC7zF3II-XjRQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["P9FJ5Q27Q3-Ejp8zb32tag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2606,7 +2606,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2621,7 +2621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba09d12a155c46e59314ab4c239c8db2
+      - 3e691939c45e4380957e1fa90ad4f9f2
   response:
     status:
       code: 200
@@ -2632,16 +2632,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4f1b4c48-91c0-4336-804a-51f9a4bfe2e8
+      - req-b8dd55d2-9132-4a8d-888a-1826488263ed
       Date:
-      - Mon, 06 Aug 2018 16:56:27 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2656,7 +2656,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2669,9 +2669,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6607e277-f5ee-4317-a814-46ca9307943d
+      - req-2982b322-f4d8-4e58-9f1f-2c380ddbdeb9
       Date:
-      - Mon, 06 Aug 2018 16:56:27 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2681,7 +2681,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2696,7 +2696,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2709,9 +2709,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ae7c0e14-785e-4d6a-8485-a9518464654f
+      - req-9318302b-0928-48d0-9160-641d897c45a2
       Date:
-      - Mon, 06 Aug 2018 16:56:27 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2721,7 +2721,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2739,13 +2739,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:27 GMT
+      - Mon, 24 Sep 2018 20:28:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b482fa67-720b-4f2a-b10e-4e3baee2337a
+      - req-90bf00fb-7d24-4283-b3f9-c32a8b8ff3a6
       Content-Length:
       - '4117'
       Connection:
@@ -2754,10 +2754,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:27.830932", "expires":
-        "2018-08-06T17:56:27Z", "id": "ad174646641448fc94c6034560539b00", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:45.871589", "expires":
+        "2018-09-24T21:28:45Z", "id": "5a5321f0683d43bfa08a0ef0324291ba", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["84bJQLx_Rm28Q3MG_ioqGw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zC8mpqSkRqGeps_4CAoVmw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2801,7 +2801,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2816,7 +2816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -2827,9 +2827,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-7bcbfbf6-454c-4090-bdc1-23aeeede03f3
+      - req-091d2a8b-b5f0-4544-a9a6-fd730b570700
       Date:
-      - Mon, 06 Aug 2018 16:56:28 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2863,7 +2863,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2878,7 +2878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -2889,14 +2889,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-cd5ff660-e306-4e37-b3a1-faaf4a0c53e6
+      - req-3b58d83e-7991-4efa-a551-90ac59903389
       Date:
-      - Mon, 06 Aug 2018 16:56:28 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2914,13 +2914,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:28 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c8b07d18-8462-4d20-b627-35e9ae3c8b0a
+      - req-24cdaee3-0595-4c6a-8b65-0042c1941666
       Content-Length:
       - '4131'
       Connection:
@@ -2929,10 +2929,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:29.130650", "expires":
-        "2018-08-06T17:56:29Z", "id": "abafe865999248acaa6b4b3cebd2f188", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:46.350814", "expires":
+        "2018-09-24T21:28:46Z", "id": "cc2508fd93be444a909ef22641dcb7da", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DLnv7gnqQrmTnfnNsx4FNg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Jiwv_5dqTwiC1bpoUPQNBg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2976,7 +2976,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2991,7 +2991,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abafe865999248acaa6b4b3cebd2f188
+      - cc2508fd93be444a909ef22641dcb7da
   response:
     status:
       code: 200
@@ -3002,14 +3002,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-76aa79f0-7607-4bc1-b41d-929ecbeab02b
+      - req-c9a8fd16-8eb5-4487-b996-d3cb7b4bcdcc
       Date:
-      - Mon, 06 Aug 2018 16:56:29 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -3024,7 +3024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 205ecc32b3af4bcc81803ca4c4f52a76
+      - 5de6f662ab5443198538f9f2f5346aa6
   response:
     status:
       code: 200
@@ -3035,14 +3035,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9917cefb-9d4e-4fc5-886b-d7d69d72e8b3
+      - req-254d7711-05b6-421e-934f-cec8cb89d7dc
       Date:
-      - Mon, 06 Aug 2018 16:56:29 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3060,13 +3060,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:29 GMT
+      - Mon, 24 Sep 2018 20:28:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c22ff259-287c-4d20-83a5-3077b8c70ed0
+      - req-1325c16c-655a-447c-a5a2-107b8a624549
       Content-Length:
       - '4118'
       Connection:
@@ -3075,10 +3075,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:30.036982", "expires":
-        "2018-08-06T17:56:29Z", "id": "d27125eef53c46719de5f474efb814fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:46.851770", "expires":
+        "2018-09-24T21:28:46Z", "id": "6269cd2ec03e41e1844242fb96559f04", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ze1iinhNS96Dr_pYxv7akA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EzHOHSFdQ72de2iJOTIH-A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3122,7 +3122,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -3137,7 +3137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d27125eef53c46719de5f474efb814fe
+      - 6269cd2ec03e41e1844242fb96559f04
   response:
     status:
       code: 200
@@ -3148,14 +3148,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-465c371d-3b38-4931-9686-06c73d254387
+      - req-c33b1df0-219c-450a-99c7-7c924df08d12
       Date:
-      - Mon, 06 Aug 2018 16:56:30 GMT
+      - Mon, 24 Sep 2018 20:28:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3170,7 +3170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3181,9 +3181,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-fb17740b-61e3-47d8-9af3-7c4a35557463
+      - req-2437bf64-eed1-44c8-9761-bd09d9a74cd6
       Date:
-      - Mon, 06 Aug 2018 16:56:34 GMT
+      - Mon, 24 Sep 2018 20:28:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3210,7 +3210,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3225,7 +3225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3236,9 +3236,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b35c284e-1160-462c-9821-9115246608fc
+      - req-15ed003d-4ce1-4445-8fbb-c85e10dcdaa3
       Date:
-      - Mon, 06 Aug 2018 16:56:35 GMT
+      - Mon, 24 Sep 2018 20:28:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3265,7 +3265,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3280,7 +3280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3291,9 +3291,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b5baf4e8-97cf-4abb-b4ce-abee44df037e
+      - req-4dd8c3f5-ed20-4e34-b805-a8a017045ae9
       Date:
-      - Mon, 06 Aug 2018 16:56:36 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3320,7 +3320,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3335,7 +3335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3346,9 +3346,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-23094a90-0c57-4d32-ac3f-eb5339c5a1da
+      - req-aae80e5f-e5c9-4b62-8dc1-a028c5284038
       Date:
-      - Mon, 06 Aug 2018 16:56:36 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3360,7 +3360,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3375,7 +3375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3386,9 +3386,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7ef7fe41-9ff4-4f89-a680-b9446c328bf5
+      - req-cbd12815-7b29-4faa-baaf-6ed000e63d1e
       Date:
-      - Mon, 06 Aug 2018 16:56:37 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3444,7 +3444,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3459,7 +3459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3470,9 +3470,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-45baedf9-5deb-4e00-84d4-7e2ff2e6debb
+      - req-6ecacf03-4218-4fb4-8ae9-15263ce373aa
       Date:
-      - Mon, 06 Aug 2018 16:56:37 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3484,7 +3484,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3499,7 +3499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3510,9 +3510,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9dd01a0e-128d-491a-8475-a519331c533d
+      - req-4918926f-a753-482a-9246-a510cbee544c
       Date:
-      - Mon, 06 Aug 2018 16:56:37 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3568,7 +3568,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3583,7 +3583,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3594,9 +3594,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-df7ca1c6-0645-4f71-97b5-8ae539426c95
+      - req-9ea88fd1-8901-4d6e-8472-90a0530f14b7
       Date:
-      - Mon, 06 Aug 2018 16:56:37 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3608,7 +3608,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3623,7 +3623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad174646641448fc94c6034560539b00
+      - 5a5321f0683d43bfa08a0ef0324291ba
   response:
     status:
       code: 200
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-315d9959-778b-4786-8bad-34977784840e
+      - req-eef7b7bb-4c28-47e4-b8eb-92cf55e1b501
       Date:
-      - Mon, 06 Aug 2018 16:56:37 GMT
+      - Mon, 24 Sep 2018 20:28:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3692,7 +3692,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3707,7 +3707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3718,14 +3718,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6ad6abc4-475b-4d11-a666-a082ecc46293
+      - req-3b1d1e3e-cd2a-4e23-9f44-36de789f66e4
       Date:
-      - Mon, 06 Aug 2018 16:56:38 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3751,9 +3751,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ede95c51-6e6d-4f6b-8739-b0477af5a0a8
+      - req-b778d8e3-ac09-4dc5-a68a-8cf50eaf693d
       Date:
-      - Mon, 06 Aug 2018 16:56:38 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3795,7 +3795,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3810,7 +3810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3821,14 +3821,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-4ccd5496-069f-48fc-832c-f359ad5e3a3c
+      - req-83197830-78ee-40e4-98f3-e8ac7df93f84
       Date:
-      - Mon, 06 Aug 2018 16:56:38 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3843,7 +3843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3854,14 +3854,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3490cfde-2364-4339-8a5e-abdeb4f0cc7b
+      - req-d018f15d-6d0b-47f9-8186-c6b66b8f2afb
       Date:
-      - Mon, 06 Aug 2018 16:56:39 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3876,7 +3876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3887,14 +3887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5a602754-8a2e-43c2-a4b5-396a87e120bb
+      - req-69d3113c-69d8-42cb-b4b9-0ade6146a6c8
       Date:
-      - Mon, 06 Aug 2018 16:56:39 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3909,7 +3909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c54b89e03477463abe9a6a86d7c2931f
+      - c2853b43099940a2bdb6abe4d13d355d
   response:
     status:
       code: 200
@@ -3920,14 +3920,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c2e89cab-6629-4b92-9406-38908337f0cb
+      - req-9060bba0-790c-4d2b-83c6-fd59fd0ed897
       Date:
-      - Mon, 06 Aug 2018 16:56:39 GMT
+      - Mon, 24 Sep 2018 20:28:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3942,7 +3942,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3955,13 +3955,13 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-ac5dc1c5-4661-4aee-84ab-56ced7147fc9
+      - req-0df011ba-4a27-4c5f-87f6-d50976ea3c0d
       Date:
-      - Mon, 06 Aug 2018 16:56:40 GMT
+      - Mon, 24 Sep 2018 20:28:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:07Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -4003,7 +4003,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -4018,7 +4018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4031,9 +4031,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-33a96184-5e0c-4dd6-8a73-9d5e091d68ef
+      - req-2ae83bcf-6065-4289-922a-ddcf8b70488c
       Date:
-      - Mon, 06 Aug 2018 16:56:41 GMT
+      - Mon, 24 Sep 2018 20:28:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -4057,7 +4057,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:59:17Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -4079,7 +4079,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -4094,7 +4094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4107,13 +4107,13 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-57145f92-00e1-42f4-8630-27dec521dcae
+      - req-a4207b0d-fe7a-44a4-8c77-c06904a3cd1a
       Date:
-      - Mon, 06 Aug 2018 16:56:41 GMT
+      - Mon, 24 Sep 2018 20:28:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:02Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -4134,7 +4134,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -4157,7 +4157,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4172,7 +4172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4185,9 +4185,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-65900957-9ec9-4fac-90d1-11402da259e5
+      - req-08933d9b-9f5d-4981-8234-8ca544ca859e
       Date:
-      - Mon, 06 Aug 2018 16:56:42 GMT
+      - Mon, 24 Sep 2018 20:28:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -4229,7 +4229,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -4244,7 +4244,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4257,9 +4257,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-28529117-8fba-4407-975e-4232c56215a6
+      - req-8e83d466-88f3-43b3-8cf0-1753d715609e
       Date:
-      - Mon, 06 Aug 2018 16:56:42 GMT
+      - Mon, 24 Sep 2018 20:28:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4282,7 +4282,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4297,7 +4297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4310,14 +4310,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-dc42ce06-1123-46c9-8d99-c83ecab3166e
+      - req-d94a2f9b-c24c-46c3-bd60-bb37f4ce79a3
       Date:
-      - Mon, 06 Aug 2018 16:56:42 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4332,7 +4332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4345,14 +4345,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-4574d923-d3a7-4c41-8954-eb142a9b4744
+      - req-50e45dc0-6c99-45f8-9668-7f2e028c2aec
       Date:
-      - Mon, 06 Aug 2018 16:56:43 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4367,7 +4367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4380,14 +4380,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6e31004a-9583-47e0-86e3-1126028bd16a
+      - req-0920a574-8382-4761-bd58-08f0fb63763c
       Date:
-      - Mon, 06 Aug 2018 16:56:43 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4402,7 +4402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4415,14 +4415,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f78a0c91-699e-4e78-b2ce-f865543d2af5
+      - req-c54486be-91a7-4967-b853-7bbe385a57c8
       Date:
-      - Mon, 06 Aug 2018 16:56:43 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4437,7 +4437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4450,14 +4450,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f721f735-2070-4cef-83fb-c1d8e58a07ae
+      - req-311b68f0-c0be-4158-800e-319c3a4a182d
       Date:
-      - Mon, 06 Aug 2018 16:56:43 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4472,7 +4472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4485,14 +4485,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-890536dd-4b5f-432f-ac79-0c600411bf67
+      - req-ac40200c-272c-4af0-b563-c3499c995ba7
       Date:
-      - Mon, 06 Aug 2018 16:56:44 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4507,7 +4507,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4520,14 +4520,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-41f32673-f5c9-4cb0-8be2-4c9e1ad98f8a
+      - req-01da04cf-834c-4f10-9557-f9abc6a92bed
       Date:
-      - Mon, 06 Aug 2018 16:56:44 GMT
+      - Mon, 24 Sep 2018 20:28:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4542,7 +4542,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4555,14 +4555,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7d61d164-1bf6-4a37-8844-1cad119cf8ca
+      - req-5ef122cd-f4b6-4562-9c95-ca2c0c915c2d
       Date:
-      - Mon, 06 Aug 2018 16:56:44 GMT
+      - Mon, 24 Sep 2018 20:28:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4577,7 +4577,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4590,14 +4590,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c2f3f3a8-3fec-4e70-901c-888c3c0f5715
+      - req-57970e5a-bdaf-4e41-b8c5-0cc7df7da0d5
       Date:
-      - Mon, 06 Aug 2018 16:56:45 GMT
+      - Mon, 24 Sep 2018 20:28:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4612,7 +4612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4625,26 +4625,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-342ee94b-e390-4228-9bbb-de53c0ce8c99
+      - req-70dad587-2c63-4998-8944-77ec377b1c19
       Date:
-      - Mon, 06 Aug 2018 16:56:45 GMT
+      - Mon, 24 Sep 2018 20:28:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:56:40.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:28:46.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:28:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:56:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:28:47.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:28:47.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:56:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:28:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4659,7 +4659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a1c251a0a53413d860cc9c5dad0829c
+      - b8a82fc22fd04194a1b5da0a145fa969
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4672,26 +4672,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-722ecb19-1e30-4291-9c9f-9cf3830d0865
+      - req-de342060-17cd-4fad-b988-3c416fc13d26
       Date:
-      - Mon, 06 Aug 2018 16:56:45 GMT
+      - Mon, 24 Sep 2018 20:28:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:56:40.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:28:46.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:28:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:56:42.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:28:47.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:56:40.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:28:47.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:56:40.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:28:44.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4709,13 +4709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:46 GMT
+      - Mon, 24 Sep 2018 20:28:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-75a021a1-7980-40e7-baa8-94ad5113fe40
+      - req-8f45b818-2504-44c4-ac68-42dd60cd9018
       Content-Length:
       - '4170'
       Connection:
@@ -4724,10 +4724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:46.478985", "expires":
-        "2018-08-06T17:56:46Z", "id": "be12d611959a4c47adce9174d3e901cd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:54.189756", "expires":
+        "2018-09-24T21:28:54Z", "id": "f0b518d411d7402981f92085710b460c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["OYxJrs86TfqFGZDdYSuwOA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["M2U80ABoQFa7UoJFKTMu_g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4772,7 +4772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4790,13 +4790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:46 GMT
+      - Mon, 24 Sep 2018 20:28:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-340fd13a-04e9-44bd-876f-85951f821894
+      - req-48db9a9b-8f9d-456a-9ba0-3d76d02aec2d
       Content-Length:
       - '4170'
       Connection:
@@ -4805,10 +4805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:46.961147", "expires":
-        "2018-08-06T17:56:46Z", "id": "995d15dff95a4fee96f30b7fd1edbdd7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:54.386596", "expires":
+        "2018-09-24T21:28:54Z", "id": "b82c70d6368c4c8aab37a4fa324450d5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DGTJnr4-TpioKqPNJIFakw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ojVMrrrWQhOwZ9rK3MhNKA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4853,7 +4853,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4868,7 +4868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -4879,9 +4879,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-bb642dbf-5426-4efc-b553-70bd44e77f81
+      - req-09782394-15de-487a-bcfd-7e79e963214b
       Date:
-      - Mon, 06 Aug 2018 16:56:47 GMT
+      - Mon, 24 Sep 2018 20:28:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4923,7 +4923,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4938,7 +4938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -4949,9 +4949,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-d58fb241-41eb-48db-9733-9b375538c434
+      - req-9f7a5863-7fab-44d8-8990-47fed7e1ac02
       Date:
-      - Mon, 06 Aug 2018 16:56:47 GMT
+      - Mon, 24 Sep 2018 20:28:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4994,7 +4994,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -5009,7 +5009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5020,9 +5020,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-3680ed49-649a-4f07-8129-04703fb39f3e
+      - req-109f16ec-0444-4c9f-a8bc-9f805ce6d31f
       Date:
-      - Mon, 06 Aug 2018 16:56:47 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -5057,7 +5057,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -5072,7 +5072,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5083,9 +5083,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-ba3363c3-f1d7-483e-8f88-c08d7cc78a3c
+      - req-487a2b49-1ff5-495a-b7be-7c43e293ed54
       Date:
-      - Mon, 06 Aug 2018 16:56:47 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -5172,7 +5172,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -5187,7 +5187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5198,26 +5198,51 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-e6760fea-05bf-4056-83e4-6c291bf445b5
+      - req-8c624293-0df7-4274-878c-7f45ddb86ccf
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        87}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["4d8b0801-addf-4ad4-8f46-e5bffa6a1002"],
         "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
         null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
         "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
@@ -5228,49 +5253,24 @@ http_interactions:
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        54}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "83e63648-5a43-4db0-907c-cf9ca0150336", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        53}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5285,7 +5285,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5296,27 +5296,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-48c78a6b-bea8-4779-961f-a06f631ff30d
+      - req-cee204b3-c8e8-4662-a75f-2945bda1e1ab
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -5365,30 +5383,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5402,7 +5402,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -5417,7 +5417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5428,28 +5428,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0da892a0-e78f-4bfd-99d1-1f96aa20985b
+      - req-fca8e46a-ce20-4835-b978-924a04508821
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -5462,79 +5487,55 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5549,7 +5550,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5560,9 +5561,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-75dc90e4-3096-4cf9-9f66-afb985d9f1a7
+      - req-de6b93f3-702b-47d7-88ba-fbd621c9c4c2
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5594,7 +5595,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5609,7 +5610,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5620,9 +5621,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-d92ffeb6-143c-49e5-acbb-95966f677377
+      - req-5cbfc45b-adb0-419c-a60d-a0856f9d4f1a
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5654,7 +5655,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5669,7 +5670,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -5680,9 +5681,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-7e473469-e6da-4db5-8c0b-1af34982f671
+      - req-58049c97-f5b5-4c50-b7bb-3f6d91a93316
       Date:
-      - Mon, 06 Aug 2018 16:56:48 GMT
+      - Mon, 24 Sep 2018 20:28:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6085,7 +6086,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6100,7 +6101,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -6111,9 +6112,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-e05d32b0-f8cb-4b79-be34-b8dfb7977b43
+      - req-59c7e28d-dc01-4c45-9310-23048058008c
       Date:
-      - Mon, 06 Aug 2018 16:56:49 GMT
+      - Mon, 24 Sep 2018 20:28:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6516,7 +6517,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6531,7 +6532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -6542,9 +6543,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-523f92a6-e681-4623-98c4-e962cd980acc
+      - req-8fe4d368-7a28-4597-b5f1-b00592a3cd78
       Date:
-      - Mon, 06 Aug 2018 16:56:49 GMT
+      - Mon, 24 Sep 2018 20:28:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6586,7 +6587,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6601,7 +6602,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 995d15dff95a4fee96f30b7fd1edbdd7
+      - b82c70d6368c4c8aab37a4fa324450d5
   response:
     status:
       code: 200
@@ -6612,9 +6613,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ccf89078-37d3-4959-9e1b-2a0fa2e9013c
+      - req-06ec641a-2826-4e29-88d5-d3bf91854f95
       Date:
-      - Mon, 06 Aug 2018 16:56:49 GMT
+      - Mon, 24 Sep 2018 20:28:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6656,7 +6657,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6674,13 +6675,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:50 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-920acb9c-ff5d-49e6-94e1-feef456300a0
+      - req-f1e08452-2876-4efa-a040-33c0d70093e9
       Content-Length:
       - '4170'
       Connection:
@@ -6689,10 +6690,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:50.579053", "expires":
-        "2018-08-06T17:56:50Z", "id": "cc0c60a8a61f4d628f3397e0492b86ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:57.166941", "expires":
+        "2018-09-24T21:28:57Z", "id": "e0737b2f816549d6879ddb8e268df4bf", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["L9r8X1y2Qay69jqGcJiTXA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["h4SXNZfSTWajpr6TOUqkzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6737,7 +6738,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6755,13 +6756,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:50 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ee2ad75-a8ed-4007-8cff-97ff8e3367dd
+      - req-5c9295bb-5bb3-4e09-b981-bf9e82a67bbb
       Content-Length:
       - '4170'
       Connection:
@@ -6770,10 +6771,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.061062", "expires":
-        "2018-08-06T17:56:50Z", "id": "ed186c04f9c846a599c65b9f6a6ba987", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:57.354633", "expires":
+        "2018-09-24T21:28:57Z", "id": "c5a9054218fb4651ab8deec82d3463b8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["PqdLtuLVTwySXgPG0qZFlQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wFCimlrISiOVX5Fu7P9YhQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6818,7 +6819,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6836,13 +6837,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:51 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-211e6daa-f06e-4dbd-938f-728bd15d480d
+      - req-ba554e65-8235-4a72-b251-5c1472f34f03
       Content-Length:
       - '370'
       Connection:
@@ -6851,13 +6852,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.231099", "expires":
-        "2018-08-06T17:56:51Z", "id": "4bc75d56cf684cc696f38224ed1d5f1c", "audit_ids":
-        ["wy-GK5oRSQqhu5aIIXaMOw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:57.513805", "expires":
+        "2018-09-24T21:28:57Z", "id": "d2adba4824494433a7e9ac5d77a34929", "audit_ids":
+        ["Vnp3jcvARmuL67ojdg_GOg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6872,20 +6873,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4bc75d56cf684cc696f38224ed1d5f1c
+      - d2adba4824494433a7e9ac5d77a34929
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:51 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-89541bc3-a0dd-4036-826f-0948bee250cd
+      - req-cc0d5955-96e8-4faa-a9aa-57c86bdcaa6f
       Content-Length:
       - '500'
       Connection:
@@ -6902,13 +6903,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"4bc75d56cf684cc696f38224ed1d5f1c"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"d2adba4824494433a7e9ac5d77a34929"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -6920,13 +6921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:51 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8e4d3954-0fcb-489d-b9bf-58aace5f488c
+      - req-d6073ec5-7e98-4709-af98-12183fbfa441
       Content-Length:
       - '4143'
       Connection:
@@ -6935,11 +6936,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.569092", "expires":
-        "2018-08-06T17:56:51Z", "id": "c421a5033be4461f8c029fad53364fe6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:57.858604", "expires":
+        "2018-09-24T21:28:57Z", "id": "8d72203a98524f0d87959fd428a50a4b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8sveZeh-RDOrlBUOAuQj_A",
-        "wy-GK5oRSQqhu5aIIXaMOw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WAXNlpvzQuqG4deygoxYQA",
+        "Vnp3jcvARmuL67ojdg_GOg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6983,7 +6984,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6998,20 +6999,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4bc75d56cf684cc696f38224ed1d5f1c
+      - d2adba4824494433a7e9ac5d77a34929
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:51 GMT
+      - Mon, 24 Sep 2018 20:28:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c5ecf08f-3947-42ac-b9fe-fb4beb3dcd91
+      - req-92598a38-27be-4782-9465-cf1540af5fdb
       Content-Length:
       - '500'
       Connection:
@@ -7028,7 +7029,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7046,13 +7047,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:51 GMT
+      - Mon, 24 Sep 2018 20:28:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-56b503c7-df7b-49d8-a481-aaeff6d7017e
+      - req-b477c798-7fc1-4a85-8c0b-ee4c16e1bb75
       Content-Length:
       - '4117'
       Connection:
@@ -7061,10 +7062,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:51.933612", "expires":
-        "2018-08-06T17:56:51Z", "id": "6bc5be06280848e3969a5e1ea819c807", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:58.177155", "expires":
+        "2018-09-24T21:28:58Z", "id": "58586a2595a64b42bacebdebadcb6eb7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RjRzm8rAQFSxrDohoxmLUQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["NsuPJy95SC6o5zau2wiozA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7108,7 +7109,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7126,13 +7127,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:52 GMT
+      - Mon, 24 Sep 2018 20:28:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-172189b5-491c-43a0-bcb0-b3ded1af5e52
+      - req-e9e3eb3b-aacd-49e8-9f76-7a7bee7d26b0
       Content-Length:
       - '4131'
       Connection:
@@ -7141,10 +7142,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.225492", "expires":
-        "2018-08-06T17:56:52Z", "id": "6d86c0a7c738417ea657be24c5bcf7d6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:58.355330", "expires":
+        "2018-09-24T21:28:58Z", "id": "8582036a9f874ee6be3fd4193d6879ef", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ev3a9TOoTLK3t5CvU19Gdw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["oWnV7tCRS9egzsMPRix0Tg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7188,7 +7189,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7206,13 +7207,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:52 GMT
+      - Mon, 24 Sep 2018 20:28:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3d4638db-9007-49a2-803b-2403e20ed8b4
+      - req-38f38159-e09f-4db5-802b-35885f5d0537
       Content-Length:
       - '4118'
       Connection:
@@ -7221,10 +7222,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.530687", "expires":
-        "2018-08-06T17:56:52Z", "id": "b0a1b7822c10457fa81cf5cd9c360bfd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:28:58.538894", "expires":
+        "2018-09-24T21:28:58Z", "id": "cf6510eb743d42339cf666ba51251404", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9_o5PeyvRDuCxAnQAO2ONw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["k14lcGIJR0ahB1zfoSZH5g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7268,7 +7269,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:28:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7286,13 +7287,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:52 GMT
+      - Mon, 24 Sep 2018 20:29:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec1f6712-37bb-427f-ac6b-94e6f55edebb
+      - req-f1b5ca09-5f4c-43c2-9af6-0667a7d037a2
       Content-Length:
       - '4117'
       Connection:
@@ -7301,10 +7302,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:52.963097", "expires":
-        "2018-08-06T17:56:52Z", "id": "06acf8463c4c4ef79ad6f44d02ccdd63", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:04.154365", "expires":
+        "2018-09-24T21:29:04Z", "id": "a863fb43af4145e2add3b2c66715b3e9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9mRETT2eTk-_D79lwBTC1g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GDzGH6gBSoaNf7hiOTyrpA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7348,7 +7349,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -7363,22 +7364,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffafa90a-69a3-4020-986b-fafdce1abcd3
+      - req-a96de10e-ea15-4877-b29e-c1f4034e414f
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-ffafa90a-69a3-4020-986b-fafdce1abcd3
+      - req-a96de10e-ea15-4877-b29e-c1f4034e414f
       Date:
-      - Mon, 06 Aug 2018 16:56:53 GMT
+      - Mon, 24 Sep 2018 20:29:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -7411,7 +7412,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -7426,22 +7427,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c9f4098a-80f8-40a5-ae49-2209b1a110c7
+      - req-af045f3f-fe1b-4b35-a3aa-56ea6a6dce2a
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-c9f4098a-80f8-40a5-ae49-2209b1a110c7
+      - req-af045f3f-fe1b-4b35-a3aa-56ea6a6dce2a
       Date:
-      - Mon, 06 Aug 2018 16:56:54 GMT
+      - Mon, 24 Sep 2018 20:29:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -7482,7 +7483,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7497,22 +7498,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96affb07-c31b-4fb5-9859-eb7224e186eb
+      - req-8047d996-8e6b-4779-8d38-16cc84c45db6
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-96affb07-c31b-4fb5-9859-eb7224e186eb
+      - req-8047d996-8e6b-4779-8d38-16cc84c45db6
       Date:
-      - Mon, 06 Aug 2018 16:56:54 GMT
+      - Mon, 24 Sep 2018 20:29:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7546,7 +7547,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7561,27 +7562,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2a4ed828-3828-4308-88ab-bf0f94a48eff
+      - req-17abf11e-b024-4337-9223-8272c020ae7f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2a4ed828-3828-4308-88ab-bf0f94a48eff
+      - req-17abf11e-b024-4337-9223-8272c020ae7f
       Date:
-      - Mon, 06 Aug 2018 16:56:55 GMT
+      - Mon, 24 Sep 2018 20:29:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7599,13 +7600,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:55 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0224ddac-a7be-4c97-bace-56d6bddb617f
+      - req-7286cd23-e5e1-4bf9-a054-67092c08ab95
       Content-Length:
       - '4131'
       Connection:
@@ -7614,10 +7615,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:55.557308", "expires":
-        "2018-08-06T17:56:55Z", "id": "7eb0a84107494998878267bc4e6dc4a9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:05.055743", "expires":
+        "2018-09-24T21:29:05Z", "id": "b7a2b21eff6f4dc9ac6a9fb450b379ae", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["M_sSZZhmRt2H7A1hipYtEA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DzoKuUodS9Gbg5xjIOOrFg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7661,7 +7662,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7676,27 +7677,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eb0a84107494998878267bc4e6dc4a9
+      - b7a2b21eff6f4dc9ac6a9fb450b379ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8dacea87-1c86-4b7d-ab96-468d7138bf11
+      - req-d4c58da0-3fdc-48a5-b9d9-c788a654c3e9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8dacea87-1c86-4b7d-ab96-468d7138bf11
+      - req-d4c58da0-3fdc-48a5-b9d9-c788a654c3e9
       Date:
-      - Mon, 06 Aug 2018 16:56:56 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7711,27 +7712,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed186c04f9c846a599c65b9f6a6ba987
+      - c5a9054218fb4651ab8deec82d3463b8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6337c501-b057-4df6-a38a-12e24df71925
+      - req-bc430b99-2f92-4a3a-84d0-b7158465d780
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6337c501-b057-4df6-a38a-12e24df71925
+      - req-bc430b99-2f92-4a3a-84d0-b7158465d780
       Date:
-      - Mon, 06 Aug 2018 16:56:56 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7749,13 +7750,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:56:56 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-99110dec-c428-4b48-b70a-24e28d0242a9
+      - req-302907b9-d408-4ea6-a9b5-5a3dba63cd1b
       Content-Length:
       - '4118'
       Connection:
@@ -7764,10 +7765,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:56:56.827925", "expires":
-        "2018-08-06T17:56:56Z", "id": "c21f45052e2f4a368d89147de075b0db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:05.653468", "expires":
+        "2018-09-24T21:29:05Z", "id": "4ab404e9d9d540d5a60508c03ce636be", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qe-PdPKlQ9W9SJ-QZuyAWg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["JdMxiaZyR_y67Kfo66W12A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7811,7 +7812,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7826,27 +7827,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21f45052e2f4a368d89147de075b0db
+      - 4ab404e9d9d540d5a60508c03ce636be
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-59ff5418-d28a-4b9a-84b1-0dd5bc648540
+      - req-faa0501c-7e26-4289-acb3-d12e22d6d9bd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-59ff5418-d28a-4b9a-84b1-0dd5bc648540
+      - req-faa0501c-7e26-4289-acb3-d12e22d6d9bd
       Date:
-      - Mon, 06 Aug 2018 16:56:57 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7861,22 +7862,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65aea607-d930-4d63-9c05-60a563cb81a0
+      - req-546fcd8a-6a5d-414b-94f1-e0115448807b
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-65aea607-d930-4d63-9c05-60a563cb81a0
+      - req-546fcd8a-6a5d-414b-94f1-e0115448807b
       Date:
-      - Mon, 06 Aug 2018 16:56:57 GMT
+      - Mon, 24 Sep 2018 20:29:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7891,7 +7892,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7906,22 +7907,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-06018a1c-711d-40b3-a136-54f5ec5700c1
+      - req-2a02c3d2-8b74-4641-a317-6f9912039988
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-06018a1c-711d-40b3-a136-54f5ec5700c1
+      - req-2a02c3d2-8b74-4641-a317-6f9912039988
       Date:
-      - Mon, 06 Aug 2018 16:56:57 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7936,7 +7937,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7951,27 +7952,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eb0a84107494998878267bc4e6dc4a9
+      - b7a2b21eff6f4dc9ac6a9fb450b379ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ecb3545-8a04-4e81-8fe7-81e26799e241
+      - req-a371fb69-84d3-4e7a-952f-728c6030abb1
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6ecb3545-8a04-4e81-8fe7-81e26799e241
+      - req-a371fb69-84d3-4e7a-952f-728c6030abb1
       Date:
-      - Mon, 06 Aug 2018 16:56:57 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7986,27 +7987,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eb0a84107494998878267bc4e6dc4a9
+      - b7a2b21eff6f4dc9ac6a9fb450b379ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a20b2645-3fc3-4a18-9e90-708b42ef8f65
+      - req-b8d44807-3ff3-4929-9090-cbce020aab55
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a20b2645-3fc3-4a18-9e90-708b42ef8f65
+      - req-b8d44807-3ff3-4929-9090-cbce020aab55
       Date:
-      - Mon, 06 Aug 2018 16:56:57 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8021,27 +8022,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed186c04f9c846a599c65b9f6a6ba987
+      - c5a9054218fb4651ab8deec82d3463b8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b082ae1e-e0c9-48c6-9bce-38a2c83dd0c9
+      - req-c6ca9a41-c234-46d9-8bc2-156e874fd965
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b082ae1e-e0c9-48c6-9bce-38a2c83dd0c9
+      - req-c6ca9a41-c234-46d9-8bc2-156e874fd965
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8056,27 +8057,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed186c04f9c846a599c65b9f6a6ba987
+      - c5a9054218fb4651ab8deec82d3463b8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6714871e-43b3-4c91-867f-5580f445e738
+      - req-3aa2f9ee-8c35-4642-b436-3c65b50621c4
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6714871e-43b3-4c91-867f-5580f445e738
+      - req-3aa2f9ee-8c35-4642-b436-3c65b50621c4
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8091,27 +8092,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21f45052e2f4a368d89147de075b0db
+      - 4ab404e9d9d540d5a60508c03ce636be
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2d6d2bf-ec34-4f6e-bfc3-725d954e1501
+      - req-1290c383-5395-4783-a663-be66eda04391
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e2d6d2bf-ec34-4f6e-bfc3-725d954e1501
+      - req-1290c383-5395-4783-a663-be66eda04391
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8126,27 +8127,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21f45052e2f4a368d89147de075b0db
+      - 4ab404e9d9d540d5a60508c03ce636be
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1c17739-8638-444f-8179-99bbbcb19595
+      - req-66a0b98b-2004-4ceb-ac87-6cc8373ce657
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e1c17739-8638-444f-8179-99bbbcb19595
+      - req-66a0b98b-2004-4ceb-ac87-6cc8373ce657
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8161,27 +8162,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-caab2ecf-1321-41f1-8193-cc03d2059485
+      - req-7c62268b-cf94-48c6-82b1-c9e049a9f204
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-caab2ecf-1321-41f1-8193-cc03d2059485
+      - req-7c62268b-cf94-48c6-82b1-c9e049a9f204
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8196,27 +8197,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06acf8463c4c4ef79ad6f44d02ccdd63
+      - a863fb43af4145e2add3b2c66715b3e9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2638cc2c-b2f8-4a31-abd3-0eaa16b3e46f
+      - req-76ffaa1b-5a01-4a69-98ec-6b8ab96e69ce
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2638cc2c-b2f8-4a31-abd3-0eaa16b3e46f
+      - req-76ffaa1b-5a01-4a69-98ec-6b8ab96e69ce
       Date:
-      - Mon, 06 Aug 2018 16:56:58 GMT
+      - Mon, 24 Sep 2018 20:29:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8231,27 +8232,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eb0a84107494998878267bc4e6dc4a9
+      - b7a2b21eff6f4dc9ac6a9fb450b379ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4d1ad414-9538-4d5f-8746-34d0ca987c5b
+      - req-d853d855-042d-42ea-8468-6b6749fe7d42
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4d1ad414-9538-4d5f-8746-34d0ca987c5b
+      - req-d853d855-042d-42ea-8468-6b6749fe7d42
       Date:
-      - Mon, 06 Aug 2018 16:56:59 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -8266,27 +8267,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7eb0a84107494998878267bc4e6dc4a9
+      - b7a2b21eff6f4dc9ac6a9fb450b379ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-876ae076-1f36-4b8b-b6dc-8ef15511b68a
+      - req-b16544bc-7554-41e2-bcb7-ddada28b6173
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-876ae076-1f36-4b8b-b6dc-8ef15511b68a
+      - req-b16544bc-7554-41e2-bcb7-ddada28b6173
       Date:
-      - Mon, 06 Aug 2018 16:56:59 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -8301,27 +8302,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed186c04f9c846a599c65b9f6a6ba987
+      - c5a9054218fb4651ab8deec82d3463b8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d8a642d-c2f0-481c-9999-14fd8e174558
+      - req-70842202-403c-4ee1-a146-102b1b071709
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9d8a642d-c2f0-481c-9999-14fd8e174558
+      - req-70842202-403c-4ee1-a146-102b1b071709
       Date:
-      - Mon, 06 Aug 2018 16:56:59 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -8336,27 +8337,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ed186c04f9c846a599c65b9f6a6ba987
+      - c5a9054218fb4651ab8deec82d3463b8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2eed5cc8-5f61-4661-a26a-4def387c432e
+      - req-df4a4046-ca51-4328-a11e-895fd94f1040
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2eed5cc8-5f61-4661-a26a-4def387c432e
+      - req-df4a4046-ca51-4328-a11e-895fd94f1040
       Date:
-      - Mon, 06 Aug 2018 16:56:59 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -8371,27 +8372,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21f45052e2f4a368d89147de075b0db
+      - 4ab404e9d9d540d5a60508c03ce636be
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-64c63ffb-0d45-425b-a478-fe8d18661c16
+      - req-23502f52-c0dd-40f4-ae8f-5be07f167798
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-64c63ffb-0d45-425b-a478-fe8d18661c16
+      - req-23502f52-c0dd-40f4-ae8f-5be07f167798
       Date:
-      - Mon, 06 Aug 2018 16:56:59 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:56:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -8406,27 +8407,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c21f45052e2f4a368d89147de075b0db
+      - 4ab404e9d9d540d5a60508c03ce636be
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aa7f5366-0965-4e71-8b19-351b457255e3
+      - req-54d9dc13-f971-42b9-87a7-2b62b31c433d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aa7f5366-0965-4e71-8b19-351b457255e3
+      - req-54d9dc13-f971-42b9-87a7-2b62b31c433d
       Date:
-      - Mon, 06 Aug 2018 16:57:00 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8444,13 +8445,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:00 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1e2705fd-23b7-433e-b625-b4f6f60c4301
+      - req-ca17dc25-bafb-472b-98ce-e26374bfec66
       Content-Length:
       - '4170'
       Connection:
@@ -8459,10 +8460,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.384701", "expires":
-        "2018-08-06T17:57:00Z", "id": "71be248c5ed042d8aff306959db2842c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:08.843351", "expires":
+        "2018-09-24T21:29:08Z", "id": "4750d13e2e9f4655b6fff0ac345993a4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["eJYJsxrjQfu8vpDfbJDj_w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Vtw9orEeQJikEZZ7mD5Fuw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8507,7 +8508,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:08 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8525,13 +8526,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:00 GMT
+      - Mon, 24 Sep 2018 20:29:08 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bd198b68-799f-4262-b33c-7b2695f94616
+      - req-6ee5c550-360c-4460-a518-9e8c9f8c403f
       Content-Length:
       - '4170'
       Connection:
@@ -8540,10 +8541,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.696703", "expires":
-        "2018-08-06T17:57:00Z", "id": "2eac73dde1584d6da60d15616eb4c873", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:09.039563", "expires":
+        "2018-09-24T21:29:09Z", "id": "ee34b6e82d7a423ca9e3d8e6fb823090", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yPj0UWyCSOaWX2aRAIzI7A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vs96movsQdaAxFv_sn_HFA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -8588,7 +8589,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8606,13 +8607,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:00 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3611b8f0-41c0-4ae6-8b6d-c19922deaaa4
+      - req-b6bc5bb8-5922-4af6-bdfc-ad12b3c5bf7c
       Content-Length:
       - '370'
       Connection:
@@ -8621,13 +8622,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:00.972189", "expires":
-        "2018-08-06T17:57:00Z", "id": "8d535895943a4208b0d9222202d126e1", "audit_ids":
-        ["zo5AJ_yTTh6-8wSKVlleqQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:09.202470", "expires":
+        "2018-09-24T21:29:09Z", "id": "a03302d3f39b43c9b752dda3ec913652", "audit_ids":
+        ["e1xcA8s4TJyTQWW-0LB0YQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8642,20 +8643,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d535895943a4208b0d9222202d126e1
+      - a03302d3f39b43c9b752dda3ec913652
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:01 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9433fb8e-04a1-49be-a808-5f44aed8d100
+      - req-fdb9428d-276a-49bc-90b4-2c190b366ca6
       Content-Length:
       - '500'
       Connection:
@@ -8672,13 +8673,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"8d535895943a4208b0d9222202d126e1"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"a03302d3f39b43c9b752dda3ec913652"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -8690,13 +8691,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:01 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-180d03b1-deef-4575-a191-86e81cbe3d7f
+      - req-287f51b1-ffd1-414e-b64c-7c2e31961bcb
       Content-Length:
       - '4143'
       Connection:
@@ -8705,11 +8706,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:01.421210", "expires":
-        "2018-08-06T17:57:00Z", "id": "3dd1fd34de034a4481f002a5b7bf69ad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:09.512162", "expires":
+        "2018-09-24T21:29:09Z", "id": "ffe276ed04bf479386421e904431ae3e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vUszXZOET_mZiX87F2ejIg",
-        "zo5AJ_yTTh6-8wSKVlleqQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ipw_DeAlRIGDdIJh--woOQ",
+        "e1xcA8s4TJyTQWW-0LB0YQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8753,7 +8754,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -8768,20 +8769,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d535895943a4208b0d9222202d126e1
+      - a03302d3f39b43c9b752dda3ec913652
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:01 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb98f8f2-7ad7-427e-be87-d5c3980a4a21
+      - req-6874bad1-8c80-4e2f-a298-f5db7e3e541c
       Content-Length:
       - '500'
       Connection:
@@ -8798,7 +8799,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8816,13 +8817,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:01 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ddefd0ab-4138-4eaf-b3b9-6c7bcd3f0154
+      - req-ad573ff3-8ec0-4ab0-9598-4e86734c3176
       Content-Length:
       - '4117'
       Connection:
@@ -8831,10 +8832,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:01.984773", "expires":
-        "2018-08-06T17:57:01Z", "id": "c9325dd5841d42018cfb6c21b7e5b308", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:09.820908", "expires":
+        "2018-09-24T21:29:09Z", "id": "510623c633574b3ca50f661c19203360", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["waNr8HdUS3qXzIugMyUgPg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RvPv2d-7SGerweNfNHBIlQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8878,7 +8879,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8896,13 +8897,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:02 GMT
+      - Mon, 24 Sep 2018 20:29:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ebc0d368-a53d-4dcc-a85f-3a254b8a4c7d
+      - req-3e0ed931-49b9-45dc-95d1-839a21e1f57f
       Content-Length:
       - '4131'
       Connection:
@@ -8911,10 +8912,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.385843", "expires":
-        "2018-08-06T17:57:02Z", "id": "c251c9e8eb75465aaccef0253c261317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:10.001539", "expires":
+        "2018-09-24T21:29:09Z", "id": "f4fba7f2c2c34e7081a9b61fd5baf7f0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jB8cVlBwTOKUTR9ildYvDw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lib7qZWJTCmtRY2ppzU08w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8958,7 +8959,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8976,13 +8977,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:02 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f14dcf98-9ac5-43f3-899d-f9a1f6628c7f
+      - req-cfb452ab-6528-4e52-898d-c737c8db7aec
       Content-Length:
       - '4118'
       Connection:
@@ -8991,10 +8992,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.608348", "expires":
-        "2018-08-06T17:57:02Z", "id": "2195d7890565448cb38d03cf9e2a217e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:10.178049", "expires":
+        "2018-09-24T21:29:10Z", "id": "db3195a006b94c659f10cc172da7f1e7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ObGIAU_dQpyMFFPj-cW9FA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["4MiA2iYZR6-glo8Zio97Bw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9038,7 +9039,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9056,13 +9057,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:02 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-15f51f56-5d47-4c46-bdcb-e7cf4c32c5a8
+      - req-4c36a509-c152-47bc-b50b-9576777024de
       Content-Length:
       - '4117'
       Connection:
@@ -9071,10 +9072,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:02.931562", "expires":
-        "2018-08-06T17:57:02Z", "id": "a2c63efa619041c58ccc9fdec7e9fbda", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:10.367299", "expires":
+        "2018-09-24T21:29:10Z", "id": "b0992d49dd994c76b93f7014bc971884", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ac8kq-1eTLKQ0Fi76WJRWg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lLSm2-XeTcqom6PXuilojA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9118,7 +9119,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9133,7 +9134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c63efa619041c58ccc9fdec7e9fbda
+      - b0992d49dd994c76b93f7014bc971884
   response:
     status:
       code: 200
@@ -9162,15 +9163,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx987ce71af18643cfb5d53-005b687ddf
+      - txe1f33d9d09a04464939b1-005ba94916
       Date:
-      - Mon, 06 Aug 2018 16:57:03 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -9185,7 +9186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c63efa619041c58ccc9fdec7e9fbda
+      - b0992d49dd994c76b93f7014bc971884
   response:
     status:
       code: 200
@@ -9214,14 +9215,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx28bca008f47d4ecfbb763-005b687ddf
+      - txd79fa163bd914e8693789-005ba94916
       Date:
-      - Mon, 06 Aug 2018 16:57:03 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9239,13 +9240,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:03 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e8fc7351-4314-4243-87b6-45dcc2654ee4
+      - req-94990b27-1bc5-4e27-bc61-f8b1b4fe330b
       Content-Length:
       - '4131'
       Connection:
@@ -9254,10 +9255,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:03.529753", "expires":
-        "2018-08-06T17:57:03Z", "id": "a06298606e024ef7a40201e115661e57", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:10.787451", "expires":
+        "2018-09-24T21:29:10Z", "id": "cee71fdf71ca469e8cefd605743c9153", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3U3HHg9KTG6z_3SsOdiMZA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zC8uixcQRqOQXNhRe3BLIg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9301,7 +9302,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -9316,7 +9317,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a06298606e024ef7a40201e115661e57
+      - cee71fdf71ca469e8cefd605743c9153
   response:
     status:
       code: 200
@@ -9329,22 +9330,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574623.88674'
+      - '1537820950.94606'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574623.88674'
+      - '1537820950.94606'
       X-Trans-Id:
-      - txad8767f21427409b8b83d-005b687ddf
+      - tx01eec6d1572c42fd8ef64-005ba94916
       Date:
-      - Mon, 06 Aug 2018 16:57:03 GMT
+      - Mon, 24 Sep 2018 20:29:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -9359,7 +9360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2eac73dde1584d6da60d15616eb4c873
+      - ee34b6e82d7a423ca9e3d8e6fb823090
   response:
     status:
       code: 200
@@ -9372,22 +9373,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574624.21729'
+      - '1537820951.14314'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574624.21729'
+      - '1537820951.14314'
       X-Trans-Id:
-      - txc42924ddd67c4540aa9d3-005b687ddf
+      - tx6b41bbb976d14c8ab27c5-005ba94917
       Date:
-      - Mon, 06 Aug 2018 16:57:04 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9405,13 +9406,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:57:04 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-47fd3399-ce5a-4ea3-a2ee-ba34d543cf5e
+      - req-467a09fe-5300-4ea4-a831-2c4c729d21e3
       Content-Length:
       - '4118'
       Connection:
@@ -9420,10 +9421,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:57:04.484115", "expires":
-        "2018-08-06T17:57:04Z", "id": "f428efed191d4db8a15191895d91f9a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:11.331307", "expires":
+        "2018-09-24T21:29:11Z", "id": "c4b4e0de4a594406834f77945ab83133", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["v3eDcWO7SzyINcD6wRdwBA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gea-vfTaTymHPcXvV-g5xw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9467,7 +9468,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -9482,7 +9483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f428efed191d4db8a15191895d91f9a1
+      - c4b4e0de4a594406834f77945ab83133
   response:
     status:
       code: 200
@@ -9495,22 +9496,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574624.91193'
+      - '1537820951.49020'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574624.91193'
+      - '1537820951.49020'
       X-Trans-Id:
-      - txe4eb1ff07f1849e5a6307-005b687de0
+      - txe06af36d0a7747acb2a5d-005ba94917
       Date:
-      - Mon, 06 Aug 2018 16:57:04 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -9525,7 +9526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c63efa619041c58ccc9fdec7e9fbda
+      - b0992d49dd994c76b93f7014bc971884
   response:
     status:
       code: 200
@@ -9546,9 +9547,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx20e266eeeb984d20b6fa2-005b687de0
+      - txe44a2f6916dd4a5c8ceb6-005ba94917
       Date:
-      - Mon, 06 Aug 2018 16:57:05 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -9558,7 +9559,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -9573,7 +9574,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c63efa619041c58ccc9fdec7e9fbda
+      - b0992d49dd994c76b93f7014bc971884
   response:
     status:
       code: 200
@@ -9594,14 +9595,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txef840bf0049f400a8410d-005b687de1
+      - tx2c68642861d64238aeb7b-005ba94917
       Date:
-      - Mon, 06 Aug 2018 16:57:05 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -9616,7 +9617,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c63efa619041c58ccc9fdec7e9fbda
+      - b0992d49dd994c76b93f7014bc971884
   response:
     status:
       code: 200
@@ -9637,12 +9638,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx725247f6a4dc47e7a0aa7-005b687de1
+      - tx3990af3b040b4d1d81523-005ba94917
       Date:
-      - Mon, 06 Aug 2018 16:57:05 GMT
+      - Mon, 24 Sep 2018 20:29:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:57:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:11 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:50 GMT
+      - Mon, 24 Sep 2018 20:30:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49fcc167-2303-408a-a933-91696d253013
+      - req-0dd55598-d600-49ec-991d-b266bd29c578
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:50.551203", "expires":
-        "2018-08-06T17:59:50Z", "id": "56fa1691c6fb4af3b50a1cf2ad67cc53", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:36.856941", "expires":
+        "2018-09-24T21:30:36Z", "id": "1f77039ee6f44a95b1e2c36f58432613", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["dV7ANEN8RQuWbXF3E9fXwA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["8u9QM8EIQueg5ZCC9jWebQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:50 GMT
+      - Mon, 24 Sep 2018 20:30:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,15 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-9baa322b-19da-437a-802a-1f1447642888
+      - req-afe36f01-4ec1-44d0-a6bc-851f1236a4e1
       Date:
-      - Mon, 06 Aug 2018 16:59:51 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -169,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:51 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fad1d3ad-b1cd-4302-9ba0-257c1084efb6
+      - req-3f3d19c5-a0e7-4c27-b392-87f9c1e26244
       Content-Length:
       - '4170'
       Connection:
@@ -184,10 +184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:51.329010", "expires":
-        "2018-08-06T17:59:51Z", "id": "8efeefad72744c61821793b8a51068c6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:37.288654", "expires":
+        "2018-09-24T21:30:37Z", "id": "1f9cd862502146599608a1e2791a84c1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["smWV1xTsQaWqNhZaynhjDA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EtHR7YCdQUmTBFjVMuDTkQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -232,7 +232,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -247,28 +247,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ee281bef-6be2-4908-9af3-971d852853a6
+      - req-6f918867-0039-4daa-8ac0-e036a936bf40
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-ee281bef-6be2-4908-9af3-971d852853a6
+      - req-6f918867-0039-4daa-8ac0-e036a936bf40
       Date:
-      - Mon, 06 Aug 2018 16:59:51 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:51 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3791392d-e3ca-41b8-b5cd-1a9cb720a686
+      - req-a2be33b0-9748-4778-96dd-e70e871ae3cf
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +301,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:51.801215", "expires":
-        "2018-08-06T17:59:51Z", "id": "d2fcf01b1d3b4dd989ba55dbf9727efa", "audit_ids":
-        ["hi09Gm2JRE2mwgKeFIkoOw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:37.592569", "expires":
+        "2018-09-24T21:30:37Z", "id": "5548e177a0764c61807232d366468a5e", "audit_ids":
+        ["0bpTwZJPRQaIyx-bTXOC3w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +322,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2fcf01b1d3b4dd989ba55dbf9727efa
+      - 5548e177a0764c61807232d366468a5e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:51 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c208d629-a4d3-4988-8bcb-a0468939289d
+      - req-5c705b72-73a4-4f5b-98a5-2d690f0cfb02
       Content-Length:
       - '500'
       Connection:
@@ -352,13 +352,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"d2fcf01b1d3b4dd989ba55dbf9727efa"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"5548e177a0764c61807232d366468a5e"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -370,13 +370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:52 GMT
+      - Mon, 24 Sep 2018 20:30:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6b8c0f01-92fd-43fb-ba06-245ec81001c8
+      - req-909efc58-bdab-4ed8-9710-9d83168952c0
       Content-Length:
       - '4143'
       Connection:
@@ -385,11 +385,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:52.250984", "expires":
-        "2018-08-06T17:59:51Z", "id": "293e12e85aa04a889f9fbc1c1e3bac9c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:37.894209", "expires":
+        "2018-09-24T21:30:37Z", "id": "b537c29386174d77b7ab32d87b497827", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["22A4tKeZRB23aAEE6-mjtQ",
-        "hi09Gm2JRE2mwgKeFIkoOw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uRJF41VVQH6ATAVQ0qpnPA",
+        "0bpTwZJPRQaIyx-bTXOC3w"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -433,7 +433,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:37 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -448,20 +448,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2fcf01b1d3b4dd989ba55dbf9727efa
+      - 5548e177a0764c61807232d366468a5e
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:52 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00d4eca9-cf48-49de-a1f5-15a541607c3b
+      - req-7492260c-d09f-41bd-9e50-7091a961b5b4
       Content-Length:
       - '500'
       Connection:
@@ -478,7 +478,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -496,13 +496,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:52 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ea3fec5f-9106-494a-8b6c-976143b68c40
+      - req-6153e9f3-cdd4-4d25-bd54-d8432e08267a
       Content-Length:
       - '4117'
       Connection:
@@ -511,10 +511,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:52.731190", "expires":
-        "2018-08-06T17:59:52Z", "id": "cd85a4926736420da6cd4881729d1172", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:38.208203", "expires":
+        "2018-09-24T21:30:38Z", "id": "228083b4f2c547039c62b6fc22d04cba", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jcsX4EZMTpqLN880docxJw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vQj3rednTQa67Gg-yBgHGg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -573,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
   response:
     status:
       code: 200
@@ -584,7 +584,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:52 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -593,7 +593,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -611,13 +611,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:52 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c5319805-76b9-4001-8dd3-4051241408bd
+      - req-bc188926-60f9-4726-9a53-be017d4f3c20
       Content-Length:
       - '4131'
       Connection:
@@ -626,10 +626,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:53.018597", "expires":
-        "2018-08-06T17:59:52Z", "id": "3155dbf6fed14fb1b8dce46bc6e1ae60", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:38.469602", "expires":
+        "2018-09-24T21:30:38Z", "id": "84823c93a3cb4461b50958f371834aa5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XsJN9zbuToCTxOqs26EzBw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4DSY-ReWR2O0FBED0WnYrw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -673,7 +673,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -688,7 +688,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
   response:
     status:
       code: 200
@@ -699,7 +699,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:53 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -708,7 +708,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -726,13 +726,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:53 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ce64a074-4d4f-48ea-ae9b-a57b534b5264
+      - req-d7cd05e1-abbd-4d9c-a9ec-02994ff6dc3e
       Content-Length:
       - '4118'
       Connection:
@@ -741,10 +741,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:53.312443", "expires":
-        "2018-08-06T17:59:53Z", "id": "0c66371c954d40358957e61a748e81d0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:38.730201", "expires":
+        "2018-09-24T21:30:38Z", "id": "21047d498d9a4a68b93f6259833b78c9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dfG5ArRpRpS8cQwKrifJgw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["YjkkjcV8S0O7_9qVnE7-UA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -788,7 +788,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -803,7 +803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
   response:
     status:
       code: 200
@@ -814,7 +814,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:53 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -823,7 +823,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -838,7 +838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -851,26 +851,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0a646a17-f984-4f0a-bca4-a957cb2e8ea0
+      - req-f05f4437-3951-4763-8559-14ab967ebce9
       Date:
-      - Mon, 06 Aug 2018 16:59:53 GMT
+      - Mon, 24 Sep 2018 20:30:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -885,7 +885,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -898,26 +898,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-01e9aa11-570e-4c55-9df1-19b22ebed087
+      - req-d7e1ca4a-f005-4945-9f08-0d720e62713a
       Date:
-      - Mon, 06 Aug 2018 16:59:53 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -932,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -945,26 +945,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-341be9c3-fa8f-40d8-b110-b427e5588185
+      - req-70aa001c-954c-47f5-b5c9-bb1fe4a1eabc
       Date:
-      - Mon, 06 Aug 2018 16:59:54 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -979,7 +979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -992,26 +992,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c79bcdb2-5885-4842-99d4-edf15f652e82
+      - req-c5365e15-dd96-423e-9e5e-79822a74bb9a
       Date:
-      - Mon, 06 Aug 2018 16:59:54 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -1026,7 +1026,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1039,26 +1039,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-3a74c502-bee4-4f8e-a85c-6330b2adeefb
+      - req-80b7c2b9-983c-444f-858e-a76c77900a76
       Date:
-      - Mon, 06 Aug 2018 16:59:54 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -1073,7 +1073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1086,26 +1086,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2448fe4f-b4d6-4a51-a80b-4d3547fc2e05
+      - req-974038b2-be76-4830-9cf9-702cec6af4c2
       Date:
-      - Mon, 06 Aug 2018 16:59:54 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -1120,7 +1120,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1133,26 +1133,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b7336026-f020-4eba-82d3-73be17171224
+      - req-f56862ce-967d-476d-83d0-f3b1526eaa06
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1167,7 +1167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1180,26 +1180,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d9433acd-864e-4610-8131-7071cf64ff8b
+      - req-0c37ca58-e60e-4033-9d36-54ffef97a82e
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-08-06T16:59:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2018-09-24T20:30:36.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2018-09-24T20:30:33.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-08-06T16:59:52.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2018-09-24T20:30:37.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2018-08-06T16:59:50.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2018-09-24T20:30:37.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-08-06T16:59:50.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2018-09-24T20:30:34.000000"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1214,7 +1214,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1227,9 +1227,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-01a96637-ecc1-4a44-b7d7-a5355f96a1aa
+      - req-51f5b44a-cde8-4d8f-ac33-f2509492c0cc
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1243,7 +1243,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1258,7 +1258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1271,9 +1271,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-cd6ece87-5180-4f67-8c25-8e09be33eeee
+      - req-2b103d94-65b2-42b5-836d-cbfba76f602e
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1287,7 +1287,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1302,7 +1302,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1315,9 +1315,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-a800d261-8066-4f18-ac1f-72ca0731cf50
+      - req-e3dd2f40-010b-40a8-97ad-da917d208918
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1332,7 +1332,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1347,7 +1347,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1360,9 +1360,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-c96fb4a5-35b0-458d-927f-a4b30a0e4745
+      - req-5feff591-ded1-444e-a1fd-f171eda53d51
       Date:
-      - Mon, 06 Aug 2018 16:59:55 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1372,7 +1372,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1387,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1400,15 +1400,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-a5b56449-69c6-4f3f-a44b-54eba318809a
+      - req-8e25b515-c773-4656-b99a-76e5b6fb49bc
       Date:
-      - Mon, 06 Aug 2018 16:59:56 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1426,13 +1426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:56 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-11e11312-513d-4bcb-9c35-10d42fc5df66
+      - req-9e74b3aa-4544-4ead-b657-23651a2473e9
       Content-Length:
       - '4170'
       Connection:
@@ -1441,10 +1441,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:56.257625", "expires":
-        "2018-08-06T17:59:56Z", "id": "0de681b6677b450899a0d95b079d4631", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:40.685986", "expires":
+        "2018-09-24T21:30:40Z", "id": "7b584ddb55f44eb8953d2fa6b36f4606", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rR0pXbnfS8W_N0oR6MPYoA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["3y5ZPEdmRb6R9wxnzTqLdA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1489,7 +1489,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0de681b6677b450899a0d95b079d4631
+      - 7b584ddb55f44eb8953d2fa6b36f4606
   response:
     status:
       code: 300
@@ -1515,7 +1515,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 16:59:56 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -1528,7 +1528,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1546,13 +1546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:56 GMT
+      - Mon, 24 Sep 2018 20:30:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9bcb2025-1877-4798-a6e0-ce0e7aa83fa6
+      - req-352eea72-7187-4c01-8eac-319612504f6d
       Content-Length:
       - '4117'
       Connection:
@@ -1561,10 +1561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:56.623669", "expires":
-        "2018-08-06T17:59:56Z", "id": "d0423ae7a2ce4c428620b0f9ce1989a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:40.951953", "expires":
+        "2018-09-24T21:30:40Z", "id": "0ae1c66b3d1d4255a9ca7830a6d6ab20", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["o3bd5pc7T7K7D3QScp09wA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EsAk5Y36Rt63qrulY8MeTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1608,7 +1608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1623,7 +1623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0423ae7a2ce4c428620b0f9ce1989a1
+      - 0ae1c66b3d1d4255a9ca7830a6d6ab20
   response:
     status:
       code: 200
@@ -1634,9 +1634,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c7088f7c-fb92-4294-b71c-59e647bd9909
+      - req-2ac3815e-560c-4e8a-9f77-899fa1ad64c6
       Date:
-      - Mon, 06 Aug 2018 16:59:56 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1678,7 +1678,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1693,7 +1693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d0423ae7a2ce4c428620b0f9ce1989a1
+      - 0ae1c66b3d1d4255a9ca7830a6d6ab20
   response:
     status:
       code: 200
@@ -1704,14 +1704,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-154642eb-f887-4828-adbc-8aa20296bab1
+      - req-2e96f02c-9d67-42ad-85ba-1a4b6630f5d9
       Date:
-      - Mon, 06 Aug 2018 16:59:57 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1729,13 +1729,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:57 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-58fe6f20-30a4-4542-9d3f-5ce3a69ac77b
+      - req-cb1f1084-1bac-4f23-85c8-9a53fa4b4ff0
       Content-Length:
       - '4131'
       Connection:
@@ -1744,10 +1744,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:57.326561", "expires":
-        "2018-08-06T17:59:57Z", "id": "4f84cc04338b4c749bfe6c34d206b36c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:41.412294", "expires":
+        "2018-09-24T21:30:41Z", "id": "2e41568b7c5a4612a7d6581bae4e5eee", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["P6kVfj_oQQSnUbgu2UYV2A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["0cdDCTO5QJugSwlPbVHmYA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1791,7 +1791,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1806,7 +1806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f84cc04338b4c749bfe6c34d206b36c
+      - 2e41568b7c5a4612a7d6581bae4e5eee
   response:
     status:
       code: 200
@@ -1817,9 +1817,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5f854669-abcc-4655-868c-2b0b69db0169
+      - req-9e557151-0484-48b1-b987-103680327584
       Date:
-      - Mon, 06 Aug 2018 16:59:57 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1861,7 +1861,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1876,7 +1876,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4f84cc04338b4c749bfe6c34d206b36c
+      - 2e41568b7c5a4612a7d6581bae4e5eee
   response:
     status:
       code: 200
@@ -1887,14 +1887,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a20c3394-07a0-415a-a649-23f9c5519190
+      - req-54264c85-6196-41f6-a27a-cb37c40e6a80
       Date:
-      - Mon, 06 Aug 2018 16:59:57 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1909,7 +1909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0de681b6677b450899a0d95b079d4631
+      - 7b584ddb55f44eb8953d2fa6b36f4606
   response:
     status:
       code: 200
@@ -1920,9 +1920,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-01dbc4de-39bd-47a2-9369-5170c3f5803c
+      - req-1dc00990-7684-4b46-969f-c783fb8219c3
       Date:
-      - Mon, 06 Aug 2018 16:59:58 GMT
+      - Mon, 24 Sep 2018 20:30:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1964,7 +1964,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1979,7 +1979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0de681b6677b450899a0d95b079d4631
+      - 7b584ddb55f44eb8953d2fa6b36f4606
   response:
     status:
       code: 200
@@ -1990,14 +1990,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1f4f7839-ef34-4426-9e0d-2b077873f36f
+      - req-3493ed02-1f0f-4912-98b9-eeae855986e6
       Date:
-      - Mon, 06 Aug 2018 16:59:58 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2015,13 +2015,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:58 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-08f735e1-5afe-43f9-8e16-e2bdc768d5a6
+      - req-0d949ab8-f195-4f4c-afa9-7f0d78f6c858
       Content-Length:
       - '4118'
       Connection:
@@ -2030,10 +2030,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:58.532641", "expires":
-        "2018-08-06T17:59:58Z", "id": "d6b1b9e707d94e36a94526cca19b3f6e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:42.256945", "expires":
+        "2018-09-24T21:30:42Z", "id": "9f1e14b490d14987baad3e79630c865e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["EqjG-wwpTzWhW0I3O241Og"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Pv066aKoQ3mIoIAyXBBMTg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2077,7 +2077,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -2092,7 +2092,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6b1b9e707d94e36a94526cca19b3f6e
+      - 9f1e14b490d14987baad3e79630c865e
   response:
     status:
       code: 200
@@ -2103,9 +2103,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3d5953f5-7008-4db3-9992-f7a3a803d496
+      - req-6a72e07e-e13e-45b9-bfcd-a58205316443
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -2147,7 +2147,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -2162,7 +2162,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d6b1b9e707d94e36a94526cca19b3f6e
+      - 9f1e14b490d14987baad3e79630c865e
   response:
     status:
       code: 200
@@ -2173,14 +2173,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-5b44998d-a72b-4707-a5cf-7311e9839773
+      - req-3651f251-513a-4d8a-8e7d-a5a9fc8cb662
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2195,7 +2195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2208,9 +2208,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-13d25faa-3110-4ee6-8871-ae34b1866b78
+      - req-4b8a5d1d-52f3-40e5-90f5-864b2c9c08c1
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2220,7 +2220,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2235,7 +2235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2248,9 +2248,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-54ec7b60-d51c-4aaa-b041-6d8d08d6ee3d
+      - req-dfe51a05-1f8e-429b-bc74-3b2bfd48550a
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2260,7 +2260,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2275,7 +2275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2288,9 +2288,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d3751315-2bd8-4a78-ae95-3801dda8fc47
+      - req-0f09367d-ab50-4a49-9ec7-85ed8a68c430
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2300,7 +2300,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2315,7 +2315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2328,9 +2328,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-f3c943ae-71dd-40ad-a52e-ad7b68f69e0c
+      - req-320f3bda-a6b1-4ff3-b6b5-44c9831cd929
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2340,7 +2340,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2355,7 +2355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2368,9 +2368,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-0b7b2954-8cd1-4c2f-918d-8c7df5136537
+      - req-b61c7b0c-94c1-4943-80b0-9a13d01a7af3
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2380,7 +2380,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7251dea6-8c0e-4924-b98b-c38c60705978
+      - req-effbcec5-3ea7-46be-8caa-641d84d570f8
       Date:
-      - Mon, 06 Aug 2018 16:59:59 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2420,7 +2420,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2435,7 +2435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2448,9 +2448,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c4d61da0-d200-46c2-91ab-c74c4bada72a
+      - req-937ccb2c-4ef2-4c6a-bf66-c5470afd3351
       Date:
-      - Mon, 06 Aug 2018 17:00:00 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2460,7 +2460,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2475,7 +2475,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2488,9 +2488,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-582bacee-0254-4d98-9e91-8cbd090639d1
+      - req-28cf7a1f-e101-439d-81b0-6719443b9b4d
       Date:
-      - Mon, 06 Aug 2018 17:00:00 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2500,7 +2500,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2518,13 +2518,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:00 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c460561-650e-4f52-8c82-8217f42dfe37
+      - req-f26368e3-4539-47f0-8ed1-3fbaac675f4c
       Content-Length:
       - '4170'
       Connection:
@@ -2533,10 +2533,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:00.491581", "expires":
-        "2018-08-06T18:00:00Z", "id": "63989ef7a2614b4c8601528c204dba77", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:43.561840", "expires":
+        "2018-09-24T21:30:43Z", "id": "0dc89e8700184696b799df70d05c9c77", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["YWUmcnCNSCuY50ZVm81sUw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vqpazgJTS_e7i4gj6Dq9tQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2581,7 +2581,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2599,13 +2599,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:00 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-73331118-8585-4bdf-888d-21028b00f1ab
+      - req-f28dc8e2-ed19-44fb-ae8b-ce8ef2db6942
       Content-Length:
       - '4117'
       Connection:
@@ -2614,10 +2614,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:00.852485", "expires":
-        "2018-08-06T18:00:00Z", "id": "219a6398964b4962bb220aab326166e3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:43.738553", "expires":
+        "2018-09-24T21:30:43Z", "id": "177a28c67b2743168d244e1b5dfd8a1e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IV9hLix8TMGrkovxExJ7hw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["srDua5TlTgSeU4KAyDD6vg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2661,7 +2661,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2676,7 +2676,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -2687,9 +2687,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-88a4bf95-c091-4215-93d6-8b841d188781
+      - req-14a8ca45-4327-414b-ab73-31189608855a
       Date:
-      - Mon, 06 Aug 2018 17:00:01 GMT
+      - Mon, 24 Sep 2018 20:30:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2723,7 +2723,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2738,7 +2738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -2749,14 +2749,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-905789f1-e476-44cc-b689-82427c50a8c0
+      - req-3988c25f-fae7-4572-8f26-33625a095b4d
       Date:
-      - Mon, 06 Aug 2018 17:00:01 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2774,13 +2774,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:01 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-568c84f3-9f49-4095-89b1-66f644a14466
+      - req-948e06eb-456b-4396-b8b3-54f6cf4786d1
       Content-Length:
       - '4131'
       Connection:
@@ -2789,10 +2789,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:01.794788", "expires":
-        "2018-08-06T18:00:01Z", "id": "814db331afec4f84be7ddb30a03e3f09", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:44.200854", "expires":
+        "2018-09-24T21:30:44Z", "id": "7396a4b612a744b3a240d3ed474aa4fd", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["W4yz6w0yThaBXQ-xOcc0qg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["y4-3uOZORcCCJPMOGmYWkQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2836,7 +2836,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2851,7 +2851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 814db331afec4f84be7ddb30a03e3f09
+      - 7396a4b612a744b3a240d3ed474aa4fd
   response:
     status:
       code: 200
@@ -2862,14 +2862,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f1506344-2b98-41b5-84ee-71f6dcc44041
+      - req-bd4dc828-ea67-4702-a3fe-b4412a74dd4c
       Date:
-      - Mon, 06 Aug 2018 17:00:02 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2884,7 +2884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 63989ef7a2614b4c8601528c204dba77
+      - 0dc89e8700184696b799df70d05c9c77
   response:
     status:
       code: 200
@@ -2895,14 +2895,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2c4a56c3-c1f5-4a56-8860-85f745ca7263
+      - req-24ff2404-e301-41ff-bcef-7a9837ca3d9d
       Date:
-      - Mon, 06 Aug 2018 17:00:02 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2920,13 +2920,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:02 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46eb2032-212b-43c2-8d3a-5d2bfae118fd
+      - req-8c8cefc6-59ff-488d-8718-2af2d4d12ec2
       Content-Length:
       - '4118'
       Connection:
@@ -2935,10 +2935,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:02.739868", "expires":
-        "2018-08-06T18:00:02Z", "id": "d2e5507f087d45a1bcbb5881f49aa4fd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:44.698948", "expires":
+        "2018-09-24T21:30:44Z", "id": "254e27da8e1f4d1895e43540ea2b28f3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wfg4notmRYaYY8dfEDB3Hw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0nxyCbdRR4On2GCFb-c7gg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2982,7 +2982,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2997,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d2e5507f087d45a1bcbb5881f49aa4fd
+      - 254e27da8e1f4d1895e43540ea2b28f3
   response:
     status:
       code: 200
@@ -3008,14 +3008,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-40923f00-d639-4c1c-8fa2-1039f426fafc
+      - req-9a8be466-7484-42b8-9bd2-5633ba2ea714
       Date:
-      - Mon, 06 Aug 2018 17:00:02 GMT
+      - Mon, 24 Sep 2018 20:30:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -3030,7 +3030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3041,9 +3041,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1e4a849b-1412-4536-aab4-fc14fed998f4
+      - req-969d08bd-3ff1-4a12-a0f5-e511ad7370a2
       Date:
-      - Mon, 06 Aug 2018 17:00:03 GMT
+      - Mon, 24 Sep 2018 20:30:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3070,7 +3070,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:04 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -3085,7 +3085,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3096,9 +3096,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f67a3177-91b4-427d-be70-588086e32021
+      - req-634e9529-eb67-43ec-8fb3-086eb00f81e5
       Date:
-      - Mon, 06 Aug 2018 17:00:05 GMT
+      - Mon, 24 Sep 2018 20:30:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3125,7 +3125,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3140,7 +3140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3151,9 +3151,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7b941492-7cb0-46a4-b378-27d899102bb2
+      - req-16d74a0c-5552-4a16-b0ad-27f22065ee53
       Date:
-      - Mon, 06 Aug 2018 17:00:06 GMT
+      - Mon, 24 Sep 2018 20:30:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3180,7 +3180,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3195,7 +3195,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3206,9 +3206,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-110b8d82-e8e8-49f7-ac46-668f48b872e3
+      - req-baf24b03-3c54-4f25-949b-9984b00615f2
       Date:
-      - Mon, 06 Aug 2018 17:00:07 GMT
+      - Mon, 24 Sep 2018 20:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3264,7 +3264,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3279,7 +3279,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3290,9 +3290,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f11878be-7c71-41b9-ae6f-347cf343730d
+      - req-03461563-5d2e-4487-92e3-4b93a5132872
       Date:
-      - Mon, 06 Aug 2018 17:00:07 GMT
+      - Mon, 24 Sep 2018 20:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3304,7 +3304,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3319,7 +3319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3332,13 +3332,13 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-7ee8e9f0-096f-47ad-a2be-28b64eac644d
+      - req-e9f271c7-da3b-4733-9966-2a64d5448749
       Date:
-      - Mon, 06 Aug 2018 17:00:08 GMT
+      - Mon, 24 Sep 2018 20:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:07Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:21:59Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:99:fa:b0", "version": 4, "addr": "192.168.1.7",
@@ -3380,7 +3380,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3395,7 +3395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3408,9 +3408,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-e07dceaa-61bd-42b1-b70c-60634f242368
+      - req-4dabef80-c4e2-414e-b387-907c7e16cbde
       Date:
-      - Mon, 06 Aug 2018 17:00:08 GMT
+      - Mon, 24 Sep 2018 20:30:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3434,7 +3434,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Suspended", "created": "2016-11-11T13:50:40Z", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached":
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
-        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-06-19T16:59:17Z",
+        "", "metadata": {}}, {"status": "PAUSED", "updated": "2018-08-27T20:24:54Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:45:40:0f", "version": 4, "addr": "192.168.1.4",
@@ -3456,7 +3456,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3471,7 +3471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3484,13 +3484,13 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-157aab20-bfdf-4da0-b39b-b380244d2aad
+      - req-1654c0e6-faa3-42e6-937e-e0f92813771d
       Date:
-      - Mon, 06 Aug 2018 17:00:08 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
-        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-06-19T16:59:02Z",
+        "rel": "next"}], "servers": [{"status": "ACTIVE", "updated": "2018-08-27T20:24:26Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate_3":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:bf:78:a4", "version": 4, "addr": "192.168.3.9",
@@ -3511,7 +3511,7 @@ http_interactions:
         "OS-DCF:diskConfig": "MANUAL", "os-extended-volumes:volumes_attached": [{"id":
         "b124469d-a857-4b39-abe9-d0e63985f834"}], "accessIPv4": "", "accessIPv6":
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
-        {}}, {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
+        {}}, {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z", "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9",
         "OS-EXT-SRV-ATTR:host": "11.22.33.44",
         "addresses": {"EmsRefreshSpec-NetworkPrivate": [{"OS-EXT-IPS-MAC:mac_addr":
         "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5", "OS-EXT-IPS:type":
@@ -3534,7 +3534,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3549,7 +3549,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3562,9 +3562,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-160be441-5b0b-49c2-a836-858f7381a98c
+      - req-e98bdf34-1618-439d-bedd-c8d2bca521bb
       Date:
-      - Mon, 06 Aug 2018 17:00:09 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3606,7 +3606,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3621,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3634,9 +3634,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-77ef48a0-7def-46f5-95cd-963eee30d907
+      - req-1da3e8d6-4aed-4d0f-8e78-45450737db23
       Date:
-      - Mon, 06 Aug 2018 17:00:09 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3659,7 +3659,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3674,7 +3674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3687,14 +3687,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-6e97405f-ce7b-4394-aa06-f012e2f34e15
+      - req-1e364b56-31ce-42e4-919a-df5d43d9b9eb
       Date:
-      - Mon, 06 Aug 2018 17:00:09 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3709,7 +3709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3722,14 +3722,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-2a13b63b-330e-4bc2-9f7e-859b9091565f
+      - req-b4a86fb6-2d97-4325-8524-6f31aac049b9
       Date:
-      - Mon, 06 Aug 2018 17:00:10 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3744,7 +3744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3757,14 +3757,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-9f4982de-f731-46cc-83a1-409ddf77e853
+      - req-16f2527c-9fc2-42cb-889d-8be3b882d022
       Date:
-      - Mon, 06 Aug 2018 17:00:10 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3779,7 +3779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3790,9 +3790,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d4879db0-838e-4887-8289-4109189234ee
+      - req-b0fb61e3-449d-4ec3-a96a-b1b99ed1ba3b
       Date:
-      - Mon, 06 Aug 2018 17:00:10 GMT
+      - Mon, 24 Sep 2018 20:30:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3848,7 +3848,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3863,7 +3863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3874,9 +3874,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ffbc0217-c9f0-4308-ab5e-fed0bf2d1840
+      - req-77ccc056-e6fa-4250-86f1-bb179635121f
       Date:
-      - Mon, 06 Aug 2018 17:00:10 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3888,7 +3888,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3903,7 +3903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3914,9 +3914,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-dc0245a8-8501-4ed2-b5b0-fb5c76ee0776
+      - req-fe1916a9-4364-49df-b813-7ec7c1a41ed0
       Date:
-      - Mon, 06 Aug 2018 17:00:10 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3972,7 +3972,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:10 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3987,7 +3987,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 219a6398964b4962bb220aab326166e3
+      - 177a28c67b2743168d244e1b5dfd8a1e
   response:
     status:
       code: 200
@@ -3998,9 +3998,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-85752491-6d83-4c2d-9cab-65a6da29e979
+      - req-efa61505-0369-4ee1-bf79-d3e4c03ed9d6
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -4012,7 +4012,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4027,7 +4027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4040,9 +4040,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-46a3a883-d408-41ef-8015-4ac4e1dc0211
+      - req-8a83b9a4-3f57-4026-87ce-96ec775fc15b
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4051,7 +4051,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4066,7 +4066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3155dbf6fed14fb1b8dce46bc6e1ae60
+      - 84823c93a3cb4461b50958f371834aa5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4079,9 +4079,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b1de8cde-e71e-4988-ab5d-6644100da5c7
+      - req-e28922b0-673f-49a1-a85f-4566cc3fa795
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4090,7 +4090,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4105,7 +4105,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4118,9 +4118,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-46ed76fe-d396-4ba3-a9b3-26d2fbfc52ab
+      - req-196547bd-9502-4185-b423-2d61d77cd8bd
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4129,7 +4129,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4144,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c66371c954d40358957e61a748e81d0
+      - 21047d498d9a4a68b93f6259833b78c9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4157,9 +4157,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-dc477a84-a55b-4270-9052-d9a8cfaa2d09
+      - req-0a9d2b46-4f35-432a-822b-7689b3004687
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4168,7 +4168,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4186,13 +4186,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:11 GMT
+      - Mon, 24 Sep 2018 20:30:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-08f19ccf-d6ff-4eb9-880a-b2980049de54
+      - req-85605d30-b0b2-4ad5-971f-99d10ed3754b
       Content-Length:
       - '4117'
       Connection:
@@ -4201,10 +4201,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:11.846922", "expires":
-        "2018-08-06T18:00:11Z", "id": "decfc8b9eb7146819ee0df0822d82d3d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:48.902812", "expires":
+        "2018-09-24T21:30:48Z", "id": "a8a06ddf8699455f8fcd479a547b7980", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3D4qnOcmSL2ICRDxti2XlA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["c6htv_NCTyaIuzzXPO6hyQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4248,7 +4248,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:11 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4263,22 +4263,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-832291ab-6d0e-4e3a-ac77-243969bd1cd2
+      - req-86742dd6-c44b-4eb7-b3b5-460039936274
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-832291ab-6d0e-4e3a-ac77-243969bd1cd2
+      - req-86742dd6-c44b-4eb7-b3b5-460039936274
       Date:
-      - Mon, 06 Aug 2018 17:00:12 GMT
+      - Mon, 24 Sep 2018 20:30:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4288,7 +4288,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4306,13 +4306,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:12 GMT
+      - Mon, 24 Sep 2018 20:30:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fd5d37c0-70b0-4f47-be38-ded3befed868
+      - req-5ec31158-5575-4e6d-8ef3-83cf6f566697
       Content-Length:
       - '4131'
       Connection:
@@ -4321,10 +4321,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:12.627330", "expires":
-        "2018-08-06T18:00:12Z", "id": "4600c460134943d289621988e0ea8124", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:49.428173", "expires":
+        "2018-09-24T21:30:49Z", "id": "15de2f1252e34647927cfb883cfe56f0", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["AOOfbRFyRXy_A-KqUsA_KA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["j2MvmgcoQkiZ8ya8CIPmcg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4368,7 +4368,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:12 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4383,22 +4383,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4600c460134943d289621988e0ea8124
+      - 15de2f1252e34647927cfb883cfe56f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fbc6a43-a288-4876-908b-63a7019c239c
+      - req-83590ea2-4e3d-4429-b254-4ae70c6ff084
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-3fbc6a43-a288-4876-908b-63a7019c239c
+      - req-83590ea2-4e3d-4429-b254-4ae70c6ff084
       Date:
-      - Mon, 06 Aug 2018 17:00:13 GMT
+      - Mon, 24 Sep 2018 20:30:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4408,7 +4408,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:13 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4423,22 +4423,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e4149a9-4998-4af4-aa67-608b8141aa05
+      - req-3d268266-eff3-421b-8261-14a94f0cb093
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-8e4149a9-4998-4af4-aa67-608b8141aa05
+      - req-3d268266-eff3-421b-8261-14a94f0cb093
       Date:
-      - Mon, 06 Aug 2018 17:00:14 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4448,7 +4448,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4466,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:14 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f716356c-5b32-455c-99f2-627bb1e572fd
+      - req-d40a9cb2-19d1-4161-ada8-60291cbb4eb4
       Content-Length:
       - '4118'
       Connection:
@@ -4481,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:14.907527", "expires":
-        "2018-08-06T18:00:14Z", "id": "e10a5d8d663f46b6a7bd8d11d35eba60", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:50.189217", "expires":
+        "2018-09-24T21:30:50Z", "id": "44b4443296d84b7eb904fc04e9cfdf26", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Hf4mQkPoRfOqbe1oVpoSTw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ao_7gO30RxmrTjG2cjM8FA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4528,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:14 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4543,22 +4543,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e10a5d8d663f46b6a7bd8d11d35eba60
+      - 44b4443296d84b7eb904fc04e9cfdf26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5107a805-f488-4348-a1a7-f2fc363f8e3b
+      - req-253167d6-9a43-45dd-965c-4d532533f19e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-5107a805-f488-4348-a1a7-f2fc363f8e3b
+      - req-253167d6-9a43-45dd-965c-4d532533f19e
       Date:
-      - Mon, 06 Aug 2018 17:00:15 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4568,7 +4568,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4586,13 +4586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:15 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-18534c89-2130-427d-9fec-2683e6872cf5
+      - req-19270bbb-acdb-4823-8616-fba233cdb271
       Content-Length:
       - '4170'
       Connection:
@@ -4601,10 +4601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:15.666900", "expires":
-        "2018-08-06T18:00:15Z", "id": "e8b4e3d0c7114c7380c010a01a0a1efc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:50.672827", "expires":
+        "2018-09-24T21:30:50Z", "id": "51c29ce8fa1d4c8f8e2f51573708987b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QLVkOA_RQLuxKCXNA-OM8Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PIxPzllTTjKZ52nMhqrssw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4649,7 +4649,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -4664,7 +4664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8b4e3d0c7114c7380c010a01a0a1efc
+      - 51c29ce8fa1d4c8f8e2f51573708987b
   response:
     status:
       code: 200
@@ -4675,13 +4675,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 17:00:15 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4699,13 +4699,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:15 GMT
+      - Mon, 24 Sep 2018 20:30:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-463b07f4-8671-4799-b04b-8a37a940c6c3
+      - req-71b96017-c4c6-422e-8e53-1971d2d19e8b
       Content-Length:
       - '4117'
       Connection:
@@ -4714,10 +4714,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:16.032814", "expires":
-        "2018-08-06T18:00:15Z", "id": "b3fa122ed0614b90b5544d0b89f48bfe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:50.924121", "expires":
+        "2018-09-24T21:30:50Z", "id": "092c121e3740489ea6adfa310e5cfd3a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mL7T7zc6RAWN816eXHOPZw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["eYpRBO6hQOKTVnQPh4WmXg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4761,7 +4761,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4776,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3fa122ed0614b90b5544d0b89f48bfe
+      - '092c121e3740489ea6adfa310e5cfd3a'
   response:
     status:
       code: 200
@@ -4787,16 +4787,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4b43ccc3-b7f1-4ddc-94a1-3c957983a8e8
+      - req-f5d24527-456e-4e69-b7b1-bd855fad5c6c
       Date:
-      - Mon, 06 Aug 2018 17:00:16 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4814,13 +4814,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:16 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50259896-6c8f-4f5e-8d18-8ddb30f4a457
+      - req-8eb61a3b-e67c-45d9-8998-0e05a9373681
       Content-Length:
       - '4131'
       Connection:
@@ -4829,10 +4829,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:16.511619", "expires":
-        "2018-08-06T18:00:16Z", "id": "1db67d4e2a5140c4ae9d578e40ff869e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:51.271275", "expires":
+        "2018-09-24T21:30:51Z", "id": "4c632f1b46c64cccbb8f382a2a88d219", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2LXnZRlfRLK69kyRx-6YFA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["QDBBbQe7QqijWg53bK9TjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4876,7 +4876,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4891,7 +4891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1db67d4e2a5140c4ae9d578e40ff869e
+      - 4c632f1b46c64cccbb8f382a2a88d219
   response:
     status:
       code: 200
@@ -4902,16 +4902,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-29ba3805-38d4-403a-9261-e3e100133e1a
+      - req-703d2de3-6da9-4a32-b97f-b8772445dec0
       Date:
-      - Mon, 06 Aug 2018 17:00:16 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4926,7 +4926,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8b4e3d0c7114c7380c010a01a0a1efc
+      - 51c29ce8fa1d4c8f8e2f51573708987b
   response:
     status:
       code: 200
@@ -4937,16 +4937,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c6a24d28-cbee-4999-a8be-7e813b85d363
+      - req-84cef2e8-c35c-4a71-b4ae-bd440d337c69
       Date:
-      - Mon, 06 Aug 2018 17:00:16 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4964,13 +4964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:17 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-766c54eb-9de5-443c-996e-4f4cab90e097
+      - req-f8bd1b67-66ce-4763-80fb-25025a28273d
       Content-Length:
       - '4118'
       Connection:
@@ -4979,10 +4979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:17.141096", "expires":
-        "2018-08-06T18:00:17Z", "id": "e9109594d130493facbc8bf5abc8cf9a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:51.751005", "expires":
+        "2018-09-24T21:30:51Z", "id": "5d41b615cff44d829353c49af2616fc4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BR_loN2wSJqBaT9P8L-Abw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["0H26eOeEQCiVl9WoD6FSzQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5026,7 +5026,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -5041,7 +5041,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9109594d130493facbc8bf5abc8cf9a
+      - 5d41b615cff44d829353c49af2616fc4
   response:
     status:
       code: 200
@@ -5052,16 +5052,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b78468b3-05e2-4535-bcd8-0dcd4e75f4ef
+      - req-849f5709-4769-4004-a7c8-e26ca7f6e566
       Date:
-      - Mon, 06 Aug 2018 17:00:17 GMT
+      - Mon, 24 Sep 2018 20:30:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5076,7 +5076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5089,9 +5089,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3d1fac2f-23a7-41cb-be62-815c1e3dd832
+      - req-c57cf04a-811c-4b2c-8665-a7e5fd4c0591
       Date:
-      - Mon, 06 Aug 2018 17:00:17 GMT
+      - Mon, 24 Sep 2018 20:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5114,7 +5114,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5129,7 +5129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5142,9 +5142,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-3559df95-f2e8-4ebf-a6be-c228b0bae4bd
+      - req-ec893f76-452e-4295-adb8-86174bbc5ac0
       Date:
-      - Mon, 06 Aug 2018 17:00:17 GMT
+      - Mon, 24 Sep 2018 20:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5167,7 +5167,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5182,7 +5182,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5195,9 +5195,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-cac5869e-2d6e-4655-9750-d33c7aa5bc4d
+      - req-bcd7387a-bd77-4ba7-b999-b2f7fb1888e1
       Date:
-      - Mon, 06 Aug 2018 17:00:18 GMT
+      - Mon, 24 Sep 2018 20:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5220,7 +5220,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5235,7 +5235,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5248,9 +5248,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1797cca9-7134-4564-960c-76c6211b6f9d
+      - req-901b871d-32d1-4f32-ae0c-55291b54d76e
       Date:
-      - Mon, 06 Aug 2018 17:00:18 GMT
+      - Mon, 24 Sep 2018 20:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5273,7 +5273,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5288,7 +5288,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5301,9 +5301,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d29cd86b-e9d5-4eb2-a254-68c28b416130
+      - req-c0687a0b-43d0-478d-a57f-8829784cdef7
       Date:
-      - Mon, 06 Aug 2018 17:00:18 GMT
+      - Mon, 24 Sep 2018 20:30:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5326,7 +5326,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -5341,7 +5341,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5354,15 +5354,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-b9964120-a6a5-416d-88e6-a0984c46ffe1
+      - req-8b21171d-3d18-4973-af01-2acf56542c78
       Date:
-      - Mon, 06 Aug 2018 17:00:19 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5377,7 +5377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5390,9 +5390,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-d14508dd-b8ff-4c40-9d0f-958dad6be408
+      - req-ced17de2-f47b-4b52-8408-79323f4708fa
       Date:
-      - Mon, 06 Aug 2018 17:00:19 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5415,7 +5415,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5430,7 +5430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5443,15 +5443,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-2c7df7ca-bda0-4ded-8098-c1cd5dace56f
+      - req-0cdb82ca-cd14-4dd0-aa0a-1b7e018ea308
       Date:
-      - Mon, 06 Aug 2018 17:00:19 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:19 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5466,7 +5466,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5479,9 +5479,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-1040897e-8d70-4dc0-a021-c2db58275072
+      - req-7321539d-a6c3-4507-bc5b-0ad3e02bd412
       Date:
-      - Mon, 06 Aug 2018 17:00:20 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5504,7 +5504,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5519,7 +5519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5532,9 +5532,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-384a1edf-59b1-4ca8-97ff-77b5b983c218
+      - req-2378b275-a48a-45bb-aaf4-03861e0883a5
       Date:
-      - Mon, 06 Aug 2018 17:00:20 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5557,7 +5557,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-floating-ips
@@ -5572,7 +5572,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cd85a4926736420da6cd4881729d1172
+      - 228083b4f2c547039c62b6fc22d04cba
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5585,9 +5585,9 @@ http_interactions:
       Content-Length:
       - '1760'
       X-Compute-Request-Id:
-      - req-df892f7e-d7e6-459c-ac93-bc22731d10c5
+      - req-d296649a-7a7d-4c89-bd94-e31a5b039eed
       Date:
-      - Mon, 06 Aug 2018 17:00:20 GMT
+      - Mon, 24 Sep 2018 20:30:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": [{"instance_id": null, "ip": "172.16.17.13", "fixed_ip":
@@ -5610,7 +5610,7 @@ http_interactions:
         "ip": "172.16.17.6", "fixed_ip": "192.168.1.4", "id": "ee601a91-f6ac-4a46-a599-87cfd83094a3",
         "pool": "EmsRefreshSpec-NetworkPublic"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5628,13 +5628,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:20 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-619d37eb-2b09-4f05-a97e-f5cd9c1d210e
+      - req-f0493ae7-ba0d-4702-9aa9-33777485fd42
       Content-Length:
       - '4170'
       Connection:
@@ -5643,10 +5643,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:20.815007", "expires":
-        "2018-08-06T18:00:20Z", "id": "99dea2b5355640f688504cab769f168b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:54.068589", "expires":
+        "2018-09-24T21:30:54Z", "id": "ede2ead570544dfbb89070f494655d77", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0SZ8GCw0TeOT7cCLtVjIuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Lsg_Ke3STN-9Zu2xLsP_wg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5691,13 +5691,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"99dea2b5355640f688504cab769f168b"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"ede2ead570544dfbb89070f494655d77"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5709,13 +5709,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:20 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c62e3dd8-3558-4a37-a827-9c8e3d7d24bc
+      - req-aab54e6c-4d64-4ee2-b7b7-dc224dfab3b3
       Content-Length:
       - '4196'
       Connection:
@@ -5724,10 +5724,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.011633", "expires":
-        "2018-08-06T18:00:20Z", "id": "adaf4faeb7f6498592ef6e96fd6840f5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:54.237088", "expires":
+        "2018-09-24T21:30:54Z", "id": "1b5438a07aed49faab9045c27b6a3fc0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0ChIQ0jjRmyYM9rd9nNYww", "0SZ8GCw0TeOT7cCLtVjIuA"]},
+        "name": "admin"}, "audit_ids": ["rSWLPzkvQPCWhxTEIPjiiQ", "Lsg_Ke3STN-9Zu2xLsP_wg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5772,7 +5772,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5790,13 +5790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:21 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d8020f5-a2f6-44e1-bdf7-53860bdfef05
+      - req-3aa6411a-aa27-41cc-aec9-b4c5acd1c380
       Content-Length:
       - '4170'
       Connection:
@@ -5805,10 +5805,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.218728", "expires":
-        "2018-08-06T18:00:21Z", "id": "f579051adf134a85abe4cd639bffb4b0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:54.412727", "expires":
+        "2018-09-24T21:30:54Z", "id": "f154ba937bc94c9e9336bea590ef9809", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mfa_Ckf7TfyRluzatXrglA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9kImnj25QKGOTnIE6I2YzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5853,13 +5853,13 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"f579051adf134a85abe4cd639bffb4b0"},"tenantName":"admin"}}'
+      string: '{"auth":{"token":{"id":"f154ba937bc94c9e9336bea590ef9809"},"tenantName":"admin"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -5871,13 +5871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:21 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec2ececc-e01d-4130-be6f-f13ca56665ec
+      - req-1e7c00a9-1efc-47ea-902e-d635a21a04fc
       Content-Length:
       - '4196'
       Connection:
@@ -5886,10 +5886,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:21.432734", "expires":
-        "2018-08-06T18:00:21Z", "id": "0f0ffae2a7cc404faf60cbf47cfbb76c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:54.577485", "expires":
+        "2018-09-24T21:30:54Z", "id": "14c5f28d559f4ccbba71323f13a0612c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9UOnWyksSPCYH2y9CTFmkg", "mfa_Ckf7TfyRluzatXrglA"]},
+        "name": "admin"}, "audit_ids": ["ryGPrFu9RGKki352t5Ucig", "9kImnj25QKGOTnIE6I2YzQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5934,7 +5934,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5949,7 +5949,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56fa1691c6fb4af3b50a1cf2ad67cc53
+      - 1f77039ee6f44a95b1e2c36f58432613
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5962,14 +5962,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-fa448189-ced8-4096-b4ea-e07a884fb0fb
+      - req-ce1bbd97-11ba-4f90-a3b2-bbb6af5f1e26
       Date:
-      - Mon, 06 Aug 2018 17:00:21 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5984,22 +5984,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d4017457-1010-4d3e-9e24-9d26048f5bbf
+      - req-928511a8-04a6-4819-b68a-ad1db05b2108
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-d4017457-1010-4d3e-9e24-9d26048f5bbf
+      - req-928511a8-04a6-4819-b68a-ad1db05b2108
       Date:
-      - Mon, 06 Aug 2018 17:00:21 GMT
+      - Mon, 24 Sep 2018 20:30:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6032,7 +6032,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -6047,22 +6047,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93e47bab-17cc-4b1a-a2d0-ba8f9e10de58
+      - req-541582d6-6544-4970-8e14-027cb3dff65d
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-93e47bab-17cc-4b1a-a2d0-ba8f9e10de58
+      - req-541582d6-6544-4970-8e14-027cb3dff65d
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6079,7 +6079,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -6094,27 +6094,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4600c460134943d289621988e0ea8124
+      - 15de2f1252e34647927cfb883cfe56f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5ece68a9-4623-4ac4-bf7e-56106e367580
+      - req-c5a823cf-b3a6-4ce0-96c7-6fb86ab78ce2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5ece68a9-4623-4ac4-bf7e-56106e367580
+      - req-c5a823cf-b3a6-4ce0-96c7-6fb86ab78ce2
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -6129,27 +6129,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7e5df97-cea0-4029-b060-6abba13104a9
+      - req-3eb3d35b-a2d5-40f6-83cb-07cda3bb19d1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c7e5df97-cea0-4029-b060-6abba13104a9
+      - req-3eb3d35b-a2d5-40f6-83cb-07cda3bb19d1
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -6164,27 +6164,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e10a5d8d663f46b6a7bd8d11d35eba60
+      - 44b4443296d84b7eb904fc04e9cfdf26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ed7368fe-8d49-4260-ba32-8039fb7b456d
+      - req-eacb49a2-5b1d-4a13-b486-46231956bc6d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ed7368fe-8d49-4260-ba32-8039fb7b456d
+      - req-eacb49a2-5b1d-4a13-b486-46231956bc6d
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -6199,22 +6199,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2b9457c-f340-4ea5-9788-aaf75249e7a3
+      - req-0a9ae826-194d-445d-8477-47e1a1f8691b
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b2b9457c-f340-4ea5-9788-aaf75249e7a3
+      - req-0a9ae826-194d-445d-8477-47e1a1f8691b
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6229,7 +6229,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -6244,22 +6244,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d427ff95-82c8-4c89-89e1-733ceb0008b7
+      - req-05087b0b-eb83-4f8f-b131-d5e9c214f692
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-d427ff95-82c8-4c89-89e1-733ceb0008b7
+      - req-05087b0b-eb83-4f8f-b131-d5e9c214f692
       Date:
-      - Mon, 06 Aug 2018 17:00:22 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -6274,7 +6274,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -6289,27 +6289,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4600c460134943d289621988e0ea8124
+      - 15de2f1252e34647927cfb883cfe56f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-51973732-9e2e-4b3b-9f38-627b2bde1e5f
+      - req-353e84d7-cc44-4252-8ef6-ab66b08f6b20
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-51973732-9e2e-4b3b-9f38-627b2bde1e5f
+      - req-353e84d7-cc44-4252-8ef6-ab66b08f6b20
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -6324,27 +6324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4600c460134943d289621988e0ea8124
+      - 15de2f1252e34647927cfb883cfe56f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e6468a5-d0bf-4547-a1e6-216ea131de19
+      - req-c00950b1-e1d1-43bc-adcc-404937d48cd6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2e6468a5-d0bf-4547-a1e6-216ea131de19
+      - req-c00950b1-e1d1-43bc-adcc-404937d48cd6
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -6359,27 +6359,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39d06fc6-1d2f-48e1-991f-6085e4f93bfc
+      - req-713c3c72-ec36-4e75-9bec-136a16391dbc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-39d06fc6-1d2f-48e1-991f-6085e4f93bfc
+      - req-713c3c72-ec36-4e75-9bec-136a16391dbc
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -6394,27 +6394,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0535fee3-4d1e-4057-b446-c3bef04eb283
+      - req-7b23d82c-1091-4c3f-a1a2-4914cc9343cb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0535fee3-4d1e-4057-b446-c3bef04eb283
+      - req-7b23d82c-1091-4c3f-a1a2-4914cc9343cb
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -6429,27 +6429,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e10a5d8d663f46b6a7bd8d11d35eba60
+      - 44b4443296d84b7eb904fc04e9cfdf26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-90cf5285-b818-4a3f-b7c0-6b7a29c9b2b3
+      - req-49a78362-f3d5-46a2-a800-416900631301
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-90cf5285-b818-4a3f-b7c0-6b7a29c9b2b3
+      - req-49a78362-f3d5-46a2-a800-416900631301
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -6464,27 +6464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e10a5d8d663f46b6a7bd8d11d35eba60
+      - 44b4443296d84b7eb904fc04e9cfdf26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-acbf4233-c08b-4ea7-a00d-7bc994ad1090
+      - req-ca23080b-2484-4f93-af9f-33eee09a7f66
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-acbf4233-c08b-4ea7-a00d-7bc994ad1090
+      - req-ca23080b-2484-4f93-af9f-33eee09a7f66
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6499,22 +6499,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-033cf682-023d-488b-a1a4-86a09ef2c83b
+      - req-5d80bde5-7536-4021-a503-91d367247d9e
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-033cf682-023d-488b-a1a4-86a09ef2c83b
+      - req-5d80bde5-7536-4021-a503-91d367247d9e
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6547,7 +6547,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6562,22 +6562,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4af4656d-4ce0-4082-8694-9790861bcdc3
+      - req-15031225-e479-447d-8dc4-530ebbddc5c9
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-4af4656d-4ce0-4082-8694-9790861bcdc3
+      - req-15031225-e479-447d-8dc4-530ebbddc5c9
       Date:
-      - Mon, 06 Aug 2018 17:00:23 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6618,7 +6618,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6633,22 +6633,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eee1e376-9313-449f-b0b5-83b9c46b5ca9
+      - req-339df6cc-8adf-40f7-83cf-ea0797cc4c48
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-eee1e376-9313-449f-b0b5-83b9c46b5ca9
+      - req-339df6cc-8adf-40f7-83cf-ea0797cc4c48
       Date:
-      - Mon, 06 Aug 2018 17:00:24 GMT
+      - Mon, 24 Sep 2018 20:30:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -6682,7 +6682,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6697,27 +6697,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - decfc8b9eb7146819ee0df0822d82d3d
+      - a8a06ddf8699455f8fcd479a547b7980
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25fc8d99-0aed-4efe-ade5-1caa4a6369c9
+      - req-2b0aec63-c6df-42f3-8ef2-a6e46fab1ab6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-25fc8d99-0aed-4efe-ade5-1caa4a6369c9
+      - req-2b0aec63-c6df-42f3-8ef2-a6e46fab1ab6
       Date:
-      - Mon, 06 Aug 2018 17:00:24 GMT
+      - Mon, 24 Sep 2018 20:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -6732,27 +6732,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4600c460134943d289621988e0ea8124
+      - 15de2f1252e34647927cfb883cfe56f0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6d196288-097b-482d-a77c-24b05a4db4dc
+      - req-74948107-a133-4b11-bdbd-904fd758d30b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6d196288-097b-482d-a77c-24b05a4db4dc
+      - req-74948107-a133-4b11-bdbd-904fd758d30b
       Date:
-      - Mon, 06 Aug 2018 17:00:24 GMT
+      - Mon, 24 Sep 2018 20:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -6767,27 +6767,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8efeefad72744c61821793b8a51068c6
+      - 1f9cd862502146599608a1e2791a84c1
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6f58466f-d2e1-4e5d-ad56-c9f13572350c
+      - req-fd4faa4f-8d67-4926-b6b5-5da35ab60dea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6f58466f-d2e1-4e5d-ad56-c9f13572350c
+      - req-fd4faa4f-8d67-4926-b6b5-5da35ab60dea
       Date:
-      - Mon, 06 Aug 2018 17:00:24 GMT
+      - Mon, 24 Sep 2018 20:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -6802,27 +6802,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e10a5d8d663f46b6a7bd8d11d35eba60
+      - 44b4443296d84b7eb904fc04e9cfdf26
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5458482f-9dec-4a95-bebb-f07c01d37503
+      - req-553862ff-1f44-4275-87cc-f79f65ad73a6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5458482f-9dec-4a95-bebb-f07c01d37503
+      - req-553862ff-1f44-4275-87cc-f79f65ad73a6
       Date:
-      - Mon, 06 Aug 2018 17:00:25 GMT
+      - Mon, 24 Sep 2018 20:30:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6840,13 +6840,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:26 GMT
+      - Mon, 24 Sep 2018 20:30:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-17d2e2fe-2d41-41f8-bc8a-c71ea7c6f4ba
+      - req-57a50676-0231-4204-80ae-fcb53a711c18
       Content-Length:
       - '4170'
       Connection:
@@ -6855,10 +6855,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:26.218965", "expires":
-        "2018-08-06T18:00:26Z", "id": "6657527c56ea4bb5ac4234c33d329961", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:58.446086", "expires":
+        "2018-09-24T21:30:58Z", "id": "e61a17aa932c4ebe8489e1c6c7a3898a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["opnvYdn_TP67xBORuESOjw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["F_jGf0dMQXCVrPxNV5Fo3w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6903,7 +6903,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6921,13 +6921,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:26 GMT
+      - Mon, 24 Sep 2018 20:30:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c12e2e64-2491-4b85-9b84-88fbe0cf7683
+      - req-f196a4d4-36d2-4f2e-b4b6-715dfd18c039
       Content-Length:
       - '4170'
       Connection:
@@ -6936,10 +6936,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:26.546876", "expires":
-        "2018-08-06T18:00:26Z", "id": "148376632eb54dcca8a03dd4ef0e7a6f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:58.626981", "expires":
+        "2018-09-24T21:30:58Z", "id": "76bf0cda81e34f20aeabdd87fc1ffde5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DvYy2NKTQUKf8umjfxyVgg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Rw1E0mJkRFCqCZoVpiNAYg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6984,7 +6984,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6999,7 +6999,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -7010,47 +7010,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-c2dc136f-32fa-4630-a686-08d2e61204f7
+      - req-4b623301-a2b8-4cac-afcd-e88b97d52bdf
       Date:
-      - Mon, 06 Aug 2018 17:00:27 GMT
+      - Mon, 24 Sep 2018 20:30:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
-        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "provider:segmentation_id":
-        87}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
+        87}, {"status": "ACTIVE", "subnets": ["93c2f53c-df39-491e-b45b-ce8b36b29437"],
         "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7075,14 +7045,44 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
+        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["c68ac5c0-9d9e-438b-a10f-6d0faeee0790"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "8da920f8-705d-4777-a938-e081b01ad41c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d0065ae4-dffb-4dcc-9e44-a0b1166337f3"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "68259081-a5ca-425f-9d9b-816eb62148a3", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7100,13 +7100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:27 GMT
+      - Mon, 24 Sep 2018 20:30:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f36dd0f1-df90-47af-8906-09bcc28da255
+      - req-1b44dedf-10d0-4cc2-8827-ce3fdd29c7ff
       Content-Length:
       - '4170'
       Connection:
@@ -7115,10 +7115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.436485", "expires":
-        "2018-08-06T18:00:27Z", "id": "1d986e079c3e4cb7bc2eceb0b7fa3022", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:58.988592", "expires":
+        "2018-09-24T21:30:58Z", "id": "3b6dc86afdec4b53bdbe41be94418df4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["xkF-VW8NS9epxTjHFOQTbw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YgOPpPXSQR6CLHwmrnft2A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7163,7 +7163,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7181,13 +7181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:27 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c471d708-e11f-40c5-9430-6ffeb585b91d
+      - req-09201577-3288-4d8f-8f06-6992f20a6cb3
       Content-Length:
       - '370'
       Connection:
@@ -7196,13 +7196,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.586909", "expires":
-        "2018-08-06T18:00:27Z", "id": "f28bd9a6f26d4218a224620734b3802f", "audit_ids":
-        ["jfw2_JNqQDGodtay4q11iQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:59.134546", "expires":
+        "2018-09-24T21:30:59Z", "id": "0b6c291aff48427f87e4eeab98260274", "audit_ids":
+        ["g37RyBfDR0WiQvD7JIqYKw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7217,20 +7217,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f28bd9a6f26d4218a224620734b3802f
+      - 0b6c291aff48427f87e4eeab98260274
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:27 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4d32098d-ff8d-4d81-96c7-dd487297f82c
+      - req-b6132dee-1545-4a7b-b12b-b07953c0a1bd
       Content-Length:
       - '500'
       Connection:
@@ -7247,13 +7247,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"f28bd9a6f26d4218a224620734b3802f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"0b6c291aff48427f87e4eeab98260274"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -7265,13 +7265,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:27 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6dfb0b9b-90ae-4023-adf6-572b309aa4b1
+      - req-53dba45f-fa39-4ec8-af60-992b1788c650
       Content-Length:
       - '4143'
       Connection:
@@ -7280,11 +7280,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:27.937877", "expires":
-        "2018-08-06T18:00:27Z", "id": "eb142ec3e2484edab88b1a78bf2068d3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:59.427601", "expires":
+        "2018-09-24T21:30:59Z", "id": "a11ef6c3cc494e43b3f6c437ae07b294", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jNSU56yfQ7KhnmWtSggUgg",
-        "jfw2_JNqQDGodtay4q11iQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["slDzODpfTNWLnBU-CSJshA",
+        "g37RyBfDR0WiQvD7JIqYKw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7328,7 +7328,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7343,20 +7343,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f28bd9a6f26d4218a224620734b3802f
+      - 0b6c291aff48427f87e4eeab98260274
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:28 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c742e0e-2271-460b-92c8-6ebaad21f020
+      - req-7133492d-b89e-4ce4-b208-fcc7ae491347
       Content-Length:
       - '500'
       Connection:
@@ -7373,7 +7373,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7391,13 +7391,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:28 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2286173c-9125-4843-889a-32306a6bf90c
+      - req-a49cf120-337f-4300-a8e6-f62af850d2f3
       Content-Length:
       - '4117'
       Connection:
@@ -7406,10 +7406,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.398925", "expires":
-        "2018-08-06T18:00:28Z", "id": "cef81a1510804f9d9ae608207226e7fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:59.732968", "expires":
+        "2018-09-24T21:30:59Z", "id": "7061401234904db99aa4cff4b46d877f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OYA97JFuS0Cc8TMPbC77Vg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mw5RWwvYQHaAvAzvB0V8Mg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7453,7 +7453,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7471,13 +7471,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:28 GMT
+      - Mon, 24 Sep 2018 20:30:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ea743871-4a4d-4b03-b1cc-758c65f135f4
+      - req-4752c837-fb2d-447a-8bf2-92af2b1fdf7e
       Content-Length:
       - '4131'
       Connection:
@@ -7486,10 +7486,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.602984", "expires":
-        "2018-08-06T18:00:28Z", "id": "e43f47204b9e495ead9152ca38722974", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:59.901786", "expires":
+        "2018-09-24T21:30:59Z", "id": "695b9671607c4a9b9cd80b6bdcf48784", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kTP0wJcYQxWmW7zwJ842bA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ysd7pgj6SsiNCmuc1BtdmQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7533,7 +7533,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7551,13 +7551,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:28 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-59bfbb5a-172c-43be-82fe-53b6e7c75b21
+      - req-31699ffc-e500-4175-be55-1e070d7ba154
       Content-Length:
       - '4118'
       Connection:
@@ -7566,10 +7566,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:28.833214", "expires":
-        "2018-08-06T18:00:28Z", "id": "1945eff6721542b1b0ef3a3fc4e999af", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:00.075754", "expires":
+        "2018-09-24T21:31:00Z", "id": "aa16383de3c742b58a0b72e87de7a13c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["e3K2w54DSLCq-top_JbV7Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["jcL6Uf_4TfazuMcWXQ_GBA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7613,7 +7613,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:28 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7631,13 +7631,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:28 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f621a60-25ef-456a-aa49-c4a89e8d31c3
+      - req-a5249377-7b7e-41da-8b4f-e97b15471e19
       Content-Length:
       - '4117'
       Connection:
@@ -7646,10 +7646,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:29.028880", "expires":
-        "2018-08-06T18:00:29Z", "id": "8158b40268cf49b8ae549525c4829180", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:00.261275", "expires":
+        "2018-09-24T21:31:00Z", "id": "36a7922df0964390b00dae08c379695b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8SjZkZhcR8CYfex55vJXUg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1hQK-X8kRau1vXpgSzLVKw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7693,7 +7693,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -7708,7 +7708,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -7719,9 +7719,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-86fb6c1a-0a63-4ed1-aec6-de69586b6a49
+      - req-8da5d3b4-beb3-40b3-ad62-57b1ffd3ea94
       Date:
-      - Mon, 06 Aug 2018 17:00:29 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -7755,7 +7755,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -7770,7 +7770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -7781,14 +7781,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ac5d2c0f-c22d-4b3d-8520-093dd0cc5f22
+      - req-1cb32ebe-b6f8-4f90-a0d9-6e11c22941cc
       Date:
-      - Mon, 06 Aug 2018 17:00:29 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7806,13 +7806,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:29 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d70eef14-d96c-4e9a-974d-8ccd9e97dee6
+      - req-23c60430-ffce-49c5-a82f-8c5d52cbf93c
       Content-Length:
       - '4131'
       Connection:
@@ -7821,10 +7821,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:29.928437", "expires":
-        "2018-08-06T18:00:29Z", "id": "378d5635795b44efb68da5ef518103c7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:00.739986", "expires":
+        "2018-09-24T21:31:00Z", "id": "caa5bd84e14f45d2b89abd85173c9666", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["JS18N_WISpKZR53Lvbx2xg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kuogx17HQ2W8YKhWqctFJQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7868,7 +7868,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -7883,7 +7883,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 378d5635795b44efb68da5ef518103c7
+      - caa5bd84e14f45d2b89abd85173c9666
   response:
     status:
       code: 200
@@ -7894,14 +7894,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9f067edb-296f-4a81-b1d1-cc137dad62b8
+      - req-5f359b1c-7abb-4268-80a9-5034b8c979e1
       Date:
-      - Mon, 06 Aug 2018 17:00:30 GMT
+      - Mon, 24 Sep 2018 20:31:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -7916,7 +7916,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1d986e079c3e4cb7bc2eceb0b7fa3022
+      - 3b6dc86afdec4b53bdbe41be94418df4
   response:
     status:
       code: 200
@@ -7927,14 +7927,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2e3ac978-4016-4b4b-b301-66cbb683f3c0
+      - req-0ad92f86-c72f-433d-8272-7a7922eeed4a
       Date:
-      - Mon, 06 Aug 2018 17:00:30 GMT
+      - Mon, 24 Sep 2018 20:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7952,13 +7952,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:30 GMT
+      - Mon, 24 Sep 2018 20:31:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-927ad627-100e-43e9-9e22-f5b844fa0253
+      - req-1df5bf73-85dc-4742-b8a7-9f32748ea3cc
       Content-Length:
       - '4118'
       Connection:
@@ -7967,10 +7967,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:30.965804", "expires":
-        "2018-08-06T18:00:30Z", "id": "b1250283d614402784ee1ece1fd1f93a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:01.251449", "expires":
+        "2018-09-24T21:31:01Z", "id": "3eabed648e194ad594f78b427a26e86e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["i57aSqSFR3Sq3mregEboxQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nOaqjVCrTZSSmwu4WK8Uaw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8014,7 +8014,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -8029,7 +8029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1250283d614402784ee1ece1fd1f93a
+      - 3eabed648e194ad594f78b427a26e86e
   response:
     status:
       code: 200
@@ -8040,14 +8040,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-81212789-049e-4b57-b5e1-1aeb51cb783b
+      - req-72b4dee1-ebcb-4794-823d-d423c06f5ed8
       Date:
-      - Mon, 06 Aug 2018 17:00:31 GMT
+      - Mon, 24 Sep 2018 20:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -8062,7 +8062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8073,9 +8073,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e58b8693-1984-479f-8e02-bc874087e73f
+      - req-4866c572-4624-4bec-9bcf-4d253fa0f1de
       Date:
-      - Mon, 06 Aug 2018 17:00:32 GMT
+      - Mon, 24 Sep 2018 20:31:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8102,7 +8102,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -8117,7 +8117,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8128,9 +8128,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-eb3b5bd7-f79a-4272-94e2-0ca5b8a9c561
+      - req-b753f6d5-b919-4284-a911-a510971a3420
       Date:
-      - Mon, 06 Aug 2018 17:00:33 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8157,7 +8157,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -8172,7 +8172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8183,9 +8183,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-2aff34ab-3196-498b-afec-8cee40eacf0a
+      - req-4e76c954-1b15-4b3d-93d2-a91ffc5e621a
       Date:
-      - Mon, 06 Aug 2018 17:00:33 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8212,7 +8212,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -8227,7 +8227,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8238,9 +8238,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-bb5d2a49-bfb3-4e36-8e5f-f55337a55ac4
+      - req-effb9239-b956-478b-ad59-85bb89c7d445
       Date:
-      - Mon, 06 Aug 2018 17:00:34 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8252,7 +8252,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -8267,7 +8267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8278,9 +8278,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-76788074-ea2e-4534-88b8-25aa114cb2b5
+      - req-e019a90d-ac9e-4238-b9a3-f68db0e4ed8c
       Date:
-      - Mon, 06 Aug 2018 17:00:34 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8292,7 +8292,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -8307,7 +8307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8158b40268cf49b8ae549525c4829180
+      - 36a7922df0964390b00dae08c379695b
   response:
     status:
       code: 200
@@ -8318,9 +8318,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4e5ccbcf-b0db-4382-b1ef-98b8cd110909
+      - req-c9bd459a-d565-4c8e-b516-d3a32533d285
       Date:
-      - Mon, 06 Aug 2018 17:00:34 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8332,7 +8332,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8350,13 +8350,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:34 GMT
+      - Mon, 24 Sep 2018 20:31:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f57bc198-dd9d-4294-9475-8297b8a70783
+      - req-8e8fb38b-79a5-4938-b646-ede904f0f7a0
       Content-Length:
       - '4117'
       Connection:
@@ -8365,10 +8365,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:34.670791", "expires":
-        "2018-08-06T18:00:34Z", "id": "59a766c81b1f46dd9a9a52210d2f7ebc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:03.025592", "expires":
+        "2018-09-24T21:31:03Z", "id": "77cb089728234fc782ef28f53b124766", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WbtVOqwoRO6EENc-Z5UFfw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["u9LXxZBGTLSzfQCQa9sNvA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8412,7 +8412,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8427,7 +8427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -8438,68 +8438,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9cc60ea1-92e9-4927-8214-490371215891
+      - req-7de9aba0-c66f-47b8-9fc5-bb162f0443ee
       Date:
-      - Mon, 06 Aug 2018 17:00:35 GMT
+      - Mon, 24 Sep 2018 20:31:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -8531,20 +8508,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8559,7 +8559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -8570,12 +8570,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-61fa7d90-d4fc-4cf7-b02e-0199f4f3ef59
+      - req-dca4f193-a36c-4345-8f43-eace1bc02ef9
       Date:
-      - Mon, 06 Aug 2018 17:00:36 GMT
+      - Mon, 24 Sep 2018 20:31:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -8640,29 +8663,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8676,7 +8676,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8694,13 +8694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:36 GMT
+      - Mon, 24 Sep 2018 20:31:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50869b77-d098-4b49-a7da-3037d285b326
+      - req-a4650651-01ee-4111-9fc0-8d772cc5855b
       Content-Length:
       - '4131'
       Connection:
@@ -8709,10 +8709,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:36.591943", "expires":
-        "2018-08-06T18:00:36Z", "id": "776200032d3144a3bb4b48d0feb96079", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:03.621116", "expires":
+        "2018-09-24T21:31:03Z", "id": "4be9e45e119f4f59be0385b81c8ba125", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eu4hE-xEQ_OqVGXvA7lm3A"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4XUUQEzrTVSY2eDRdXKeCw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8756,7 +8756,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8771,7 +8771,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -8782,53 +8782,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0fd92a59-0d2f-4e30-91f4-623712b4fb44
+      - req-f67610cc-c8ef-45c6-b089-45ce6d902523
       Date:
-      - Mon, 06 Aug 2018 17:00:37 GMT
+      - Mon, 24 Sep 2018 20:31:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -8852,74 +8811,6 @@ http_interactions:
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-877c84fd-4ebd-49cd-a00a-d98882f43d95
-      Date:
-      - Mon, 06 Aug 2018 17:00:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -8984,29 +8875,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9020,10 +8888,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -9035,7 +8903,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -9046,53 +8914,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-10ba617b-555b-45b3-b73e-a3a9dea7f562
+      - req-55e9e1e0-4cce-469d-9d4c-f4fb2c04324a
       Date:
-      - Mon, 06 Aug 2018 17:00:37 GMT
+      - Mon, 24 Sep 2018 20:31:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -9116,74 +8943,6 @@ http_interactions:
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7dbaba48-27fa-42ce-8056-ab2d6685d8dd
-      Date:
-      - Mon, 06 Aug 2018 17:00:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -9248,7 +9007,51 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:31:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-943d33b8-443b-45c6-95ff-f36ec15c44af
+      Date:
+      - Mon, 24 Sep 2018 20:31:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -9271,6 +9074,71 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9284,7 +9152,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-afe524c3-782d-46b0-b269-83c908e88340
+      Date:
+      - Mon, 24 Sep 2018 20:31:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9302,13 +9302,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:38 GMT
+      - Mon, 24 Sep 2018 20:31:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b55447be-415b-4c2a-8eeb-6bf075a16bab
+      - req-fb2b1cb0-e2f8-4759-b7e0-0a894d2b4bd3
       Content-Length:
       - '4118'
       Connection:
@@ -9317,10 +9317,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:38.232180", "expires":
-        "2018-08-06T18:00:38Z", "id": "30a8e490b3de4722a8597f7a2bbab88d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:04.435834", "expires":
+        "2018-09-24T21:31:04Z", "id": "2328f64b89bf4716990acc5e92eb08ca", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MjdgePjnS9WNXcYGu8Fq6g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["wrMWnsLfQvONecVnEyGrWA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9364,7 +9364,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -9379,7 +9379,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -9390,113 +9390,114 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b1f028de-75ec-4bd4-91ac-1327bb4a5abe
+      - req-513bc85f-42a9-4ef7-b2f1-b036d9b2c55b
       Date:
-      - Mon, 06 Aug 2018 17:00:38 GMT
+      - Mon, 24 Sep 2018 20:31:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -9511,7 +9512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -9522,12 +9523,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-46421aa9-a566-4c4f-83e7-c2cc87953079
+      - req-bf2412ed-16d8-47db-8483-e75c8c0f1cf9
       Date:
-      - Mon, 06 Aug 2018 17:00:39 GMT
+      - Mon, 24 Sep 2018 20:31:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -9592,29 +9616,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -9628,7 +9629,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9643,7 +9644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -9654,9 +9655,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-c2d6b575-5d2f-46c2-950f-c194bb8d2f0d
+      - req-f08c080f-78f4-4dc4-8fc2-5542a7253615
       Date:
-      - Mon, 06 Aug 2018 17:00:41 GMT
+      - Mon, 24 Sep 2018 20:31:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9698,7 +9699,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9713,7 +9714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -9724,9 +9725,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-84a59bf2-f433-4c73-b88f-23470e9ebf91
+      - req-e23dbcac-593b-44d2-bc89-e433d190f0a8
       Date:
-      - Mon, 06 Aug 2018 17:00:41 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9768,7 +9769,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9783,7 +9784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -9794,9 +9795,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0735ada4-6e49-4277-9dc7-72678f54f6c7
+      - req-b6d50aa7-2fcc-4cdb-bc05-40ccd7c411d0
       Date:
-      - Mon, 06 Aug 2018 17:00:41 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9838,7 +9839,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9853,7 +9854,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -9864,9 +9865,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1c12ed95-ecf6-43cb-bdf8-5fb98a364add
+      - req-1c306793-b18b-416d-a6cd-7883c5eed33e
       Date:
-      - Mon, 06 Aug 2018 17:00:41 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9908,7 +9909,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9923,7 +9924,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -9934,9 +9935,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-dd3002db-6031-464d-9752-ad36f796e540
+      - req-ec80fb95-b095-4edf-990a-da97c5463c17
       Date:
-      - Mon, 06 Aug 2018 17:00:41 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9978,7 +9979,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9993,7 +9994,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -10004,9 +10005,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-32b994b6-1b30-45ae-ba8f-d02eb05efccb
+      - req-e2dc8b41-dcfc-4f7c-a061-c55fa6b569b6
       Date:
-      - Mon, 06 Aug 2018 17:00:42 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10048,7 +10049,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -10063,7 +10064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -10074,9 +10075,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1614b603-ab2b-4299-a286-24a1739dee01
+      - req-3985b067-3bad-4158-80cb-71769c55a0bf
       Date:
-      - Mon, 06 Aug 2018 17:00:42 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10118,7 +10119,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -10133,7 +10134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -10144,9 +10145,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-9b096c05-9cf2-403e-a685-67b4d7ce82e8
+      - req-10134ff1-c0d7-4854-a77f-99e7bdd61d8c
       Date:
-      - Mon, 06 Aug 2018 17:00:42 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -10188,7 +10189,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10203,7 +10204,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -10214,9 +10215,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-98c1c9c8-a743-4ffa-a740-766fe5e2c856
+      - req-a41060c4-0694-486e-9573-c0e2b85970b9
       Date:
-      - Mon, 06 Aug 2018 17:00:42 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10619,7 +10620,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10634,7 +10635,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -10645,9 +10646,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-20a062cc-de2e-4c8b-a568-7a45ba421958
+      - req-e04c7f70-9ce5-4754-a1f1-9665679fa75a
       Date:
-      - Mon, 06 Aug 2018 17:00:42 GMT
+      - Mon, 24 Sep 2018 20:31:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11050,7 +11051,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11065,7 +11066,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -11076,9 +11077,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bb29df73-1efd-4272-aea5-c7c92e4616a9
+      - req-cc1455df-3815-422a-9a04-5e05a5954aa9
       Date:
-      - Mon, 06 Aug 2018 17:00:43 GMT
+      - Mon, 24 Sep 2018 20:31:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11481,7 +11482,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11496,7 +11497,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -11507,9 +11508,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8b0a2b41-edd9-4002-90d9-6a0f599f3079
+      - req-05126d5d-6f31-49ab-9ac8-9c82a6b98d71
       Date:
-      - Mon, 06 Aug 2018 17:00:43 GMT
+      - Mon, 24 Sep 2018 20:31:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11912,7 +11913,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11927,7 +11928,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -11938,9 +11939,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-280ed1ae-0482-4801-87ef-a5417d1de3ce
+      - req-6df06952-3c7b-45dd-9f65-f04f6f62aab3
       Date:
-      - Mon, 06 Aug 2018 17:00:43 GMT
+      - Mon, 24 Sep 2018 20:31:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12343,7 +12344,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12358,7 +12359,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -12369,9 +12370,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6d7021fa-f594-408e-a761-0d415374c5ef
+      - req-46c8c3cc-7571-4745-9265-71dd164730cc
       Date:
-      - Mon, 06 Aug 2018 17:00:43 GMT
+      - Mon, 24 Sep 2018 20:31:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12774,7 +12775,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12789,7 +12790,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -12800,9 +12801,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bade9464-f6da-4fa5-9908-49e7ddc06eeb
+      - req-e631f404-0083-4670-bf47-403920db9cf1
       Date:
-      - Mon, 06 Aug 2018 17:00:44 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13205,7 +13206,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -13220,7 +13221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -13231,9 +13232,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b380f525-21fa-4948-be0c-8c132f4abe1c
+      - req-6df007f5-18c5-4382-8895-47a84a197d1c
       Date:
-      - Mon, 06 Aug 2018 17:00:44 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13636,7 +13637,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13651,7 +13652,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -13662,9 +13663,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-620f789b-219a-4bf8-812a-70b22413213c
+      - req-e6d9c261-3c8c-4d30-a4b1-30cf5efdb411
       Date:
-      - Mon, 06 Aug 2018 17:00:44 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13696,7 +13697,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13711,7 +13712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -13722,9 +13723,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2e8bfd9a-2f93-4dd3-8b1a-431a63972ea4
+      - req-d1174222-63c9-46d5-86c5-9d976a99f291
       Date:
-      - Mon, 06 Aug 2018 17:00:44 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13756,7 +13757,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13771,7 +13772,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -13782,9 +13783,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-67785b3f-fa20-404d-8d51-b56d0a663724
+      - req-6d7c49c9-6852-41cb-ae2d-86516c96eb1f
       Date:
-      - Mon, 06 Aug 2018 17:00:44 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13816,7 +13817,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13831,7 +13832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -13842,9 +13843,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f1b82b09-c6b3-485e-8525-5e8a869e5d15
+      - req-230fe245-2900-47d6-a136-47416325fc60
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13876,7 +13877,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13891,7 +13892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -13902,9 +13903,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8edcefac-c5db-47c5-8b4d-4005426c36b2
+      - req-90180000-3edc-4e3c-9609-40a9e6cd032f
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13936,7 +13937,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13951,7 +13952,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -13962,9 +13963,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ad5ca9a1-0b80-4e0f-8a52-a953b501a8b7
+      - req-d881ec0e-a34e-46ed-9d08-df57498329d4
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13996,7 +13997,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -14011,7 +14012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -14022,9 +14023,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-5fd524f0-92b9-4a18-87af-a0dd665980d0
+      - req-e3de38cd-3b10-4eaa-84c9-9917df689adc
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14056,7 +14057,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -14071,7 +14072,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -14082,9 +14083,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a6ae2af3-2f94-42b6-b52e-861b0824229b
+      - req-b5080a74-d770-4080-add1-ca1917dd944c
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -14116,7 +14117,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14131,7 +14132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -14142,9 +14143,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-91bc8367-093b-48b2-852e-81ec9a98f19a
+      - req-44e06a55-696e-4b36-ae52-67cd2ad45eaf
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14186,7 +14187,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14201,7 +14202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -14212,9 +14213,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-e356500f-862d-4a9d-81ed-93144124bb12
+      - req-56d5f754-440e-44ac-9fe1-9c1750bc9780
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14257,7 +14258,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14272,7 +14273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -14283,9 +14284,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-eade6049-488e-4c2e-a02b-01e01ad7e942
+      - req-c6b8a4ef-e018-4064-8598-2ef1111ab23a
       Date:
-      - Mon, 06 Aug 2018 17:00:45 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14320,7 +14321,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14335,7 +14336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 59a766c81b1f46dd9a9a52210d2f7ebc
+      - 77cb089728234fc782ef28f53b124766
   response:
     status:
       code: 200
@@ -14346,9 +14347,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-1c722657-6337-49cd-957b-cb9fc8a84999
+      - req-6dc0b07c-70b1-40f2-abb6-8b4f20c8ffba
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14435,7 +14436,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14450,7 +14451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -14461,9 +14462,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-214364c7-1ad6-4164-94aa-0b5b8939b0be
+      - req-cb0b173e-5917-42db-a8e3-1c3effb2f570
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14505,7 +14506,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14520,7 +14521,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -14531,9 +14532,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4abeef11-f4df-4ae3-ab27-8e0ca79e080e
+      - req-c46bfdf8-69e1-41be-abc8-d9e04c003bf2
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14576,7 +14577,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14591,7 +14592,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -14602,9 +14603,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-cca0eb7d-8882-4b19-9a93-0693a4a8ba59
+      - req-a7f8a585-a9c1-40fe-b8a0-b18b42f9e571
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14639,7 +14640,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14654,7 +14655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 776200032d3144a3bb4b48d0feb96079
+      - 4be9e45e119f4f59be0385b81c8ba125
   response:
     status:
       code: 200
@@ -14665,9 +14666,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-47f79c71-312c-488f-8972-bb94aba7a341
+      - req-71f93e83-d7ee-424d-9f39-285b04493fb9
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14754,7 +14755,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14769,7 +14770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -14780,9 +14781,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-8f0c4ab8-5d05-4281-9592-070bc16b2408
+      - req-084dfac3-c66f-4a96-94fc-0f30949f2b74
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14824,7 +14825,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14839,7 +14840,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -14850,9 +14851,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-297871b7-acc1-4b32-8dc6-7d67757a1e06
+      - req-86f0060f-6802-4a52-aded-e3b09562b130
       Date:
-      - Mon, 06 Aug 2018 17:00:46 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14895,7 +14896,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14910,7 +14911,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -14921,9 +14922,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-c3202eb1-c891-4812-8428-f7c691cd9208
+      - req-ebdf6c15-6e99-4637-84e9-7d5bfb777967
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14958,7 +14959,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14973,7 +14974,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 148376632eb54dcca8a03dd4ef0e7a6f
+      - 76bf0cda81e34f20aeabdd87fc1ffde5
   response:
     status:
       code: 200
@@ -14984,9 +14985,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-e70641d3-f472-40f2-b13a-cddda36aebf0
+      - req-1390378c-7adc-4174-9235-e366cb20c232
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15073,7 +15074,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -15088,7 +15089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -15099,9 +15100,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-05da1314-7cb4-43c7-98a4-83233b5988f3
+      - req-bf259eeb-a225-46fc-a298-5fbb1205d7d1
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -15143,7 +15144,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -15158,7 +15159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -15169,9 +15170,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-caae9784-d71c-49a3-903a-2e177fc76419
+      - req-45e52938-20c9-4c85-a5ba-b3c28cfb9cdd
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -15214,7 +15215,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -15229,7 +15230,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -15240,9 +15241,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-f17e65c1-2d5a-4e48-b8f1-4605db030a15
+      - req-e8d36b37-25a4-4fbc-952b-5f6290600795
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -15277,7 +15278,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15292,7 +15293,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30a8e490b3de4722a8597f7a2bbab88d
+      - 2328f64b89bf4716990acc5e92eb08ca
   response:
     status:
       code: 200
@@ -15303,9 +15304,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-a2866cd4-0b6b-47c4-8f2c-4d7666428146
+      - req-5784b203-f5c6-4076-99bd-626a8274da2e
       Date:
-      - Mon, 06 Aug 2018 17:00:47 GMT
+      - Mon, 24 Sep 2018 20:31:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15392,7 +15393,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15410,13 +15411,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:48 GMT
+      - Mon, 24 Sep 2018 20:31:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0cb49c9-68a8-46d7-9645-a7f0430d2ec2
+      - req-3e25bf28-d8e0-469e-92fa-2b75ff4ca486
       Content-Length:
       - '4170'
       Connection:
@@ -15425,10 +15426,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.556447", "expires":
-        "2018-08-06T18:00:48Z", "id": "1f51bb6885e949cfac2df0b63bdb8d16", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:10.523297", "expires":
+        "2018-09-24T21:31:10Z", "id": "bae845d2b5ac4b6aaf5a89374a7597ec", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["n0zdjjtlQWumMBsvEOjUvQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["U4Yn0BO5Tay_3fPr6wjgQg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15473,7 +15474,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15491,13 +15492,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:48 GMT
+      - Mon, 24 Sep 2018 20:31:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-dec7f270-4cbd-4b7c-8ca3-65d66267884d
+      - req-054dcefb-d4d8-4e00-aad8-c200525a86b3
       Content-Length:
       - '4170'
       Connection:
@@ -15506,10 +15507,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.764517", "expires":
-        "2018-08-06T18:00:48Z", "id": "ecca10a7335e40c6acd2b26fe074b540", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:10.715046", "expires":
+        "2018-09-24T21:31:10Z", "id": "42d0ea920f614695a44b5a7f9b3c8c54", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["rZtk-qEsTUuT6DMVHF6Zng"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["H80Wu6pCTcKIpZKHTPX5fQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15554,7 +15555,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15572,13 +15573,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:48 GMT
+      - Mon, 24 Sep 2018 20:31:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d381bdb0-c8b5-4f79-9ed7-dc75a5e41f90
+      - req-331af932-56ce-4b55-96ac-80ea4d53d22c
       Content-Length:
       - '370'
       Connection:
@@ -15587,13 +15588,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:48.950486", "expires":
-        "2018-08-06T18:00:48Z", "id": "6141e1af3a824db6a897ad43a852aa8e", "audit_ids":
-        ["JPGZhLA4RHarOIl3KqSGtQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:10.882217", "expires":
+        "2018-09-24T21:31:10Z", "id": "e916705e98454ad5a42d8a47b15706ed", "audit_ids":
+        ["0FLUEMERSx6ucpqYlsb6Fg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15608,20 +15609,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6141e1af3a824db6a897ad43a852aa8e
+      - e916705e98454ad5a42d8a47b15706ed
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:49 GMT
+      - Mon, 24 Sep 2018 20:31:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-977f4df1-6a6b-4671-877a-2d679fc93241
+      - req-d1051f9f-8866-4985-847d-79f8f6379d04
       Content-Length:
       - '500'
       Connection:
@@ -15638,13 +15639,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"6141e1af3a824db6a897ad43a852aa8e"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"e916705e98454ad5a42d8a47b15706ed"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -15656,13 +15657,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:49 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d2d069d4-03bb-4f00-bdab-a495991f914e
+      - req-a060dae7-3449-4969-b7f8-90a200a3dbfc
       Content-Length:
       - '4143'
       Connection:
@@ -15671,11 +15672,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.301359", "expires":
-        "2018-08-06T18:00:48Z", "id": "c39654dc5d7140ecb0696c1924992b73", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:11.174112", "expires":
+        "2018-09-24T21:31:10Z", "id": "e16cad90bcc1491ab0ca124a053b145c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JEN2Jo-PSICpwJJjlnCtBA",
-        "JPGZhLA4RHarOIl3KqSGtQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yMp2g3XgS7i4_LLCsbd-KQ",
+        "0FLUEMERSx6ucpqYlsb6Fg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15719,7 +15720,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15734,20 +15735,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6141e1af3a824db6a897ad43a852aa8e
+      - e916705e98454ad5a42d8a47b15706ed
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:49 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ede5b056-a461-4466-b50d-fae7e907fe4d
+      - req-8b87f295-749e-409e-97c1-02f9de7ba5cc
       Content-Length:
       - '500'
       Connection:
@@ -15764,7 +15765,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15782,13 +15783,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:49 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d21320ac-df97-4801-a08e-b0d3b2147eb1
+      - req-580e3067-ed1b-4f21-9737-2902ff3b1cf5
       Content-Length:
       - '4117'
       Connection:
@@ -15797,10 +15798,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.682435", "expires":
-        "2018-08-06T18:00:49Z", "id": "93a884bd5e7945ac81adc8e930e51317", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:11.488829", "expires":
+        "2018-09-24T21:31:11Z", "id": "b708b36f75f8437eb87657da53331df0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["2msDfIuyRnqbxQy5DWSYtg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wNmwv5_nToapTat-KGvUwQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15844,7 +15845,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15862,13 +15863,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:49 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2103b112-e958-4170-be60-cb1a73e39072
+      - req-e581df0c-3a19-4d6d-b3c9-3db061c19487
       Content-Length:
       - '4131'
       Connection:
@@ -15877,10 +15878,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:49.894970", "expires":
-        "2018-08-06T18:00:49Z", "id": "6863161fa4ce48d1a8f2f545291329a3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:11.665048", "expires":
+        "2018-09-24T21:31:11Z", "id": "ef5a1d2417aa402cbdce0d6f330c0299", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["F4zBQj7nQCO73sGy_isUtQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Graw2BAwRuaGuROaZX8Hew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15924,7 +15925,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15942,13 +15943,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:50 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-461e977b-95ac-4c10-ae31-a55e2496237f
+      - req-d727efbb-4f4e-4904-bd50-dce591dfce90
       Content-Length:
       - '4118'
       Connection:
@@ -15957,10 +15958,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:50.100326", "expires":
-        "2018-08-06T18:00:50Z", "id": "8621a4dba9704e498e5f79d4b007cc50", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:11.840301", "expires":
+        "2018-09-24T21:31:11Z", "id": "4ff1ccb7d0544694a9dd901162a162dd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["h52XRftxQAyFPYCRb2cPqg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KN-kLIeYRiWeex-Hq76sGA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16004,7 +16005,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16022,13 +16023,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:50 GMT
+      - Mon, 24 Sep 2018 20:31:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-abb5750c-c591-41a4-aba2-ab3f91a5c47b
+      - req-68fa136d-28b6-43c1-93e2-d6f4c2abdb02
       Content-Length:
       - '4117'
       Connection:
@@ -16037,10 +16038,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:50.310965", "expires":
-        "2018-08-06T18:00:50Z", "id": "7a571e53cfef47c691c355add1c4cedc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:12.026664", "expires":
+        "2018-09-24T21:31:12Z", "id": "a534bcb0c30543b5956f1430f135ce3d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yJcDFfSkRqSWhmJq1ykb5g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["I7LePfjoT-yAdPLlQ0mSQw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -16084,7 +16085,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -16099,22 +16100,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1919fc1a-75a2-4e3f-ad54-762eb1a46d4d
+      - req-97061d6b-d03f-4e57-9cdd-c2c282d3c6f6
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-1919fc1a-75a2-4e3f-ad54-762eb1a46d4d
+      - req-97061d6b-d03f-4e57-9cdd-c2c282d3c6f6
       Date:
-      - Mon, 06 Aug 2018 17:00:50 GMT
+      - Mon, 24 Sep 2018 20:31:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -16147,7 +16148,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -16162,22 +16163,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-605dc0b0-c998-48ba-834e-1d5d994f1c50
+      - req-1b3c703d-0ece-4b2f-84c9-c021f05db352
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-605dc0b0-c998-48ba-834e-1d5d994f1c50
+      - req-1b3c703d-0ece-4b2f-84c9-c021f05db352
       Date:
-      - Mon, 06 Aug 2018 17:00:51 GMT
+      - Mon, 24 Sep 2018 20:31:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -16218,7 +16219,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -16233,22 +16234,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8ee364a-2386-4ca9-9663-728080b430ca
+      - req-27c09282-75af-4fee-ad08-6408be747093
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-b8ee364a-2386-4ca9-9663-728080b430ca
+      - req-27c09282-75af-4fee-ad08-6408be747093
       Date:
-      - Mon, 06 Aug 2018 17:00:52 GMT
+      - Mon, 24 Sep 2018 20:31:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -16282,7 +16283,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -16297,27 +16298,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b316847b-1da0-46ad-ba7e-f12c3395c3fd
+      - req-c41f6b64-85bb-49ec-8b3c-b1750c0bb44e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b316847b-1da0-46ad-ba7e-f12c3395c3fd
+      - req-c41f6b64-85bb-49ec-8b3c-b1750c0bb44e
       Date:
-      - Mon, 06 Aug 2018 17:00:52 GMT
+      - Mon, 24 Sep 2018 20:31:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16335,13 +16336,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:52 GMT
+      - Mon, 24 Sep 2018 20:31:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-104381fa-9414-4f97-9ca9-64bc07d008f0
+      - req-32189796-8551-4a1d-8c11-55ff77e553e5
       Content-Length:
       - '4131'
       Connection:
@@ -16350,10 +16351,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:52.674061", "expires":
-        "2018-08-06T18:00:52Z", "id": "5b92fcc730654fd9ad60bf96c5991831", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:12.852477", "expires":
+        "2018-09-24T21:31:12Z", "id": "ed5ff63e6f464702a6ada3cec614088b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ndvzQ0SpSYa0P1HnwEQ0aA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["elQ-1wRrSBuCJ1p06npZzA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -16397,7 +16398,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -16412,27 +16413,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-275f4427-5c91-436e-a1e0-213023653349
+      - req-a8b622e0-0f00-4394-8003-a45d272ce49e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-275f4427-5c91-436e-a1e0-213023653349
+      - req-a8b622e0-0f00-4394-8003-a45d272ce49e
       Date:
-      - Mon, 06 Aug 2018 17:00:53 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -16447,27 +16448,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c14b1ced-140f-44ac-8d04-5ef7b076f222
+      - req-78820c23-8b4e-4d4b-a68c-b19d75e87c36
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c14b1ced-140f-44ac-8d04-5ef7b076f222
+      - req-78820c23-8b4e-4d4b-a68c-b19d75e87c36
       Date:
-      - Mon, 06 Aug 2018 17:00:54 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16485,13 +16486,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:54 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-653d3906-1407-49d3-b4c9-584ef3271ea0
+      - req-983415bb-1cc8-4436-acec-5c6634442d48
       Content-Length:
       - '4118'
       Connection:
@@ -16500,10 +16501,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:54.858840", "expires":
-        "2018-08-06T18:00:54Z", "id": "4b2148c4a29c42eebc12ac2874db78b4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:13.409369", "expires":
+        "2018-09-24T21:31:13Z", "id": "8f73b44c7b024a7680c69ccf7d1d145c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["din76STlRua05KzKUMkQkw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nS6Ua93WRiGAD6yDZcQ3Qw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -16547,7 +16548,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:54 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -16562,27 +16563,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa65ce4c-f21b-4292-ac27-beabb175872b
+      - req-ded13a68-59f7-429a-aa18-fd41083e8e93
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fa65ce4c-f21b-4292-ac27-beabb175872b
+      - req-ded13a68-59f7-429a-aa18-fd41083e8e93
       Date:
-      - Mon, 06 Aug 2018 17:00:55 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -16597,22 +16598,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2daf1e1a-4f10-43ef-9460-99e935410480
+      - req-c6ca2dec-532b-44ce-88c5-46310a49f5f0
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-2daf1e1a-4f10-43ef-9460-99e935410480
+      - req-c6ca2dec-532b-44ce-88c5-46310a49f5f0
       Date:
-      - Mon, 06 Aug 2018 17:00:55 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16627,7 +16628,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -16642,22 +16643,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60bd5617-729f-45a2-b19f-01c73eac5402
+      - req-ea33d02d-14ad-459f-809d-ea06f5122d7e
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-60bd5617-729f-45a2-b19f-01c73eac5402
+      - req-ea33d02d-14ad-459f-809d-ea06f5122d7e
       Date:
-      - Mon, 06 Aug 2018 17:00:55 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16672,7 +16673,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16687,27 +16688,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23977f98-acf4-4311-a108-a3303097b3c1
+      - req-42256d50-a9a2-4512-bb5b-a27f68b2531c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-23977f98-acf4-4311-a108-a3303097b3c1
+      - req-42256d50-a9a2-4512-bb5b-a27f68b2531c
       Date:
-      - Mon, 06 Aug 2018 17:00:55 GMT
+      - Mon, 24 Sep 2018 20:31:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16722,27 +16723,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b27d20e-cef1-45d6-8877-ad6e05ab146b
+      - req-24dab322-fac9-414c-abb8-749d6e99826f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5b27d20e-cef1-45d6-8877-ad6e05ab146b
+      - req-24dab322-fac9-414c-abb8-749d6e99826f
       Date:
-      - Mon, 06 Aug 2018 17:00:56 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16757,27 +16758,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1a2ed46a-ecac-4f1c-b2dc-fbe8a3e8c6f1
+      - req-6c0c2788-40be-4cca-8d9a-d08390d39981
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1a2ed46a-ecac-4f1c-b2dc-fbe8a3e8c6f1
+      - req-6c0c2788-40be-4cca-8d9a-d08390d39981
       Date:
-      - Mon, 06 Aug 2018 17:00:56 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16792,27 +16793,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-04a0ea4a-b7c2-40b9-b447-a1b88d3bd314
+      - req-6b0a8624-6634-4e26-9f90-4a7e3152dd45
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-04a0ea4a-b7c2-40b9-b447-a1b88d3bd314
+      - req-6b0a8624-6634-4e26-9f90-4a7e3152dd45
       Date:
-      - Mon, 06 Aug 2018 17:00:56 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:56 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16827,27 +16828,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9dc437b7-7c51-4ef2-8bdd-3e4598a3b184
+      - req-1b460bab-7c7a-4b86-944d-a96244157780
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-9dc437b7-7c51-4ef2-8bdd-3e4598a3b184
+      - req-1b460bab-7c7a-4b86-944d-a96244157780
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16862,27 +16863,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7d9e92d1-61b0-44fc-871c-c33bc7fd8f82
+      - req-c99a2fe3-3dd2-4934-8a2d-3d24af7cdf2f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7d9e92d1-61b0-44fc-871c-c33bc7fd8f82
+      - req-c99a2fe3-3dd2-4934-8a2d-3d24af7cdf2f
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16897,27 +16898,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-258d00e6-8440-4c85-950e-d4350d08fe34
+      - req-758aebf7-7ef4-4e8e-908c-7210737b12b4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-258d00e6-8440-4c85-950e-d4350d08fe34
+      - req-758aebf7-7ef4-4e8e-908c-7210737b12b4
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16932,27 +16933,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b118fc6d-e50f-4e36-8e6b-a46e6e30c538
+      - req-c999c208-669a-46f2-a6dd-1b5b3d236aa1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b118fc6d-e50f-4e36-8e6b-a46e6e30c538
+      - req-c999c208-669a-46f2-a6dd-1b5b3d236aa1
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16967,27 +16968,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-95b67be9-7e9d-4969-ac15-ca513794bf07
+      - req-348c1de6-ed06-4f1a-91b3-0e1d0d30df5d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-95b67be9-7e9d-4969-ac15-ca513794bf07
+      - req-348c1de6-ed06-4f1a-91b3-0e1d0d30df5d
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -17002,27 +17003,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e655a3b5-f6cd-4f75-900a-d66084344d90
+      - req-aa8c6840-0759-42da-a143-b3eed79bb31a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e655a3b5-f6cd-4f75-900a-d66084344d90
+      - req-aa8c6840-0759-42da-a143-b3eed79bb31a
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -17037,27 +17038,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7c3afc54-d6eb-49e4-8edd-8b9d675c5eca
+      - req-70dad766-9073-4566-8d20-0f85b00afe52
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7c3afc54-d6eb-49e4-8edd-8b9d675c5eca
+      - req-70dad766-9073-4566-8d20-0f85b00afe52
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -17072,27 +17073,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12815f18-bcb0-4b0d-958b-a7fbf85715ed
+      - req-62d472fb-80e3-4529-b396-5b7492edf4fa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-12815f18-bcb0-4b0d-958b-a7fbf85715ed
+      - req-62d472fb-80e3-4529-b396-5b7492edf4fa
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -17107,27 +17108,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a070af36-a081-43ff-98ff-0b3d9a5d0a7d
+      - req-6b52e721-6b95-4402-9437-88d9a62b34d8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a070af36-a081-43ff-98ff-0b3d9a5d0a7d
+      - req-6b52e721-6b95-4402-9437-88d9a62b34d8
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:57 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -17142,27 +17143,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-85c5925f-17a5-4b5e-8f22-5a3ce065c2ca
+      - req-8f2d1b94-30da-4e15-948c-2ee839646cea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-85c5925f-17a5-4b5e-8f22-5a3ce065c2ca
+      - req-8f2d1b94-30da-4e15-948c-2ee839646cea
       Date:
-      - Mon, 06 Aug 2018 17:00:57 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -17177,22 +17178,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b70e41c-3e96-44e3-8f03-c6d8002f9573
+      - req-518d2bfc-dd3d-40f0-9d3e-b0f31a24ac65
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3b70e41c-3e96-44e3-8f03-c6d8002f9573
+      - req-518d2bfc-dd3d-40f0-9d3e-b0f31a24ac65
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17204,7 +17205,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17219,22 +17220,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a571e53cfef47c691c355add1c4cedc
+      - a534bcb0c30543b5956f1430f135ce3d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c31122cf-452d-4775-905e-d8a3682f9f78
+      - req-5eecc64f-6110-4fd2-80ea-141ee1c688d3
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c31122cf-452d-4775-905e-d8a3682f9f78
+      - req-5eecc64f-6110-4fd2-80ea-141ee1c688d3
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17246,7 +17247,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -17261,22 +17262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8186e4f5-aa19-4637-aa5f-64ea6ea5e994
+      - req-7a34fe96-c37e-474b-9999-e8e48f81194d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8186e4f5-aa19-4637-aa5f-64ea6ea5e994
+      - req-7a34fe96-c37e-474b-9999-e8e48f81194d
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17288,7 +17289,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17303,22 +17304,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b92fcc730654fd9ad60bf96c5991831
+      - ed5ff63e6f464702a6ada3cec614088b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d20b9c34-4e6d-43a2-ba2e-ffbdda171233
+      - req-a38ddbe0-a477-4e72-88df-d30ba08fd987
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d20b9c34-4e6d-43a2-ba2e-ffbdda171233
+      - req-a38ddbe0-a477-4e72-88df-d30ba08fd987
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17330,7 +17331,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -17345,22 +17346,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-605d667d-6f24-40cc-a38d-1e21806d75bf
+      - req-9110f300-4602-413b-bd92-9c0cbc86b621
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-605d667d-6f24-40cc-a38d-1e21806d75bf
+      - req-9110f300-4602-413b-bd92-9c0cbc86b621
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17372,7 +17373,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17387,22 +17388,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ecca10a7335e40c6acd2b26fe074b540
+      - 42d0ea920f614695a44b5a7f9b3c8c54
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6fe71af8-40fc-4971-9448-08fc12d927c5
+      - req-ffc049ec-f878-4952-86cd-2e79ea991385
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6fe71af8-40fc-4971-9448-08fc12d927c5
+      - req-ffc049ec-f878-4952-86cd-2e79ea991385
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17414,7 +17415,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -17429,22 +17430,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5cad3b8d-06f3-4632-a40d-0cee7fcf94f6
+      - req-b5ad66db-d91e-4e25-b3e8-2aadfec36c59
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-5cad3b8d-06f3-4632-a40d-0cee7fcf94f6
+      - req-b5ad66db-d91e-4e25-b3e8-2aadfec36c59
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17456,7 +17457,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:58 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -17471,22 +17472,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4b2148c4a29c42eebc12ac2874db78b4
+      - 8f73b44c7b024a7680c69ccf7d1d145c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9dd8bd54-3733-4523-bcce-d29fbd7263af
+      - req-04c5c212-e26e-48fb-b68e-6740c4228dcc
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9dd8bd54-3733-4523-bcce-d29fbd7263af
+      - req-04c5c212-e26e-48fb-b68e-6740c4228dcc
       Date:
-      - Mon, 06 Aug 2018 17:00:58 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -17498,7 +17499,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17516,13 +17517,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:59 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-56bc6e95-2a2c-4833-b1c2-665d3754cc64
+      - req-70b4d371-630e-48dd-bc4b-9a1a780787b7
       Content-Length:
       - '4170'
       Connection:
@@ -17531,10 +17532,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:59.356895", "expires":
-        "2018-08-06T18:00:59Z", "id": "9ece4ed0acd1448ba620add95468e992", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:16.303892", "expires":
+        "2018-09-24T21:31:16Z", "id": "d9d25612c98b450ea8bdf77a40fad690", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["eVAsx3ODRCqqWXDmH1yBBw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["U5-86OF0SkW5PNMx76qKXA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17579,7 +17580,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17597,13 +17598,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:00:59 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bb58ec10-52fd-4b06-8d9d-c879c0a68816
+      - req-e44c8515-307c-4fa9-9880-6057039bd142
       Content-Length:
       - '4170'
       Connection:
@@ -17612,10 +17613,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:00:59.678776", "expires":
-        "2018-08-06T18:00:59Z", "id": "45f160c86b294c10b6e3d7a643091f25", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:16.491874", "expires":
+        "2018-09-24T21:31:16Z", "id": "1cc35541ff8042d996b81db79e4d3662", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Cn25BO0ER5iRzI32SPyTNg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AUWjVKMuRc2y7aBvEwcdLg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17660,7 +17661,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:00:59 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17678,13 +17679,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:00 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7337f72f-11ac-4d03-a69e-fd914ea11ae7
+      - req-9f28e102-8e6a-4327-8bcc-0ac74327a800
       Content-Length:
       - '370'
       Connection:
@@ -17693,13 +17694,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.156061", "expires":
-        "2018-08-06T18:01:00Z", "id": "90e91a7adaf64453a4aed49510b22b64", "audit_ids":
-        ["8u6ZFriDTUaAZstcYEvd5Q"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:16.644791", "expires":
+        "2018-09-24T21:31:16Z", "id": "77f4839449694ee8a44bae8c3c10a7e7", "audit_ids":
+        ["Kq-CfqgoTUOwOf-cSoq2Yg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17714,20 +17715,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90e91a7adaf64453a4aed49510b22b64
+      - 77f4839449694ee8a44bae8c3c10a7e7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:00 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b797f3a1-5c89-4e30-bedd-ed2ca95fa3bd
+      - req-e1ac26ab-8e3c-4700-841f-cf461039f29b
       Content-Length:
       - '500'
       Connection:
@@ -17744,13 +17745,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"90e91a7adaf64453a4aed49510b22b64"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"77f4839449694ee8a44bae8c3c10a7e7"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -17762,13 +17763,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:00 GMT
+      - Mon, 24 Sep 2018 20:31:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7529acb6-2a97-4eb7-95a9-64c44c55f141
+      - req-6c55d441-81d3-422d-8d20-b5cd7108482b
       Content-Length:
       - '4143'
       Connection:
@@ -17777,11 +17778,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.531375", "expires":
-        "2018-08-06T18:01:00Z", "id": "86c878eee8e748cdb34b6dfb0a14db75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:16.937592", "expires":
+        "2018-09-24T21:31:16Z", "id": "a624f7341f524a15b484bf84f9b2d9d7", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GAPqqnsDROuDEFJ1n7NUyA",
-        "8u6ZFriDTUaAZstcYEvd5Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JYPCvNBuT9qLSW94eZ_GDQ",
+        "Kq-CfqgoTUOwOf-cSoq2Yg"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17825,7 +17826,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17840,20 +17841,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 90e91a7adaf64453a4aed49510b22b64
+      - 77f4839449694ee8a44bae8c3c10a7e7
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:00 GMT
+      - Mon, 24 Sep 2018 20:31:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c26d5238-c720-4974-9321-a2c676315b98
+      - req-7fcfe0ba-3856-417a-9647-c4e8e070ae59
       Content-Length:
       - '500'
       Connection:
@@ -17870,7 +17871,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17888,13 +17889,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:00 GMT
+      - Mon, 24 Sep 2018 20:31:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68f958eb-c27e-46c8-ba14-aa894a592f98
+      - req-b3a071ed-7fb3-4c85-8911-dd99eec29a41
       Content-Length:
       - '4117'
       Connection:
@@ -17903,10 +17904,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:00.946368", "expires":
-        "2018-08-06T18:01:00Z", "id": "1996949e0ece485f919c08922ee53f3c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:17.730760", "expires":
+        "2018-09-24T21:31:17Z", "id": "996b02a82ab7405eba726b773a38930e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8Yc7h-D-RJuvkJSdAmthIg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_9MuhhvgRjSTGZkWT0vrqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17950,7 +17951,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:00 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17968,13 +17969,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:01 GMT
+      - Mon, 24 Sep 2018 20:31:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6737788a-46e7-4985-81c4-3a533ae28c4a
+      - req-557c63a3-aadd-4374-8268-9c0392431da9
       Content-Length:
       - '4131'
       Connection:
@@ -17983,10 +17984,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.167810", "expires":
-        "2018-08-06T18:01:01Z", "id": "50139e013ace43889659a8fcc24b2c4a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:17.912346", "expires":
+        "2018-09-24T21:31:17Z", "id": "ad9326ab72eb42fdb595c6f8e9d24ecf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["pFNHDkheT4eJsI0H-PJLjw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_Al4fOI5TSyvcB_M01yWvw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18030,7 +18031,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18048,13 +18049,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:01 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b07460ea-16ff-4459-817f-23bf07ac9a66
+      - req-81c2b44d-abf1-486e-905f-df26240d4032
       Content-Length:
       - '4118'
       Connection:
@@ -18063,10 +18064,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.380979", "expires":
-        "2018-08-06T18:01:01Z", "id": "bddaef6a9b5043fc83089cc41d3d12c0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:18.096070", "expires":
+        "2018-09-24T21:31:18Z", "id": "3ce9233fab2a44608ce69991aaecad46", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["GwEWOIfUQp6Yd20_xqcSDg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5BH7vfruQdG6tBUNbZqBUw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18110,7 +18111,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18128,13 +18129,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:01 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-afb2d687-2c53-433b-bb2d-7a521559ad58
+      - req-46e6a39e-4dae-4fd4-b9c6-19ac6649f275
       Content-Length:
       - '4117'
       Connection:
@@ -18143,10 +18144,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:01.806168", "expires":
-        "2018-08-06T18:01:01Z", "id": "7b119a4e71b24f34bde66e9ce95ca112", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:18.287801", "expires":
+        "2018-09-24T21:31:18Z", "id": "ef852f7d6d324bdbb4eb692a847ac2d8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3jqFRqOGSEmn6VFNQONcjA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0Qq4WPx1QTK_r2rYPEZbIA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -18190,7 +18191,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:01 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -18205,7 +18206,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b119a4e71b24f34bde66e9ce95ca112
+      - ef852f7d6d324bdbb4eb692a847ac2d8
   response:
     status:
       code: 200
@@ -18234,15 +18235,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txa4694a32f50c493ba4a8d-005b687ecd
+      - txa1cde3cdbd79459e86819-005ba94996
       Date:
-      - Mon, 06 Aug 2018 17:01:02 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -18257,7 +18258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b119a4e71b24f34bde66e9ce95ca112
+      - ef852f7d6d324bdbb4eb692a847ac2d8
   response:
     status:
       code: 200
@@ -18286,14 +18287,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx92c0f8f7b78c404ea2227-005b687ece
+      - txad025a54b6ae494dbe6aa-005ba94996
       Date:
-      - Mon, 06 Aug 2018 17:01:02 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18311,13 +18312,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:02 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f71b15af-c75f-4b88-bec9-9194cf605246
+      - req-bd3bb17f-ef6c-4a7b-b415-1125a70452d4
       Content-Length:
       - '4131'
       Connection:
@@ -18326,10 +18327,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:02.386851", "expires":
-        "2018-08-06T18:01:02Z", "id": "ccd2b550728248fbbdb696b0d3befb5b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:18.719849", "expires":
+        "2018-09-24T21:31:18Z", "id": "e71c475e63ff4b1c9095cb2f6fbff1a8", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["38GPSHsdRdiSXkCQFgE3kg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hEOO1jc9RqCEZLDU56ZZYg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -18373,7 +18374,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -18388,7 +18389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ccd2b550728248fbbdb696b0d3befb5b
+      - e71c475e63ff4b1c9095cb2f6fbff1a8
   response:
     status:
       code: 200
@@ -18401,22 +18402,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574862.62021'
+      - '1537821078.87636'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574862.62021'
+      - '1537821078.87636'
       X-Trans-Id:
-      - tx5fe20d5a22704f19b4e21-005b687ece
+      - tx7ee98f48bf0e499daee50-005ba94996
       Date:
-      - Mon, 06 Aug 2018 17:01:02 GMT
+      - Mon, 24 Sep 2018 20:31:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -18431,7 +18432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 45f160c86b294c10b6e3d7a643091f25
+      - 1cc35541ff8042d996b81db79e4d3662
   response:
     status:
       code: 200
@@ -18444,22 +18445,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574862.97479'
+      - '1537821079.03219'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574862.97479'
+      - '1537821079.03219'
       X-Trans-Id:
-      - tx0aa5e04446214107aa8af-005b687ece
+      - tx1776a58c8a1645038254f-005ba94996
       Date:
-      - Mon, 06 Aug 2018 17:01:02 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:02 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -18477,13 +18478,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:03 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-29b6fdf8-ee31-4fa0-837d-d89f4f51a560
+      - req-af6c0f80-1563-4822-af6c-26c37bb797c9
       Content-Length:
       - '4118'
       Connection:
@@ -18492,10 +18493,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:03.175178", "expires":
-        "2018-08-06T18:01:03Z", "id": "34818cb6faf649dbab3eb4c53f3054d6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:31:19.216774", "expires":
+        "2018-09-24T21:31:19Z", "id": "466418c8f57e43458d19e8b0c2bdaebd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SWN9KzTlT7iKgaaV0Z0-HQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["TEW1QQ2rSL2D8Tfhd8WY7w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -18539,7 +18540,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -18554,7 +18555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 34818cb6faf649dbab3eb4c53f3054d6
+      - 466418c8f57e43458d19e8b0c2bdaebd
   response:
     status:
       code: 200
@@ -18567,22 +18568,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1533574863.42643'
+      - '1537821079.38162'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1533574863.42643'
+      - '1537821079.38162'
       X-Trans-Id:
-      - txe8a4acaf8294495b8fe1a-005b687ecf
+      - tx6264b9865a0c4eb48621d-005ba94997
       Date:
-      - Mon, 06 Aug 2018 17:01:03 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -18597,7 +18598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b119a4e71b24f34bde66e9ce95ca112
+      - ef852f7d6d324bdbb4eb692a847ac2d8
   response:
     status:
       code: 200
@@ -18618,9 +18619,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txf9a524465efc4dbaab667-005b687ecf
+      - txabe60bab31b147098cd81-005ba94997
       Date:
-      - Mon, 06 Aug 2018 17:01:03 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -18630,7 +18631,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -18645,7 +18646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b119a4e71b24f34bde66e9ce95ca112
+      - ef852f7d6d324bdbb4eb692a847ac2d8
   response:
     status:
       code: 200
@@ -18666,14 +18667,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx618a028b3ba84e1b8832a-005b687ecf
+      - tx2455e69404f2479b8daf2-005ba94997
       Date:
-      - Mon, 06 Aug 2018 17:01:03 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -18688,7 +18689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b119a4e71b24f34bde66e9ce95ca112
+      - ef852f7d6d324bdbb4eb692a847ac2d8
   response:
     status:
       code: 200
@@ -18709,14 +18710,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx92954e711d924d3984c48-005b687ecf
+      - txf8a5ec064a624c51a9a2a-005ba94997
       Date:
-      - Mon, 06 Aug 2018 17:01:03 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:03 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -18731,7 +18732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8b4e3d0c7114c7380c010a01a0a1efc
+      - 51c29ce8fa1d4c8f8e2f51573708987b
   response:
     status:
       code: 200
@@ -18742,9 +18743,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-4662da9c-434c-4b45-b506-60f98063ca17
+      - req-f5929b84-9e96-4966-807e-f96d69e1851f
       Date:
-      - Mon, 06 Aug 2018 17:01:04 GMT
+      - Mon, 24 Sep 2018 20:31:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -18754,7 +18755,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:05 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -18769,7 +18770,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b3fa122ed0614b90b5544d0b89f48bfe
+      - '092c121e3740489ea6adfa310e5cfd3a'
   response:
     status:
       code: 200
@@ -18780,317 +18781,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8229831c-5147-4b8d-a421-a9efeb8c1c30
+      - req-f65bdc73-f68e-42dc-b64a-c7fb9dddd4e2
       Date:
-      - Mon, 06 Aug 2018 17:01:05 GMT
+      - Mon, 24 Sep 2018 20:31:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:05 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - b3fa122ed0614b90b5544d0b89f48bfe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d9fe0ac1-58fa-4aa1-9648-3787776550b8
-      Date:
-      - Mon, 06 Aug 2018 17:01:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1db67d4e2a5140c4ae9d578e40ff869e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-85c1f3e3-67bf-46e5-9ed0-4af1acc017a3
-      Date:
-      - Mon, 06 Aug 2018 17:01:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -19137,74 +18833,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1db67d4e2a5140c4ae9d578e40ff869e
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c2e99c09-f035-4138-9b41-dc7878c0096a
-      Date:
-      - Mon, 06 Aug 2018 17:01:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -19246,29 +18874,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19282,7 +18887,140 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - '092c121e3740489ea6adfa310e5cfd3a'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-939acc9f-ed56-41a2-a7fd-8fc810f6e4b0
+      Date:
+      - Mon, 24 Sep 2018 20:31:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19297,7 +19035,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8b4e3d0c7114c7380c010a01a0a1efc
+      - 4c632f1b46c64cccbb8f382a2a88d219
   response:
     status:
       code: 200
@@ -19308,12 +19046,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f2e6c526-94ba-461a-b2ba-89f937c85a24
+      - req-e4dca4b0-aba3-40aa-8057-5bcb030dd405
       Date:
-      - Mon, 06 Aug 2018 17:01:06 GMT
+      - Mon, 24 Sep 2018 20:31:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -19354,53 +19133,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19414,7 +19152,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -19429,7 +19167,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8b4e3d0c7114c7380c010a01a0a1efc
+      - 4c632f1b46c64cccbb8f382a2a88d219
   response:
     status:
       code: 200
@@ -19440,53 +19178,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7f202ed7-022d-45b7-96d4-47e0a31257d3
+      - req-882b02d5-bb07-4131-b087-e473b8078b89
       Date:
-      - Mon, 06 Aug 2018 17:01:06 GMT
+      - Mon, 24 Sep 2018 20:31:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -19533,20 +19230,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19561,7 +19299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9109594d130493facbc8bf5abc8cf9a
+      - 51c29ce8fa1d4c8f8e2f51573708987b
   response:
     status:
       code: 200
@@ -19572,113 +19310,114 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ebf8ff34-88bd-4d17-9285-16711f47d7cf
+      - req-fa8ad58b-85ce-4e9a-9644-f6031cddaa3d
       Date:
-      - Mon, 06 Aug 2018 17:01:06 GMT
+      - Mon, 24 Sep 2018 20:31:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:06 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -19693,7 +19432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e9109594d130493facbc8bf5abc8cf9a
+      - 51c29ce8fa1d4c8f8e2f51573708987b
   response:
     status:
       code: 200
@@ -19704,12 +19443,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-43a73b3e-9ead-47e2-ab3b-ae05c679490b
+      - req-72a7f7c1-cee9-49df-b9c3-3869ed10714b
       Date:
-      - Mon, 06 Aug 2018 17:01:07 GMT
+      - Mon, 24 Sep 2018 20:31:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -19750,53 +19530,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -19810,5 +19549,270 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:07 GMT
+  recorded_at: Mon, 24 Sep 2018 20:31:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5d41b615cff44d829353c49af2616fc4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-239eb9a6-c497-4656-8b7a-d73863e15f15
+      Date:
+      - Mon, 24 Sep 2018 20:31:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:31:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 5d41b615cff44d829353c49af2616fc4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-188ddcb0-7cfe-4e79-b0b0-7038970dfac0
+      Date:
+      - Mon, 24 Sep 2018 20:31:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:31:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:50 GMT
+      - Mon, 24 Sep 2018 20:30:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e99cdf84-ad27-4c1f-8345-0dcce211ffd3
+      - req-28ed2a35-3d4f-4af5-a20b-7f4ac2aab17b
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.460559", "expires":
-        "2018-08-06T18:01:50Z", "id": "5a95816840f74809af3d2ba263c72526", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:15.817328", "expires":
+        "2018-09-24T21:30:15Z", "id": "1cae86a5f15343b9b6534561ecb14668", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["JB18f2erRQ29gh2no0t68g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["q4SxyPPNQEmzv0to7wdz0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5a95816840f74809af3d2ba263c72526
+      - 1cae86a5f15343b9b6534561ecb14668
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:50 GMT
+      - Mon, 24 Sep 2018 20:30:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:50 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-906359dc-fb28-4e1d-b5b2-f9dd70983dbe
+      - req-8cccd183-e9d8-4b2a-95e2-d5048e3a28d0
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.739933", "expires":
-        "2018-08-06T18:01:50Z", "id": "c35c10b5575242ceb871e386b5d8014f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:16.089282", "expires":
+        "2018-09-24T21:30:16Z", "id": "98e3f595661841e2a487a21492d6c814", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6GRIfBDFQ3KXuVfOoackXQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_GSkQowHT0aFtuWP--fFcg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c35c10b5575242ceb871e386b5d8014f
+      - 98e3f595661841e2a487a21492d6c814
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 17:01:50 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:50 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:50 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8707172f-3773-4f3f-9986-93300a46e0ac
+      - req-a4514ea3-fd96-4cfa-a8a2-fba0ea0c6135
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +261,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:50.979519", "expires":
-        "2018-08-06T18:01:50Z", "id": "37456e079baf40efa98bec32f0629f1d", "audit_ids":
-        ["yoGSA-3FQMOQzNoiL70LwQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:16.318182", "expires":
+        "2018-09-24T21:30:16Z", "id": "176ffdce172945eabe3f1497a46896cc", "audit_ids":
+        ["rEvJKJ3jTRWTqH2PYiSizA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +282,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37456e079baf40efa98bec32f0629f1d
+      - 176ffdce172945eabe3f1497a46896cc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-deca35cb-610b-4429-b0b5-0552ca4c6d89
+      - req-41406fc9-07f2-41cd-8737-ca93d951529f
       Content-Length:
       - '500'
       Connection:
@@ -312,13 +312,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"37456e079baf40efa98bec32f0629f1d"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"176ffdce172945eabe3f1497a46896cc"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -330,13 +330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a33c6c6b-9f78-45b6-a38f-399589da106e
+      - req-5815c4b4-6714-418f-8876-9ad6ba1153fb
       Content-Length:
       - '4143'
       Connection:
@@ -345,11 +345,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.308010", "expires":
-        "2018-08-06T18:01:50Z", "id": "b9a23c90ac054253812f3d4dff7c898c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:16.619488", "expires":
+        "2018-09-24T21:30:16Z", "id": "64277e7ea9164c538f599a9c05023334", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XxTvjm2RSm6_r6Z6flNtcw",
-        "yoGSA-3FQMOQzNoiL70LwQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["s9AOBTX4QGKBTDxwuBrDaQ",
+        "rEvJKJ3jTRWTqH2PYiSizA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -393,7 +393,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37456e079baf40efa98bec32f0629f1d
+      - 176ffdce172945eabe3f1497a46896cc
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e49d11e-f3f2-4d66-8b9f-5474a4ae52bf
+      - req-9a59c2d0-9f1c-4a00-941d-6a694b5d3ee9
       Content-Length:
       - '500'
       Connection:
@@ -438,7 +438,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48aa9b90-d62f-4e10-8e70-4e207147fe05
+      - req-c1c77497-e2e5-4a00-a00d-d67a8af27f26
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +471,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.686703", "expires":
-        "2018-08-06T18:01:51Z", "id": "fdd80dc78b764471896cf79595ce70ba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:16.976652", "expires":
+        "2018-09-24T21:30:16Z", "id": "cf310319947048e1a83a234f0b09c35b", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["grDLvqkQSUq68_XOtRc7Dw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LZdpElb2TROufIrO4pNaJQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +518,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fdd80dc78b764471896cf79595ce70ba
+      - cf310319947048e1a83a234f0b09c35b
   response:
     status:
       code: 200
@@ -544,7 +544,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +553,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:51 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +571,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:51 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d51fb4e-2217-4b1c-9267-99c49094dd6d
+      - req-7891272c-d1a9-40cf-9b33-c718b0ad359b
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +586,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:51.994659", "expires":
-        "2018-08-06T18:01:51Z", "id": "11ac600211d44f76aa8ac48581e9deac", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:17.246742", "expires":
+        "2018-09-24T21:30:17Z", "id": "643a6d892af64be1b836472e06bfd3f6", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["3xv88PHFSlqoipqVYqaJyg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["6C_5gVb_RyWnkZXuRXL6tg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +633,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 11ac600211d44f76aa8ac48581e9deac
+      - 643a6d892af64be1b836472e06bfd3f6
   response:
     status:
       code: 200
@@ -659,7 +659,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:52 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +668,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +686,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:52 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-285ada13-1ecb-4c15-a024-86a6cfb57d9e
+      - req-4b0d6627-f897-4ff9-b3f6-661f70674788
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +701,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:52.291978", "expires":
-        "2018-08-06T18:01:52Z", "id": "33a96c37a8f34836aaea0039a364eb2a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:17.511574", "expires":
+        "2018-09-24T21:30:17Z", "id": "1bfd4c4345ba4705a7c6015ee9f32958", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["268iTP_JS0i3GhljHbaZ9g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xqupoi_XRaGIdM3UECMCPg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +748,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33a96c37a8f34836aaea0039a364eb2a
+      - 1bfd4c4345ba4705a7c6015ee9f32958
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:52 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +801,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:52 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e6d3f3f3-13ab-4393-9559-6ef05cd99755
+      - req-cd51678b-6ac7-41ad-8815-8b3d6f72a639
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +816,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:52.595855", "expires":
-        "2018-08-06T18:01:52Z", "id": "7733b1d636b247e0b1f7cef2274ccdf6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:17.771964", "expires":
+        "2018-09-24T21:30:17Z", "id": "df6a1af8653d4ff2b0cb37efb00897e9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Y1x5fDV-SLiVYdqdk5UiTg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["8xtpXIgaQKKI9mwa6MW7DA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +863,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:52 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7733b1d636b247e0b1f7cef2274ccdf6
+      - df6a1af8653d4ff2b0cb37efb00897e9
   response:
     status:
       code: 200
@@ -889,185 +889,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7dfab56d-c4ab-4b0b-a401-37a4b33b2d46
+      - req-60db713d-bfb2-4499-9277-0242ce232561
       Date:
-      - Mon, 06 Aug 2018 17:01:52 GMT
+      - Mon, 24 Sep 2018 20:30:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7733b1d636b247e0b1f7cef2274ccdf6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4cd03230-87d8-47fb-ad59-9d8d16a1bf36
-      Date:
-      - Mon, 06 Aug 2018 17:01:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1114,154 +941,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 06 Aug 2018 17:01:53 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-b0592fbe-6bc1-44b0-8df2-b65bdcf6ee5a
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:53.570275", "expires":
-        "2018-08-06T18:01:53Z", "id": "a261a05cf3864bcba15a9b487e8d8093", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ov9WnPJbSkKg1qYjGw7D0w"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a261a05cf3864bcba15a9b487e8d8093
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-acc6d49e-5f99-4c45-835e-2629a5de0c24
-      Date:
-      - Mon, 06 Aug 2018 17:01:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -1303,29 +982,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1339,7 +995,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:53 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1354,7 +1010,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a261a05cf3864bcba15a9b487e8d8093
+      - df6a1af8653d4ff2b0cb37efb00897e9
   response:
     status:
       code: 200
@@ -1365,529 +1021,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-45f5fd41-0914-4629-bf4e-3c2a56d5a29f
+      - req-32da8746-ca2f-4976-bd09-986f1ce2502b
       Date:
-      - Mon, 06 Aug 2018 17:01:54 GMT
+      - Mon, 24 Sep 2018 20:30:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c35c10b5575242ceb871e386b5d8014f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c74f709f-b7d4-4bdc-8a3a-3d6c9615423b
-      Date:
-      - Mon, 06 Aug 2018 17:01:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - c35c10b5575242ceb871e386b5d8014f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a7475491-7ec3-4aa1-86a8-6446eedecbb1
-      Date:
-      - Mon, 06 Aug 2018 17:01:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 06 Aug 2018 17:01:54 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-632a7134-1115-43b8-a0d1-2f5b03be7302
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:54.936107", "expires":
-        "2018-08-06T18:01:54Z", "id": "e6bbd7b654644c1999c1e689fdfd30aa", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["t6aT_XpnSy-3yV1oIh3nQg"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:54 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e6bbd7b654644c1999c1e689fdfd30aa
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ebbfe071-5148-4e80-aff6-fc91c52c923e
-      Date:
-      - Mon, 06 Aug 2018 17:01:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1934,20 +1073,273 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Sep 2018 20:30:18 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-9256d7fa-edad-4130-b90c-d083440e9d58
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:18.313217", "expires":
+        "2018-09-24T21:30:18Z", "id": "b1555c178e9e4962aa7fb5f25ff59d7a", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["IQle7R3ISIu2FiqVajuj9Q"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - b1555c178e9e4962aa7fb5f25ff59d7a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d723067d-5970-4843-b885-d209e2ff9106
+      Date:
+      - Mon, 24 Sep 2018 20:30:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1962,7 +1354,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e6bbd7b654644c1999c1e689fdfd30aa
+      - b1555c178e9e4962aa7fb5f25ff59d7a
   response:
     status:
       code: 200
@@ -1973,12 +1365,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9ad5c206-64db-4715-aa2e-bb06020d0a10
+      - req-6c8da437-2f6b-41ef-a469-3950aac0739f
       Date:
-      - Mon, 06 Aug 2018 17:01:55 GMT
+      - Mon, 24 Sep 2018 20:30:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2043,7 +1458,51 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 98e3f595661841e2a487a21492d6c814
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5760a6b7-d2df-4a98-b0f0-0939395957df
+      Date:
+      - Mon, 24 Sep 2018 20:30:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -2066,6 +1525,71 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2079,7 +1603,484 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 98e3f595661841e2a487a21492d6c814
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-22e7df19-308d-494f-a670-ab12fe34cb10
+      Date:
+      - Mon, 24 Sep 2018 20:30:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:19 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Sep 2018 20:30:19 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-53cf79ea-3edd-46a9-ad37-2b12899ffdb1
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:19.292851", "expires":
+        "2018-09-24T21:30:19Z", "id": "629644fbb4ec42b8b0a7aec5687fac72", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["aqUzWxiDRdWOOmFxobD69Q"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 629644fbb4ec42b8b0a7aec5687fac72
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-09f1684a-b4b0-478f-8348-cc67b83d3a01
+      Date:
+      - Mon, 24 Sep 2018 20:30:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 629644fbb4ec42b8b0a7aec5687fac72
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0cf0687d-a388-46b4-8937-9bd2e3938e1b
+      Date:
+      - Mon, 24 Sep 2018 20:30:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -2094,7 +2095,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c35c10b5575242ceb871e386b5d8014f
+      - 98e3f595661841e2a487a21492d6c814
   response:
     status:
       code: 200
@@ -2105,9 +2106,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-5d96e067-7190-4421-a63e-9cfcdd58d131
+      - req-62e5aa6d-cdb9-4977-bfd8-22cab6d1a633
       Date:
-      - Mon, 06 Aug 2018 17:01:55 GMT
+      - Mon, 24 Sep 2018 20:30:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2122,5 +2123,5 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:55 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:19 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:38 GMT
+      - Mon, 24 Sep 2018 20:30:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-496e0c16-c017-46b8-a91e-14fea61e6f9e
+      - req-eab09484-4642-4627-b6f8-e481a576e618
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.170184", "expires":
-        "2018-08-06T17:59:39Z", "id": "36135bd8d3c04167b41436b53a798a32", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:26.011228", "expires":
+        "2018-09-24T21:30:25Z", "id": "33d001d34b2c4038946f2cf6360201cc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["spIkHwZCQge83i_v4gU35A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4NqOXs0ERYSpuz3Ulvur1w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 36135bd8d3c04167b41436b53a798a32
+      - 33d001d34b2c4038946f2cf6360201cc
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:39 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:39 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b6c02fc-c24f-4092-a689-abd4407ca72c
+      - req-622b70dd-3ae4-41c2-b18f-af5b8df8f969
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.647531", "expires":
-        "2018-08-06T17:59:39Z", "id": "c1c3a99b350e48339113a3da4355ce77", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:26.270208", "expires":
+        "2018-09-24T21:30:26Z", "id": "42a9d1a2e42e493096357ea616e7f007", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["t2aAAtPER4-rwajPNdvDqw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["37W3ssMwQwi_kFjkjE_u4g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -211,7 +211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1c3a99b350e48339113a3da4355ce77
+      - 42a9d1a2e42e493096357ea616e7f007
   response:
     status:
       code: 200
@@ -222,13 +222,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 16:59:39 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -246,13 +246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:39 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ffb22683-68ec-4e0a-919a-1f9758ff410e
+      - req-1097b504-a1f8-4b01-82af-f9abb85154f3
       Content-Length:
       - '370'
       Connection:
@@ -261,13 +261,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:39.963630", "expires":
-        "2018-08-06T17:59:39Z", "id": "ab8b05a08e584e2cb1513a1bdf2bb65a", "audit_ids":
-        ["MhytMwrdTgOw6GXM_wfeLQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:26.503044", "expires":
+        "2018-09-24T21:30:26Z", "id": "c154ca45c5d74248bdc4b4d1b646a6a6", "audit_ids":
+        ["ciTfhnR8Q-Gp4-jqHQ4X4Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -282,20 +282,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab8b05a08e584e2cb1513a1bdf2bb65a
+      - c154ca45c5d74248bdc4b4d1b646a6a6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:40 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0ebad9d7-e79e-4c7a-a0b2-33bb97fdfb99
+      - req-5da60298-23ce-4e64-a699-e956d6b37fcf
       Content-Length:
       - '500'
       Connection:
@@ -312,13 +312,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"ab8b05a08e584e2cb1513a1bdf2bb65a"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"c154ca45c5d74248bdc4b4d1b646a6a6"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -330,13 +330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:40 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fac52739-9f9d-4058-9e88-c55487583ebd
+      - req-948c9357-e80c-4ec4-8ea2-180cfaf714ba
       Content-Length:
       - '4143'
       Connection:
@@ -345,11 +345,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:40.468400", "expires":
-        "2018-08-06T17:59:39Z", "id": "b71c3c1f0ba742ab838ac248703a2723", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:26.798892", "expires":
+        "2018-09-24T21:30:26Z", "id": "c20afb06249a43ef9c9faa9a8979de6c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KP_lh-N4R8-j9irgMWmzQQ",
-        "MhytMwrdTgOw6GXM_wfeLQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["w7kOmCR1TX-oK4jNFwOzCw",
+        "ciTfhnR8Q-Gp4-jqHQ4X4Q"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -393,7 +393,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ab8b05a08e584e2cb1513a1bdf2bb65a
+      - c154ca45c5d74248bdc4b4d1b646a6a6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:40 GMT
+      - Mon, 24 Sep 2018 20:30:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-edef366a-1822-4fe3-9c8e-99ecbf3f7776
+      - req-9f1f1f47-d5eb-49cf-9a47-59ba30838fc3
       Content-Length:
       - '500'
       Connection:
@@ -438,7 +438,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:40 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-080eb5b3-9eac-4be0-931d-a723d0a8b78c
+      - req-a14c13ee-c518-4e99-86f9-cad99f5b3643
       Content-Length:
       - '4117'
       Connection:
@@ -471,10 +471,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.019845", "expires":
-        "2018-08-06T17:59:40Z", "id": "86ed377f68d84ee99592ce64e33a7dbb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:27.112838", "expires":
+        "2018-09-24T21:30:27Z", "id": "59c21b7e418143adb0f0bda81d6f8489", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["x0ey1kMGT_Sap-w-3s51cw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["JLsPDDHsSJyuHD5ySvFjYQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -518,7 +518,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -533,7 +533,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 86ed377f68d84ee99592ce64e33a7dbb
+      - 59c21b7e418143adb0f0bda81d6f8489
   response:
     status:
       code: 200
@@ -544,7 +544,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:41 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -553,7 +553,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -571,13 +571,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:41 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0c4dffd2-e3aa-4260-8bee-b1f02d597b4a
+      - req-d05ee98c-e80e-4c22-951d-ea68169f4cd9
       Content-Length:
       - '4131'
       Connection:
@@ -586,10 +586,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.411701", "expires":
-        "2018-08-06T17:59:41Z", "id": "249087e25526445dac77ca9602389bde", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:27.373092", "expires":
+        "2018-09-24T21:30:27Z", "id": "987b7f40354a48749d9a563a65433437", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["B07dGMfGRVu4lWrz-VIFXw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["WMa_PzTvRDKqT9VCehkRNw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -633,7 +633,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -648,7 +648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 249087e25526445dac77ca9602389bde
+      - 987b7f40354a48749d9a563a65433437
   response:
     status:
       code: 200
@@ -659,7 +659,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:41 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -668,7 +668,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -686,13 +686,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:41 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-700dc967-537b-43fd-adc6-56264a4a4fd1
+      - req-63ed2563-b2e3-4ab8-be3c-77601c5a91b1
       Content-Length:
       - '4118'
       Connection:
@@ -701,10 +701,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:41.793285", "expires":
-        "2018-08-06T17:59:41Z", "id": "ee90bcb6e62b445d992c4aecc0783f37", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:27.633162", "expires":
+        "2018-09-24T21:30:27Z", "id": "5420331b0c4946c9ad9528f01921050b", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3D9ZyS0jT_KASe0zUUxkcA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vQfrzy0HR8Cov0R1jXt0yA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -748,7 +748,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -763,7 +763,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ee90bcb6e62b445d992c4aecc0783f37
+      - 5420331b0c4946c9ad9528f01921050b
   response:
     status:
       code: 200
@@ -774,7 +774,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 16:59:41 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -783,7 +783,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -801,13 +801,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:42 GMT
+      - Mon, 24 Sep 2018 20:30:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-54b90340-8d88-404b-9cc4-4431f8e67a1d
+      - req-c9bf286e-91e1-4014-a261-88fb702d102d
       Content-Length:
       - '4117'
       Connection:
@@ -816,10 +816,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:42.079606", "expires":
-        "2018-08-06T17:59:42Z", "id": "0899ff7c58974735a7edb167d2178d60", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:27.895537", "expires":
+        "2018-09-24T21:30:27Z", "id": "35060bbd82b24bec9a81162def7adc4e", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["iA4JT8HxTNylTXSRZpjR0w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["G0v0en2tSDGPSDCyyb7N1g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -863,7 +863,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -878,7 +878,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0899ff7c58974735a7edb167d2178d60'
+      - 35060bbd82b24bec9a81162def7adc4e
   response:
     status:
       code: 200
@@ -889,27 +889,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-adb5939f-a3bf-4254-990e-76d597825884
+      - req-aa54de31-dc44-4ed8-a6f2-58a705eb0a41
       Date:
-      - Mon, 06 Aug 2018 16:59:42 GMT
+      - Mon, 24 Sep 2018 20:30:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -958,30 +976,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -995,7 +995,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1010,7 +1010,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0899ff7c58974735a7edb167d2178d60'
+      - 35060bbd82b24bec9a81162def7adc4e
   response:
     status:
       code: 200
@@ -1021,9 +1021,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-89abb468-ae16-4871-bf28-bec119ea364a
+      - req-d4d38bf1-8253-43ed-8534-b6489b645812
       Date:
-      - Mon, 06 Aug 2018 16:59:42 GMT
+      - Mon, 24 Sep 2018 20:30:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -1127,7 +1127,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1145,13 +1145,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:42 GMT
+      - Mon, 24 Sep 2018 20:30:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9fc84881-cc7d-475d-9695-2f86b572c96a
+      - req-c4752375-3d1c-47d6-9fc5-3f23f04da397
       Content-Length:
       - '4131'
       Connection:
@@ -1160,10 +1160,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:42.878084", "expires":
-        "2018-08-06T17:59:42Z", "id": "09fee8bbfe834cc1a7eb3b714b7d17db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:28.513634", "expires":
+        "2018-09-24T21:30:28Z", "id": "95d71a94379e46e3b274ea2ff6659479", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["378JHu4RSAOZvyZfNYIEHg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["42aScNVLRjSyG1kqEL3PAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1207,7 +1207,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1222,7 +1222,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09fee8bbfe834cc1a7eb3b714b7d17db'
+      - 95d71a94379e46e3b274ea2ff6659479
   response:
     status:
       code: 200
@@ -1233,69 +1233,53 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e39bb477-85cd-4f93-8f08-9df94aa7f413
+      - req-710eb0b3-f0eb-4506-a8b9-a851f3c50e04
       Date:
-      - Mon, 06 Aug 2018 16:59:43 GMT
+      - Mon, 24 Sep 2018 20:30:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
@@ -1308,18 +1292,35 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
@@ -1339,7 +1340,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1354,7 +1355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '09fee8bbfe834cc1a7eb3b714b7d17db'
+      - 95d71a94379e46e3b274ea2ff6659479
   response:
     status:
       code: 200
@@ -1365,27 +1366,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c0a396d9-54aa-4189-8c1a-b6a071325fb0
+      - req-1cec423c-faad-4281-804d-e97c05229355
       Date:
-      - Mon, 06 Aug 2018 16:59:43 GMT
+      - Mon, 24 Sep 2018 20:30:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1434,30 +1453,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1471,7 +1472,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1486,7 +1487,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1c3a99b350e48339113a3da4355ce77
+      - 42a9d1a2e42e493096357ea616e7f007
   response:
     status:
       code: 200
@@ -1497,9 +1498,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-0e01c5b4-69d4-436d-abb7-988276e06e95
+      - req-f90436af-a28c-449d-997d-c9f54694f161
       Date:
-      - Mon, 06 Aug 2018 16:59:43 GMT
+      - Mon, 24 Sep 2018 20:30:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -1603,7 +1604,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1618,7 +1619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1c3a99b350e48339113a3da4355ce77
+      - 42a9d1a2e42e493096357ea616e7f007
   response:
     status:
       code: 200
@@ -1629,9 +1630,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3772cec9-c82a-4016-b9cb-762a0b0c1a6a
+      - req-263ac3f1-4397-429a-beaf-ffcc3c30dbaa
       Date:
-      - Mon, 06 Aug 2018 16:59:48 GMT
+      - Mon, 24 Sep 2018 20:30:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -1735,7 +1736,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1753,13 +1754,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 16:59:48 GMT
+      - Mon, 24 Sep 2018 20:30:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9568556d-4cac-4b48-abfe-53e9eb23c191
+      - req-6cbc5b5e-2d5a-471e-9d67-a8c52be68d78
       Content-Length:
       - '4118'
       Connection:
@@ -1768,10 +1769,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T16:59:48.933473", "expires":
-        "2018-08-06T17:59:48Z", "id": "1ce09af7174e4e5d8f57664e808b2604", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:29.416523", "expires":
+        "2018-09-24T21:30:29Z", "id": "909daeaddd8549ad96ab90cb2ed609d1", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["u2r2ouiQSPO6yV9lb0Jb8A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ZDkA1Nk5QvyTqsH5fC6DOw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1815,7 +1816,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1830,7 +1831,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ce09af7174e4e5d8f57664e808b2604
+      - 909daeaddd8549ad96ab90cb2ed609d1
   response:
     status:
       code: 200
@@ -1841,141 +1842,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1aea8e98-146a-45e9-900f-0dedc1e45ded
+      - req-8de3d45f-84c6-48bd-ba3d-18451b06eb66
       Date:
-      - Mon, 06 Aug 2018 16:59:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1ce09af7174e4e5d8f57664e808b2604
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-336198b9-65e0-413f-b35c-3237b3aee114
-      Date:
-      - Mon, 06 Aug 2018 16:59:49 GMT
+      - Mon, 24 Sep 2018 20:30:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
@@ -2079,7 +1948,140 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 909daeaddd8549ad96ab90cb2ed609d1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3bdb1adc-a485-4681-ac06-8f6e1abb4e3e
+      Date:
+      - Mon, 24 Sep 2018 20:30:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -2094,7 +2096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1c3a99b350e48339113a3da4355ce77
+      - 42a9d1a2e42e493096357ea616e7f007
   response:
     status:
       code: 200
@@ -2105,9 +2107,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-1bc1666f-4975-49f6-bbb7-d36c8398ed32
+      - req-8c77a919-eae8-4219-9382-6ea6feeb4d7a
       Date:
-      - Mon, 06 Aug 2018 16:59:49 GMT
+      - Mon, 24 Sep 2018 20:30:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -2116,5 +2118,5 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 16:59:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:08 GMT
+      - Mon, 24 Sep 2018 20:30:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-407ebd37-42c6-4a87-97f6-ee246caac22f
+      - req-b500d479-f5d6-4b96-9a32-ea7372b45163
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:08.387326", "expires":
-        "2018-08-06T18:01:08Z", "id": "4133bedfa1114d0e89eb0e37879f1668", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:30.905334", "expires":
+        "2018-09-24T21:30:30Z", "id": "ab507e4ce59d48bfa77073598ff54c9c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["0REhtG72Rse_5jeR08nvpQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bu58NXgwSPqDFCxoZybNyA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4133bedfa1114d0e89eb0e37879f1668
+      - ab507e4ce59d48bfa77073598ff54c9c
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:08 GMT
+      - Mon, 24 Sep 2018 20:30:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:08 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4f0e0741-942c-464d-9a28-e512ef5f7612
+      - req-5d189593-f6e1-4ae2-ad6d-3ac887c158e5
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:08.690472", "expires":
-        "2018-08-06T18:01:08Z", "id": "37527ba51d1e47b1a77fe5eb86a4a1ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:31.172517", "expires":
+        "2018-09-24T21:30:31Z", "id": "25666fa0bf494ccca5225581feaec2a5", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pZFRUfOYSh-dkdzhSpMLQQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["IEDFO-u1QS-m993ygZv_SQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37527ba51d1e47b1a77fe5eb86a4a1ed
+      - 25666fa0bf494ccca5225581feaec2a5
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:08 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-14259d9a-ac2b-4eb4-8a91-6a375d1b853f
+      - req-637cf372-d858-4d41-a786-75b591bcdc7d
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:08 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:08 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d5ee14c9-487b-4a89-b5b4-8b2b30b717cc
+      - req-0e3a75a5-27a0-43b6-8bbe-f42ca2362329
       Content-Length:
       - '4117'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:09.049997", "expires":
-        "2018-08-06T18:01:09Z", "id": "8c995389c85a41f4801fb8446fa3a56a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:31.486740", "expires":
+        "2018-09-24T21:30:31Z", "id": "25f6779b43624f08bb3304174ddeeed3", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tY-OkjIUTRuCikuA11uSrw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lKAUqsZURoiRGWfpTFs7Cw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -321,7 +321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -336,7 +336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c995389c85a41f4801fb8446fa3a56a
+      - 25f6779b43624f08bb3304174ddeeed3
   response:
     status:
       code: 200
@@ -347,9 +347,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-117e610e-bafa-4df2-a26b-9577bcbca667
+      - req-a96972ab-f5c3-4e6e-928e-b7c9151dc9dc
       Date:
-      - Mon, 06 Aug 2018 17:01:09 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -383,7 +383,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -398,7 +398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c995389c85a41f4801fb8446fa3a56a
+      - 25f6779b43624f08bb3304174ddeeed3
   response:
     status:
       code: 200
@@ -409,9 +409,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-0eeb1cae-4f54-4f5b-bf8b-408d7cf2b723
+      - req-7ed09a2b-259b-408a-a82b-10199d307689
       Date:
-      - Mon, 06 Aug 2018 17:01:09 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -467,7 +467,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -482,7 +482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c995389c85a41f4801fb8446fa3a56a
+      - 25f6779b43624f08bb3304174ddeeed3
   response:
     status:
       code: 200
@@ -493,9 +493,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b2933088-3ee4-4546-816f-f0034eb2287a
+      - req-cfa50ae8-ea6d-4a56-9d48-7bec0d099562
       Date:
-      - Mon, 06 Aug 2018 17:01:09 GMT
+      - Mon, 24 Sep 2018 20:30:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -507,7 +507,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:09 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -525,13 +525,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:14 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-995e056c-1f27-4a07-b6e1-ea5e8436dc0a
+      - req-88d8a809-1138-4408-a71f-479f6b112c29
       Content-Length:
       - '4170'
       Connection:
@@ -540,10 +540,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:15.028292", "expires":
-        "2018-08-06T18:01:14Z", "id": "44c5ae1b11214ff09c99669c1b030c56", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:32.180345", "expires":
+        "2018-09-24T21:30:32Z", "id": "be864a6d2cbb4a6bbe75e7bd929893df", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mNd3ZyCQQuKR7oXnzqKb3A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xfVOjerNQfGLXfAEuMfxPA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -588,7 +588,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:15 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -603,7 +603,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 44c5ae1b11214ff09c99669c1b030c56
+      - be864a6d2cbb4a6bbe75e7bd929893df
   response:
     status:
       code: 200
@@ -614,13 +614,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 17:01:16 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -638,13 +638,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:16 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3615aa26-8411-4e05-9d87-cb3c7fdb10c1
+      - req-204bc32e-6cb0-4793-803b-0a7bd42eabcf
       Content-Length:
       - '370'
       Connection:
@@ -653,13 +653,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:16.291634", "expires":
-        "2018-08-06T18:01:16Z", "id": "cbe4abbb36dc4a889d310ca4572d25cc", "audit_ids":
-        ["0tznGvS6QReO6e5x-yP27g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:32.414133", "expires":
+        "2018-09-24T21:30:32Z", "id": "396ee370be494009a0ccdbe29b3f8760", "audit_ids":
+        ["LdUY4CwgT6OoHDkvlj1Dmw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -674,20 +674,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cbe4abbb36dc4a889d310ca4572d25cc
+      - 396ee370be494009a0ccdbe29b3f8760
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:16 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c9b5e4e-8138-47ab-8436-afc9c655b90f
+      - req-40001631-3636-41f9-a88a-853b219e238a
       Content-Length:
       - '500'
       Connection:
@@ -704,13 +704,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"cbe4abbb36dc4a889d310ca4572d25cc"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"396ee370be494009a0ccdbe29b3f8760"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -722,13 +722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:16 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1d6152c0-ab48-4991-a20d-82b54c283691
+      - req-74aeac56-a90f-4aa8-9555-b784d9b58930
       Content-Length:
       - '4143'
       Connection:
@@ -737,11 +737,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:16.939224", "expires":
-        "2018-08-06T18:01:16Z", "id": "a274401090e24370bb2deee0c01aca1c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:32.706410", "expires":
+        "2018-09-24T21:30:32Z", "id": "5279a942feae4fdbae347cc8b7617947", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zISP-pOmQXalDjRXduFgXQ",
-        "0tznGvS6QReO6e5x-yP27g"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["YbhS_dzrQzqcPLsWPvW3Gg",
+        "LdUY4CwgT6OoHDkvlj1Dmw"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -785,7 +785,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:16 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -800,20 +800,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cbe4abbb36dc4a889d310ca4572d25cc
+      - 396ee370be494009a0ccdbe29b3f8760
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d48e9eeb-d32d-4f35-8162-98e40a9d057a
+      - req-369639c0-2f80-41bd-a84a-921e7a0a40de
       Content-Length:
       - '500'
       Connection:
@@ -830,7 +830,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -848,13 +848,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-18632503-b97b-4e21-8244-ac0c7883f3db
+      - req-e2ae9869-9aaf-4943-b95a-03cc588a7651
       Content-Length:
       - '4117'
       Connection:
@@ -863,10 +863,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.290243", "expires":
-        "2018-08-06T18:01:17Z", "id": "c85208321df140ef8f6d84512c8aaf81", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:33.015314", "expires":
+        "2018-09-24T21:30:32Z", "id": "3695aa5193064a708974680036eed589", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fojVoLNWQP-dKJhc_ur7SQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FiEXaXv6Qx6LMKcnNgTtpQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -910,7 +910,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -925,7 +925,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c85208321df140ef8f6d84512c8aaf81
+      - 3695aa5193064a708974680036eed589
   response:
     status:
       code: 200
@@ -936,7 +936,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -945,7 +945,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -963,13 +963,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c2060bae-5348-4deb-a39f-a87406b828f1
+      - req-921c2a07-7fea-48c9-8244-258da9a48a24
       Content-Length:
       - '4131'
       Connection:
@@ -978,10 +978,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.566898", "expires":
-        "2018-08-06T18:01:17Z", "id": "97dd9f1f0ec54eea8878a668370faedd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:33.292313", "expires":
+        "2018-09-24T21:30:33Z", "id": "71d2b7b9f40b4092b58728f220eb17dc", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ta_RSzMoThm5_2YXPYj17Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MzuwxzccSm6bWJCMDKHagg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1025,7 +1025,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1040,7 +1040,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 97dd9f1f0ec54eea8878a668370faedd
+      - 71d2b7b9f40b4092b58728f220eb17dc
   response:
     status:
       code: 200
@@ -1051,7 +1051,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1060,7 +1060,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1078,13 +1078,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-80896249-7cde-4924-b01d-de76aab025ba
+      - req-95ab501d-a5d4-462c-8c1f-9024783b6856
       Content-Length:
       - '4118'
       Connection:
@@ -1093,10 +1093,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:17.849140", "expires":
-        "2018-08-06T18:01:17Z", "id": "62896bf235b74e24bcab9f2576cf6038", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:33.585765", "expires":
+        "2018-09-24T21:30:33Z", "id": "bb6d19b1c77647af9224c42fa6c52770", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1wiDVEEbSKOGDQXaY_bXFA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["pqWCxApvSsa8PTtrlhKeAA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1140,7 +1140,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1155,7 +1155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62896bf235b74e24bcab9f2576cf6038
+      - bb6d19b1c77647af9224c42fa6c52770
   response:
     status:
       code: 200
@@ -1166,7 +1166,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:17 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1175,7 +1175,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:17 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1193,13 +1193,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:18 GMT
+      - Mon, 24 Sep 2018 20:30:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e06edd2a-2684-485b-b560-06a75833c635
+      - req-91d5a50c-ec53-4f90-a173-85b4921e3708
       Content-Length:
       - '4117'
       Connection:
@@ -1208,10 +1208,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:18.126146", "expires":
-        "2018-08-06T18:01:18Z", "id": "ea907f15076144d99588f0fe9fc89d0a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:33.844530", "expires":
+        "2018-09-24T21:30:33Z", "id": "d49ad93c6e564ffbbab5c04a28ba78a4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wVBT5_h3Tiinmn4ycYuPnw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["08PEaLUKQ_uGWqvvyJvNMQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1255,7 +1255,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1270,7 +1270,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ea907f15076144d99588f0fe9fc89d0a
+      - d49ad93c6e564ffbbab5c04a28ba78a4
   response:
     status:
       code: 200
@@ -1281,1005 +1281,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-610443d5-279f-4d81-a946-434664fa974b
+      - req-cdcf86a8-c8eb-47bd-9a38-3d7a50c33282
       Date:
-      - Mon, 06 Aug 2018 17:01:18 GMT
+      - Mon, 24 Sep 2018 20:30:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ea907f15076144d99588f0fe9fc89d0a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8c875450-5df4-40d3-9dc9-103169713fe7
-      Date:
-      - Mon, 06 Aug 2018 17:01:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:18 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 06 Aug 2018 17:01:18 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-1f642d6f-d735-475c-a1af-36da3d87a0ba
-      Content-Length:
-      - '4131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:19.062199", "expires":
-        "2018-08-06T18:01:19Z", "id": "eafda5cec7ed4d9eae70ea2ba09cae9f", "tenant":
-        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sTuZvheBRkeJKwT9rRmK4A"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eafda5cec7ed4d9eae70ea2ba09cae9f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-83a2e358-9925-4452-b87c-da4eec86d79d
-      Date:
-      - Mon, 06 Aug 2018 17:01:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eafda5cec7ed4d9eae70ea2ba09cae9f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-497ab87d-e413-49f8-af84-a573ce73c6c3
-      Date:
-      - Mon, 06 Aug 2018 17:01:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 44c5ae1b11214ff09c99669c1b030c56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-e42d5dc4-d7e5-4010-808e-e6d2811ba228
-      Date:
-      - Mon, 06 Aug 2018 17:01:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:19 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 44c5ae1b11214ff09c99669c1b030c56
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-707c9b08-f42d-425f-859c-cc438c5ad42d
-      Date:
-      - Mon, 06 Aug 2018 17:01:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 06 Aug 2018 17:01:20 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a3ba0e39-2e98-4128-add8-a5051f7f4ad5
-      Content-Length:
-      - '4118'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:20.297612", "expires":
-        "2018-08-06T18:01:20Z", "id": "40784ef2808f449b8b8a7d92985191d0", "tenant":
-        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["5JLYgZr8QEiSUP53R3w8aQ"]},
-        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
-        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 40784ef2808f449b8b8a7d92985191d0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-82876867-842b-4e79-9af0-07efb83685d3
-      Date:
-      - Mon, 06 Aug 2018 17:01:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -2326,20 +1333,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2354,7 +1402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 40784ef2808f449b8b8a7d92985191d0
+      - d49ad93c6e564ffbbab5c04a28ba78a4
   response:
     status:
       code: 200
@@ -2365,12 +1413,380 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-90ada232-fc49-4b6d-a737-114f0cd78a07
+      - req-e50b061e-3311-4fc1-b21e-240fb6f6b8cd
       Date:
-      - Mon, 06 Aug 2018 17:01:20 GMT
+      - Mon, 24 Sep 2018 20:30:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:34 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project-No-Admin-Role"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Sep 2018 20:30:34 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-b5c70fc3-2eb5-4b3e-843c-dca22ef36982
+      Content-Length:
+      - '4131'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:34.445029", "expires":
+        "2018-09-24T21:30:34Z", "id": "4aa516ebeb7044b980995d3ff545fdab", "tenant":
+        {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["z4UbyG_ATWyDR-wNbv5MyQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4aa516ebeb7044b980995d3ff545fdab
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-df252e0b-488c-47af-87ec-89d5c580b294
+      Date:
+      - Mon, 24 Sep 2018 20:30:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4aa516ebeb7044b980995d3ff545fdab
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f3765134-f7c5-45a0-8fe6-1b17a719c52a
+      Date:
+      - Mon, 24 Sep 2018 20:30:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2435,29 +1851,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2471,5 +1864,615 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:20 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:34 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - be864a6d2cbb4a6bbe75e7bd929893df
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ef351150-15ee-4f22-9fe2-8b9a0438cd12
+      Date:
+      - Mon, 24 Sep 2018 20:30:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - be864a6d2cbb4a6bbe75e7bd929893df
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9bd475ef-2b37-45c3-a5d9-e1b9a04abff0
+      Date:
+      - Mon, 24 Sep 2018 20:30:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:35 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"EmsRefreshSpec-Project2"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Sep 2018 20:30:35 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-f6c4085d-f92e-416d-9a8c-eb640f9acf26
+      Content-Length:
+      - '4118'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:35.402308", "expires":
+        "2018-09-24T21:30:35Z", "id": "111b9bc360224feea6d52735b43c59c3", "tenant":
+        {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qxmgRNyqTE-2q6z1zwJLzQ"]},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
+        0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 111b9bc360224feea6d52735b43c59c3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d488e3f5-7743-4316-acc2-af2a17214eb5
+      Date:
+      - Mon, 24 Sep 2018 20:30:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:35 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 111b9bc360224feea6d52735b43c59c3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f2b61405-c0e2-47c9-9c61-516c1f8755de
+      Date:
+      - Mon, 24 Sep 2018 20:30:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:21 GMT
+      - Mon, 24 Sep 2018 20:30:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-091710ed-315a-4d05-a238-3c1602be54f9
+      - req-3053521e-4084-4351-aaf0-19e33dc5f81a
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:21.820491", "expires":
-        "2018-08-06T18:01:21Z", "id": "56e66823b45446b2b6c0193abe192c28", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:20.731536", "expires":
+        "2018-09-24T21:30:20Z", "id": "870b66f4c8eb44c592db2d7c47e92080", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_MzYkDOuQC2mBelkGt1Acg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pjB4ofxnTEq6oJQnRf8AAg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56e66823b45446b2b6c0193abe192c28
+      - 870b66f4c8eb44c592db2d7c47e92080
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:21 GMT
+      - Mon, 24 Sep 2018 20:30:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:21 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:22 GMT
+      - Mon, 24 Sep 2018 20:30:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f8fe790c-6ad5-4081-9efd-444cf81838e2
+      - req-8826d035-e337-4dae-8718-6d07c05986f1
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.125679", "expires":
-        "2018-08-06T18:01:22Z", "id": "4fb68998789c411ca3a6c1225b031d20", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:20.994777", "expires":
+        "2018-09-24T21:30:20Z", "id": "d234fb71371e4b688e27d13f9ec3e352", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6dlbEqENT2iH2hiI2T6bbQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DKyua62WTqeZZUy4A3CU1w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4fb68998789c411ca3a6c1225b031d20
+      - d234fb71371e4b688e27d13f9ec3e352
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:22 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d6efd2c4-ccf1-4a8e-b038-3d1f1d26c339
+      - req-54695d1c-467a-4cb9-959d-de820eaa3857
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:22 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6228d5c7-71d6-494d-a74a-901be37224d0
+      - req-d5220d3a-2c3d-4833-9b3f-0fc4ed5e351e
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.607053", "expires":
-        "2018-08-06T18:01:22Z", "id": "e5ff1ba4e1b04f3083f38a1fa54529ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:21.387744", "expires":
+        "2018-09-24T21:30:21Z", "id": "ecd72f144fd349db8de15a2aebb4c3b7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Nrgi7k1mTei525Mi0BtfCw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DFVMq8ULTEqaBU65GW8xhw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -337,7 +337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5ff1ba4e1b04f3083f38a1fa54529ce
+      - ecd72f144fd349db8de15a2aebb4c3b7
   response:
     status:
       code: 200
@@ -348,13 +348,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 17:01:22 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:22 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -372,13 +372,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:22 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-480b12a6-5564-436f-bcf7-28c62d56eee9
+      - req-4c541be2-0a73-4b4c-8100-bba0ed060361
       Content-Length:
       - '370'
       Connection:
@@ -387,13 +387,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:22.896523", "expires":
-        "2018-08-06T18:01:22Z", "id": "02081742577d46ff9ea50eaaaebeceb3", "audit_ids":
-        ["lu13pYLuTc2GKKOXKBX0pA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:21.623525", "expires":
+        "2018-09-24T21:30:21Z", "id": "ad479cf40b904b1e8db95b42f8ffb5da", "audit_ids":
+        ["DnXKdF0KRi6TTcerFoopaQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -408,20 +408,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '02081742577d46ff9ea50eaaaebeceb3'
+      - ad479cf40b904b1e8db95b42f8ffb5da
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:23 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-73b54805-36a7-4130-bbbc-fc6ed3e094c8
+      - req-431550bb-6d5a-4bf7-83fe-51384288ca06
       Content-Length:
       - '500'
       Connection:
@@ -438,13 +438,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"02081742577d46ff9ea50eaaaebeceb3"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"ad479cf40b904b1e8db95b42f8ffb5da"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -456,13 +456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:23 GMT
+      - Mon, 24 Sep 2018 20:30:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8354ef93-eb7c-42cf-8455-7aac478d6176
+      - req-fea494e5-eaaa-4c7b-b946-7d7c0810dd56
       Content-Length:
       - '4143'
       Connection:
@@ -471,11 +471,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:23.688060", "expires":
-        "2018-08-06T18:01:22Z", "id": "c15c831a4d0a44b2b2173dd113402747", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:21.916916", "expires":
+        "2018-09-24T21:30:21Z", "id": "0df6461c21524ff5bb5f02fb5ac7f89f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["uqR0bLzcSlqJx1DVI7sUhw",
-        "lu13pYLuTc2GKKOXKBX0pA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["lgSx-cZmTuKo7dQRTASL6g",
+        "DnXKdF0KRi6TTcerFoopaQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -519,7 +519,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:21 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -534,20 +534,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '02081742577d46ff9ea50eaaaebeceb3'
+      - ad479cf40b904b1e8db95b42f8ffb5da
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:23 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f4aceda4-0287-48fb-b3e6-4a1a443e2905
+      - req-1d20cf97-0791-4575-9fdb-524b994283bb
       Content-Length:
       - '500'
       Connection:
@@ -564,7 +564,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:23 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -582,13 +582,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:23 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-624c463a-a2f3-4bb0-8b0c-727c12373256
+      - req-005f69c0-ecd2-45b6-acf2-aea308e13ef0
       Content-Length:
       - '4117'
       Connection:
@@ -597,10 +597,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.080989", "expires":
-        "2018-08-06T18:01:24Z", "id": "35f1bed92862436a9ee6e5d961274c8d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:22.241114", "expires":
+        "2018-09-24T21:30:22Z", "id": "61d20c7ea23a481b85d826cd8b9fa02d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GU6OzpFyRtWUlj0vjWcJMw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vRH6dnxMTcqEgthZfST79w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -644,7 +644,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -659,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 35f1bed92862436a9ee6e5d961274c8d
+      - 61d20c7ea23a481b85d826cd8b9fa02d
   response:
     status:
       code: 200
@@ -670,7 +670,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -679,7 +679,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -697,13 +697,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bf7d575d-0673-4186-becf-eb0849011815
+      - req-90a7fd71-9ff7-482f-a7da-fc7d09fc8cdb
       Content-Length:
       - '4131'
       Connection:
@@ -712,10 +712,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.426734", "expires":
-        "2018-08-06T18:01:24Z", "id": "54806edc7b14417783f4bb4e797881a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:22.501632", "expires":
+        "2018-09-24T21:30:22Z", "id": "bb012ca5955a4c02a093882a1b2cfaae", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ca5SzTdkSJecNm7HiovEAA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-DhnToirT3S-FAh_jXx1Yw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -759,7 +759,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -774,7 +774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 54806edc7b14417783f4bb4e797881a1
+      - bb012ca5955a4c02a093882a1b2cfaae
   response:
     status:
       code: 200
@@ -785,7 +785,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -794,7 +794,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -812,13 +812,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f1225153-a7a3-4e7f-b320-93946b24333f
+      - req-bc6c7f00-6da5-4476-8f8c-35f1de42b294
       Content-Length:
       - '4118'
       Connection:
@@ -827,10 +827,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:24.716902", "expires":
-        "2018-08-06T18:01:24Z", "id": "ff1d8a59099a4d2d818c79bb357b70b8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:22.769132", "expires":
+        "2018-09-24T21:30:22Z", "id": "460995abd1c54b3694d66912a97db5ce", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["qqoYBEyAR-2Tkkl6Q-XvmQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["B6lhXkjxSgWPPXxsLpBTWA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -874,7 +874,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -889,7 +889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff1d8a59099a4d2d818c79bb357b70b8
+      - 460995abd1c54b3694d66912a97db5ce
   response:
     status:
       code: 200
@@ -900,7 +900,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -909,7 +909,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:24 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -927,13 +927,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:24 GMT
+      - Mon, 24 Sep 2018 20:30:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7ea91920-7790-4734-b336-abdf176fd563
+      - req-fbcbeb08-40e2-419d-91ed-2443abddcd3a
       Content-Length:
       - '4117'
       Connection:
@@ -942,10 +942,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:25.028130", "expires":
-        "2018-08-06T18:01:24Z", "id": "e59c3d725c944d17ba3287380d3c7d87", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:23.032872", "expires":
+        "2018-09-24T21:30:23Z", "id": "25243d9e996f4c7ba0f5ff0e0321d000", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DCwsqRSGQzWisYgvLtcAzQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["GKNCFMawTfatuf77IUczaw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -989,7 +989,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1004,7 +1004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e59c3d725c944d17ba3287380d3c7d87
+      - 25243d9e996f4c7ba0f5ff0e0321d000
   response:
     status:
       code: 200
@@ -1015,53 +1015,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-abebe494-a46b-42c7-b253-b833da4f9947
+      - req-b8c8ad00-faa6-462e-b3ab-a4b922a51e59
       Date:
-      - Mon, 06 Aug 2018 17:01:25 GMT
+      - Mon, 24 Sep 2018 20:30:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1085,74 +1044,6 @@ http_interactions:
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e59c3d725c944d17ba3287380d3c7d87
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9dab98c0-b341-4e12-afaa-f536f2ea350d
-      Date:
-      - Mon, 06 Aug 2018 17:01:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1217,7 +1108,51 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:23 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 25243d9e996f4c7ba0f5ff0e0321d000
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-aceb8d28-fd0c-4274-a395-4347b9c0cf70
+      Date:
+      - Mon, 24 Sep 2018 20:30:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1240,6 +1175,71 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1253,7 +1253,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1271,13 +1271,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:25 GMT
+      - Mon, 24 Sep 2018 20:30:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c44458e4-3764-4c09-ab45-1f79d691c6c5
+      - req-2d23592f-c989-48ae-a0ba-66c9fce1283c
       Content-Length:
       - '4131'
       Connection:
@@ -1286,10 +1286,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:25.823952", "expires":
-        "2018-08-06T18:01:25Z", "id": "a5e51bd9e52e45159fd979b3ee43f970", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:23.603075", "expires":
+        "2018-09-24T21:30:23Z", "id": "208343f8f7364195ab6e187710e819fb", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GsoF60euSUq0dCIQX0i-nw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["dytkkbgeST24FqD-o0-BrA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1333,7 +1333,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:25 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1348,7 +1348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a5e51bd9e52e45159fd979b3ee43f970
+      - 208343f8f7364195ab6e187710e819fb
   response:
     status:
       code: 200
@@ -1359,317 +1359,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-926a2121-20b5-4f1a-9e90-9bf36b5cafd3
+      - req-c9640906-1946-47c8-a2da-1b5cc7b5d9ab
       Date:
-      - Mon, 06 Aug 2018 17:01:26 GMT
+      - Mon, 24 Sep 2018 20:30:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a5e51bd9e52e45159fd979b3ee43f970
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-428be09f-3723-4640-abb3-9730ba3bd4db
-      Date:
-      - Mon, 06 Aug 2018 17:01:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e5ff1ba4e1b04f3083f38a1fa54529ce
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-95ac63d4-6fc3-4a9d-96e5-82a5152ea715
-      Date:
-      - Mon, 06 Aug 2018 17:01:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1716,20 +1411,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:26 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1744,7 +1480,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5ff1ba4e1b04f3083f38a1fa54529ce
+      - 208343f8f7364195ab6e187710e819fb
   response:
     status:
       code: 200
@@ -1755,12 +1491,168 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c287f38b-1697-4cdd-9929-11e7785cda31
+      - req-8a1c1f10-4dac-4f95-94c9-a55bc71c6f69
       Date:
-      - Mon, 06 Aug 2018 17:01:27 GMT
+      - Mon, 24 Sep 2018 20:30:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ecd72f144fd349db8de15a2aebb4c3b7
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c314530a-9076-42f2-b349-9cafb636802d
+      Date:
+      - Mon, 24 Sep 2018 20:30:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -1825,7 +1717,51 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ecd72f144fd349db8de15a2aebb4c3b7
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1d568103-a072-4bec-9558-47758f07f212
+      Date:
+      - Mon, 24 Sep 2018 20:30:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -1848,6 +1784,71 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1861,7 +1862,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1879,13 +1880,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:27 GMT
+      - Mon, 24 Sep 2018 20:30:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c5b587a6-522d-48d3-bd86-e0eea9feeedf
+      - req-d8c7dc05-92a3-4e40-abde-b37175efa271
       Content-Length:
       - '4118'
       Connection:
@@ -1894,10 +1895,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:27.314932", "expires":
-        "2018-08-06T18:01:27Z", "id": "d9ae62c99f9141b3a65891e4fee0d1fc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:24.577243", "expires":
+        "2018-09-24T21:30:24Z", "id": "e00c5098a9b04c08b4512c558b6dcbf3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["g05fy2b_R4S5cPiN6dM3zQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SoTdQLY4SU2BsNKPk8onjA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1941,7 +1942,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1956,7 +1957,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9ae62c99f9141b3a65891e4fee0d1fc
+      - e00c5098a9b04c08b4512c558b6dcbf3
   response:
     status:
       code: 200
@@ -1967,68 +1968,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a261f7e0-b50b-4d69-aa20-384b9f797953
+      - req-6eb911d7-b32f-436a-9342-2b3b27b8d01d
       Date:
-      - Mon, 06 Aug 2018 17:01:27 GMT
+      - Mon, 24 Sep 2018 20:30:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2037,74 +2015,6 @@ http_interactions:
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - d9ae62c99f9141b3a65891e4fee0d1fc
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-dd3af27c-96cf-4f50-92b6-2b3cc8f64b25
-      Date:
-      - Mon, 06 Aug 2018 17:01:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2145,53 +2055,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2205,5 +2074,138 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:27 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - e00c5098a9b04c08b4512c558b6dcbf3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d86d5fd4-5c07-4103-942b-63a3c4b755d2
+      Date:
+      - Mon, 24 Sep 2018 20:30:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:28 GMT
+      - Mon, 24 Sep 2018 20:29:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7d9fa120-4409-4b32-b85a-2aaa36272412
+      - req-c129fe0c-e0c7-40f9-88b5-c360ae868fb0
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:28.971310", "expires":
-        "2018-08-06T18:01:28Z", "id": "1013e719859748ada14555f11a0435b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:55.896308", "expires":
+        "2018-09-24T21:29:55Z", "id": "1a04ed2436024247a404b8bd8ed3442f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["2zOiVfUwQ_G1fw8IakaFiw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["4SNncj2gSLC6VcwV-nI6tw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:29 GMT
+      - Mon, 24 Sep 2018 20:29:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,12 +143,12 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-7b7f059f-ac16-488a-8631-99b34778135d
+      - req-89c114ff-6e2c-4913-9b67-e528c2b78423
       Date:
-      - Mon, 06 Aug 2018 17:01:29 GMT
+      - Mon, 24 Sep 2018 20:29:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"server": {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z",
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-0803c51f-a62e-4f19-a85b-6195016df49f
+      - req-b81cc21e-98e0-4087-8a80-059909b0d9f0
       Date:
-      - Mon, 06 Aug 2018 17:01:29 GMT
+      - Mon, 24 Sep 2018 20:29:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:29 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-a131a60e-7b09-48f0-aadc-5f9de1bfcf8f
+      - req-c91865ce-5328-4757-99fd-0e8a8e823050
       Date:
-      - Mon, 06 Aug 2018 17:01:30 GMT
+      - Mon, 24 Sep 2018 20:29:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a761a7cc-a52b-4327-b1c5-87e1283dcb57
+      - req-547289c9-5728-407e-94f3-3baf264f11d7
       Date:
-      - Mon, 06 Aug 2018 17:01:30 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:30 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:30 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7539165b-dab5-4fae-adc8-55ff8b5ff8a4
+      - req-ef76ddef-db76-4334-ab72-127774435dae
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:31.084469", "expires":
-        "2018-08-06T18:01:31Z", "id": "e186ce13f156403197449ac3a94fd48c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:57.264826", "expires":
+        "2018-09-24T21:29:57Z", "id": "fa2722f6e91d4d1c9999f070612397dd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["SECWVX_iS9en-mGKJbNbWg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Ar25SqlwSXyWKfkXXdxIJQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -434,13 +434,13 @@ http_interactions:
       Content-Length:
       - '119'
       Date:
-      - Mon, 06 Aug 2018 17:01:31 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.0", "links": [{"href":
         "http://10.8.99.233:9696/v2.0", "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -455,7 +455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -466,9 +466,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-424c78af-59db-4b44-809f-9435964de6ad
+      - req-30c136fe-1532-4de9-a2d4-fe8622299be1
       Date:
-      - Mon, 06 Aug 2018 17:01:31 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -477,7 +477,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -495,13 +495,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:31 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f0c7c0a1-6efb-4f49-a195-2113a84dac49
+      - req-1267dc5e-8ceb-4436-982b-80eec03a3ff7
       Content-Length:
       - '4170'
       Connection:
@@ -510,10 +510,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:31.591743", "expires":
-        "2018-08-06T18:01:31Z", "id": "321e7dc3f9ad44d38d10a1c9793c7244", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:57.684812", "expires":
+        "2018-09-24T21:29:57Z", "id": "33efe8fd523e465384311437bb0fec61", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["-6NLkLL0Qn6kWSXvqXq_vA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SeZ428iKSh-DiYwtrua0wA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -558,7 +558,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -573,20 +573,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321e7dc3f9ad44d38d10a1c9793c7244
+      - 33efe8fd523e465384311437bb0fec61
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:31 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-21aaf223-df2b-4468-af6a-843253308922
+      - req-46db479b-738d-4fa3-971d-5c6abcba6619
       Content-Length:
       - '500'
       Connection:
@@ -603,7 +603,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -618,7 +618,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -631,9 +631,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-39dd42b1-4172-4e6f-a58c-257d11d94d87
+      - req-ee3d5344-fccd-4c92-a570-cb03cbf35d02
       Date:
-      - Mon, 06 Aug 2018 17:01:31 GMT
+      - Mon, 24 Sep 2018 20:29:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -642,7 +642,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:31 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -660,13 +660,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df0a290c-ca9a-4269-96f9-d155e86164ef
+      - req-cfde7f32-9e13-4294-a3fc-c6fcb3a6b8ff
       Content-Length:
       - '4170'
       Connection:
@@ -675,10 +675,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:32.140401", "expires":
-        "2018-08-06T18:01:32Z", "id": "748be19a274448b0b87ca06c1225d378", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:58.171223", "expires":
+        "2018-09-24T21:29:58Z", "id": "376a69d4472c485fb9f1371f3682ee7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HWWpo3-LQfGeG_anNI91nQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HFhpocAoRa-p-KrSSkYQ-g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -723,7 +723,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/
@@ -738,7 +738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 748be19a274448b0b87ca06c1225d378
+      - 376a69d4472c485fb9f1371f3682ee7f
   response:
     status:
       code: 300
@@ -749,7 +749,7 @@ http_interactions:
       Content-Length:
       - '648'
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "CURRENT", "id": "v2.3", "links": [{"href":
@@ -762,7 +762,7 @@ http_interactions:
         {"status": "SUPPORTED", "id": "v1.0", "links": [{"href": "http://10.8.99.233:9292/v1/",
         "rel": "self"}]}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -777,7 +777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 748be19a274448b0b87ca06c1225d378
+      - 376a69d4472c485fb9f1371f3682ee7f
   response:
     status:
       code: 200
@@ -788,9 +788,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6f8a2fc9-d4a4-4ef7-aba2-d9a24da3ac3c
+      - req-3a19d138-50e0-43da-b35e-f70d28c66092
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -801,7 +801,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -819,13 +819,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eacb4c8e-128f-4425-ae78-54f21a87add0
+      - req-0e3feaef-1654-4513-8a44-72a41bd4bb2f
       Content-Length:
       - '370'
       Connection:
@@ -834,13 +834,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:32.675622", "expires":
-        "2018-08-06T18:01:32Z", "id": "3922484c86514dcc99f842409448573f", "audit_ids":
-        ["Jds7kGn-SaGuqMVJODPzNQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:58.572992", "expires":
+        "2018-09-24T21:29:58Z", "id": "4478acd14d33413db9e5c05a9a6cbedd", "audit_ids":
+        ["4GKxOx7-QSqXqEG8qxs5LA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -855,20 +855,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3922484c86514dcc99f842409448573f
+      - 4478acd14d33413db9e5c05a9a6cbedd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9f01a3c0-e5bf-41d7-bc35-3f34071e1bf8
+      - req-2aca3b7e-3f18-4f63-83f8-8f74ae014104
       Content-Length:
       - '500'
       Connection:
@@ -885,13 +885,13 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:32 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
     body:
       encoding: UTF-8
-      string: '{"auth":{"token":{"id":"3922484c86514dcc99f842409448573f"},"tenantName":"EmsRefreshSpec-Project"}}'
+      string: '{"auth":{"token":{"id":"4478acd14d33413db9e5c05a9a6cbedd"},"tenantName":"EmsRefreshSpec-Project"}}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -903,13 +903,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:32 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0836b2a8-e766-450d-8e9c-2800f5b1ca50
+      - req-9ecd1ad6-92b0-4090-b0ae-76df7cd4bbbe
       Content-Length:
       - '4143'
       Connection:
@@ -918,11 +918,11 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.071911", "expires":
-        "2018-08-06T18:01:32Z", "id": "b7d5eee97a374a50ba3b8bc870db264c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:58.863847", "expires":
+        "2018-09-24T21:29:58Z", "id": "eceba8b8600b4120a14c704e00d1e2d1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Z7Kse_7kTpGCCaRuEO4WZw",
-        "Jds7kGn-SaGuqMVJODPzNQ"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["th-LJQjNQbO-3jKWTJq71Q",
+        "4GKxOx7-QSqXqEG8qxs5LA"]}, "serviceCatalog": [{"endpoints": [{"adminURL":
         "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a", "region": "RegionOne",
         "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -966,7 +966,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:58 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -981,20 +981,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3922484c86514dcc99f842409448573f
+      - 4478acd14d33413db9e5c05a9a6cbedd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:58 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f2d8699-91d4-4beb-952a-b76f8eccea1d
+      - req-4606f041-921a-4ca0-b235-b7890fcad6e0
       Content-Length:
       - '500'
       Connection:
@@ -1011,7 +1011,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1029,13 +1029,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cbeae936-67bd-4c36-97ab-c7f7d1c6098f
+      - req-bad6312e-7944-4fa9-9282-3b6df9f8011a
       Content-Length:
       - '4117'
       Connection:
@@ -1044,10 +1044,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.460040", "expires":
-        "2018-08-06T18:01:33Z", "id": "472274e41a3649caa8929e0848b3de4b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:59.179369", "expires":
+        "2018-09-24T21:29:59Z", "id": "d67e5bdae7b944e280e497590316ca4c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Hm_TqbmSSi6LdK5eepNV3A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fPvl7a68TA2VEuEFz8xyPQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1091,7 +1091,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1106,7 +1106,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 472274e41a3649caa8929e0848b3de4b
+      - d67e5bdae7b944e280e497590316ca4c
   response:
     status:
       code: 200
@@ -1117,7 +1117,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1126,7 +1126,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1144,13 +1144,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-190bf866-a756-4708-bad5-18f7efa35c28
+      - req-8cde38da-6f6f-4747-a18d-340378f66fa9
       Content-Length:
       - '4131'
       Connection:
@@ -1159,10 +1159,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:33.750079", "expires":
-        "2018-08-06T18:01:33Z", "id": "4d0edf8d676b46229afdbce9d3627a0c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:59.449520", "expires":
+        "2018-09-24T21:29:59Z", "id": "bcefaa71c8154a53b88973736ba50443", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1Eu_37OZQHi8vK7dcIydNg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fVEVWfICT_2SmstVhUyHGA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1206,7 +1206,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1221,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d0edf8d676b46229afdbce9d3627a0c
+      - bcefaa71c8154a53b88973736ba50443
   response:
     status:
       code: 200
@@ -1232,7 +1232,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1241,7 +1241,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:33 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1259,13 +1259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:33 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4b93dc03-6445-4fd7-a3d3-4a5c752e76d5
+      - req-ccd40ca1-bd8d-454c-a897-29e750d88402
       Content-Length:
       - '4118'
       Connection:
@@ -1274,10 +1274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:34.031537", "expires":
-        "2018-08-06T18:01:34Z", "id": "8434b7e4079f46a3bbce4aaf55c5c541", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:29:59.723757", "expires":
+        "2018-09-24T21:29:59Z", "id": "5ae0db44c0e9486396c6399517ee9181", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["HfIyMx1zTVKmnqFt7hbs7w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["V_lDdcqLQK-vnX6u6rCeNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1321,7 +1321,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1336,7 +1336,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8434b7e4079f46a3bbce4aaf55c5c541
+      - 5ae0db44c0e9486396c6399517ee9181
   response:
     status:
       code: 200
@@ -1347,7 +1347,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1356,7 +1356,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -1371,7 +1371,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 472274e41a3649caa8929e0848b3de4b
+      - d67e5bdae7b944e280e497590316ca4c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1384,9 +1384,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-cd301338-f5ce-48c9-8c48-5f318b118f6a
+      - req-4a69960b-7fb7-4dfa-85e7-941afb576dcc
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:29:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1396,7 +1396,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:29:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1411,7 +1411,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 472274e41a3649caa8929e0848b3de4b
+      - d67e5bdae7b944e280e497590316ca4c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1424,9 +1424,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-96489484-a0e0-4b7c-a1e4-5e8f409369ed
+      - req-04fbeb6f-428f-4083-a09d-5b0fe08aa5b4
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1436,7 +1436,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -1451,7 +1451,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d0edf8d676b46229afdbce9d3627a0c
+      - bcefaa71c8154a53b88973736ba50443
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1464,9 +1464,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-97acbf7a-d0c2-4fd3-ad10-6a11349e470a
+      - req-296d7cc5-7cd5-499f-b4c2-0218cd10452d
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1476,7 +1476,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1491,7 +1491,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d0edf8d676b46229afdbce9d3627a0c
+      - bcefaa71c8154a53b88973736ba50443
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1504,9 +1504,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a0e9fe49-afea-46b2-86aa-4abd3b736282
+      - req-57af4b0d-6579-40ff-97d9-92d10afc9ddc
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1516,7 +1516,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -1531,7 +1531,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1544,9 +1544,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-db7e2e81-03cf-4695-906a-ece0c5e08bae
+      - req-a97a66c9-a572-40e7-ac1e-d3b4635bb1b0
       Date:
-      - Mon, 06 Aug 2018 17:01:34 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1556,7 +1556,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:34 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1571,7 +1571,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1584,9 +1584,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-a0e94151-5873-48ce-8bde-1ee14d0b1b8b
+      - req-9ae3d06e-703a-42e4-915e-6743b39d647b
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1596,7 +1596,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -1611,7 +1611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8434b7e4079f46a3bbce4aaf55c5c541
+      - 5ae0db44c0e9486396c6399517ee9181
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1624,9 +1624,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-88cf52b4-a539-4e3f-9df6-d665275d1680
+      - req-346c93c4-ac7d-4d86-a325-4c8de5ae6d3e
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1636,7 +1636,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1651,7 +1651,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8434b7e4079f46a3bbce4aaf55c5c541
+      - 5ae0db44c0e9486396c6399517ee9181
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1664,9 +1664,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-864cedfc-d0f3-4d12-a237-d22fca06ddee
+      - req-8c16929e-593e-4500-8b53-731966c4709b
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1676,7 +1676,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -1691,7 +1691,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1704,9 +1704,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-ed6b4afb-5fe2-4bd7-a57a-03f4d59b9363
+      - req-d24dd71d-c15d-49b1-98ed-64e8feab0e79
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -1715,7 +1715,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -1730,7 +1730,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1743,15 +1743,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-3f31ec2b-42bd-4d13-af2b-98adb17191f0
+      - req-9ceadaae-da96-4c1d-99f7-263f72dd1a40
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -1766,7 +1766,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -1777,19 +1777,19 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-72e3df59-b925-4177-98b6-80bb9db8fee5
+      - req-937cd4c1-d3ab-4ba5-9851-41e7691b3cdf
       Date:
-      - Mon, 06 Aug 2018 17:01:35 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:35 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -1804,7 +1804,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -1815,9 +1815,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-6d9ca7f5-1950-41b9-9506-be3967a567ac
+      - req-9e0d10cf-377d-44b2-806e-d648ee6896e1
       Date:
-      - Mon, 06 Aug 2018 17:01:36 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -1827,7 +1827,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1845,13 +1845,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:36 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ca906362-e505-4311-a57e-68320c236eb1
+      - req-4f094cba-fc6d-4069-b333-149d9370647d
       Content-Length:
       - '4117'
       Connection:
@@ -1860,10 +1860,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:36.240424", "expires":
-        "2018-08-06T18:01:36Z", "id": "02e15f58164b485c99de220dbbdbc03b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:01.395697", "expires":
+        "2018-09-24T21:30:01Z", "id": "22a5e367267440e6ae1ed7bf75aedbd1", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ait_C091QcSu5_WzG20fww"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RQn6hcnCTwaeuripXVFbjw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1907,7 +1907,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1922,7 +1922,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -1933,68 +1933,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5d2e437c-661f-45be-a3ed-d2e4a5a589c2
+      - req-96d36fc1-3ebf-4d3b-a330-74169c85e2ce
       Date:
-      - Mon, 06 Aug 2018 17:01:36 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2026,20 +2003,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2054,7 +2054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -2065,12 +2065,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-292cf660-7de8-43ef-ae73-8e035502c4b9
+      - req-ce29a1db-b119-499c-8b65-3446504ce82e
       Date:
-      - Mon, 06 Aug 2018 17:01:36 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2135,29 +2158,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2171,7 +2171,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2189,13 +2189,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:36 GMT
+      - Mon, 24 Sep 2018 20:30:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-db023adb-0cb3-4336-bcb2-71b3aede3b80
+      - req-cdbff05d-6e08-4eb9-b24e-3909600d2921
       Content-Length:
       - '4131'
       Connection:
@@ -2204,10 +2204,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:36.907717", "expires":
-        "2018-08-06T18:01:36Z", "id": "2c39416231ba4f76920e66025b1198eb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:02.017999", "expires":
+        "2018-09-24T21:30:02Z", "id": "a2bd21f783be4d8ab8265878b8bd4ee1", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BLW28kmVQUSnQmCNJ2j_YA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nGrVkfyFQSWSVNnJfA97Xg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2251,7 +2251,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:36 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2266,7 +2266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -2277,12 +2277,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cea41b83-c1ae-4807-b99f-191866b1776a
+      - req-1ecb75b4-464e-4299-844a-ce5828579879
       Date:
-      - Mon, 06 Aug 2018 17:01:37 GMT
+      - Mon, 24 Sep 2018 20:30:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2347,29 +2370,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2383,7 +2383,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2398,7 +2398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -2409,53 +2409,145 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-3c8da589-8db0-478e-a88b-acbaca609670
+      - req-d1e48702-3cf9-4210-ac03-402f75b4e597
       Date:
-      - Mon, 06 Aug 2018 17:01:37 GMT
+      - Mon, 24 Sep 2018 20:30:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fa2722f6e91d4d1c9999f070612397dd
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-97a3ea37-527a-437e-9ce1-9bd43dcee4fc
+      Date:
+      - Mon, 24 Sep 2018 20:30:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -2479,74 +2571,6 @@ http_interactions:
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d5fe90ad-8a27-41b8-966f-e1d91b962d5f
-      Date:
-      - Mon, 06 Aug 2018 17:01:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -2611,29 +2635,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2647,7 +2648,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2662,7 +2663,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -2673,68 +2674,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8b7c1dde-a05b-4b2f-a922-04537595bdd3
+      - req-5a31c273-440f-4db8-a9a3-28163979c9a4
       Date:
-      - Mon, 06 Aug 2018 17:01:37 GMT
+      - Mon, 24 Sep 2018 20:30:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2766,20 +2744,43 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:37 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2797,13 +2798,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:37 GMT
+      - Mon, 24 Sep 2018 20:30:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32f8d320-393b-47a1-ba12-0dec85d8520b
+      - req-289ca789-ae47-4a9c-bfbc-b7d7b4119385
       Content-Length:
       - '4118'
       Connection:
@@ -2812,10 +2813,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:38.034314", "expires":
-        "2018-08-06T18:01:38Z", "id": "62c051c02683488ba9cc0a197d945652", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:02.911515", "expires":
+        "2018-09-24T21:30:02Z", "id": "3e75589e8f53458995447dc574d57b1f", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["r-CqgDMtT6W0HfKgi_GRpQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["VEWgMwKXT-aorJLvtFgRpQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2859,7 +2860,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2874,7 +2875,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -2885,113 +2886,114 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6e3a63e7-23f0-4569-8b26-5480ab45864c
+      - req-ef86d0d2-939b-4328-a886-d19f68a1a7da
       Date:
-      - Mon, 06 Aug 2018 17:01:38 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -3006,7 +3008,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -3017,12 +3019,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-5f461a5f-9074-475c-8ebb-be411f71d85f
+      - req-6e2db714-ad77-4436-a70c-5ab151ffd71f
       Date:
-      - Mon, 06 Aug 2018 17:01:38 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -3087,29 +3112,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -3123,7 +3125,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -3138,7 +3140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3149,9 +3151,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-d3278a38-8ed6-46eb-b8f5-e151e7bd28b3
+      - req-9fdd8fa2-c778-46f6-811f-3e86a2b2335a
       Date:
-      - Mon, 06 Aug 2018 17:01:38 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3166,7 +3168,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:38 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3181,7 +3183,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -3192,9 +3194,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-c27d8701-8407-4376-9d56-cd64241f2a0e
+      - req-7f004c3e-6c53-4adf-ba82-daf6445b788d
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3230,7 +3232,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3245,7 +3247,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -3256,9 +3258,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-76bd5f5f-fc68-4cd1-afb6-e11c707673b8
+      - req-375fa919-c695-4f87-bfec-98ce11383066
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3294,7 +3296,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3309,7 +3311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -3320,9 +3322,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a8e2e81f-ab8b-488a-86fd-3694b526fecc
+      - req-1f40df47-b565-4a08-9250-ecea36cae397
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3358,7 +3360,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3373,7 +3375,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -3384,9 +3386,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-b85cb0e9-9187-48d9-bc65-7ae4403f18d1
+      - req-b6fb6e95-1aa7-4858-ba0b-f74f7fd8ae8e
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3422,7 +3424,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3437,7 +3439,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3448,9 +3450,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-974598d8-ce52-4ff7-ad4d-d43764b22f4b
+      - req-a683870f-d1b6-4e95-815b-6d9d5f5a674e
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3486,7 +3488,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3501,7 +3503,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3512,9 +3514,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-09fa0760-8afb-47bf-aa86-68c66651b080
+      - req-880a09b2-4993-4fce-8ad8-b0b0c601186a
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3550,7 +3552,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3565,7 +3567,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -3576,9 +3578,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-f3972123-067c-466b-913c-529f0a5641a4
+      - req-9212c092-a748-42f2-97d4-d1c65693085d
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3614,7 +3616,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3629,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -3640,9 +3642,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-6f30e6ad-f7b1-46f8-9bb1-c8a612b658b6
+      - req-7dc7b114-4d22-4200-8a9b-e3f810f9d32b
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3678,7 +3680,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -3693,7 +3695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3704,9 +3706,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-d5390d7d-e469-4e57-9d01-bac8b7a368be
+      - req-799dbf10-ba2b-4f7d-8372-3441d85bbfcf
       Date:
-      - Mon, 06 Aug 2018 17:01:39 GMT
+      - Mon, 24 Sep 2018 20:30:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -3715,7 +3717,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:39 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -3730,7 +3732,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3741,9 +3743,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-aa7af5e2-e348-4d31-8361-99eda89a41d4
+      - req-d0d5538b-af6c-4c9e-b01c-30dedb02f20a
       Date:
-      - Mon, 06 Aug 2018 17:01:40 GMT
+      - Mon, 24 Sep 2018 20:30:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -3829,7 +3831,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -3844,7 +3846,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -3855,9 +3857,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-ad8425b8-a84c-4ed3-a088-c287efd136ba
+      - req-5d6d56e0-2661-4051-8f7b-9fa3e3e7de88
       Date:
-      - Mon, 06 Aug 2018 17:01:40 GMT
+      - Mon, 24 Sep 2018 20:30:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -3871,7 +3873,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3889,13 +3891,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:40 GMT
+      - Mon, 24 Sep 2018 20:30:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2355608a-819e-416e-b937-14259596c4d2
+      - req-77cbc1c2-ae92-4042-b4e8-a25808039e94
       Content-Length:
       - '4117'
       Connection:
@@ -3904,10 +3906,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2018-08-06T17:01:40.407978", "expires":
-        "2018-08-06T18:01:40Z", "id": "c4392a5fbcdd45d6aa5f6223a63b03dc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2018-09-24T20:30:07.875998", "expires":
+        "2018-09-24T21:30:07Z", "id": "e62fa2666d014e48ac2a912d71f358af", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["DiH6_VbQSvGB5GHHKW4Myg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yttnCRH7QJuRWOoDkvAPWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3951,7 +3953,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:40 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -3966,22 +3968,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4392a5fbcdd45d6aa5f6223a63b03dc
+      - e62fa2666d014e48ac2a912d71f358af
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c4e332b6-2bc8-4f89-9516-56038a513338
+      - req-8a9577c5-e525-4290-93b1-b72403fc1a09
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-c4e332b6-2bc8-4f89-9516-56038a513338
+      - req-8a9577c5-e525-4290-93b1-b72403fc1a09
       Date:
-      - Mon, 06 Aug 2018 17:01:40 GMT
+      - Mon, 24 Sep 2018 20:30:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -4002,7 +4004,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -4017,22 +4019,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4392a5fbcdd45d6aa5f6223a63b03dc
+      - e62fa2666d014e48ac2a912d71f358af
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f5febc9a-cad9-48dd-a4b2-0f9ef4ab0d43
+      - req-6b4c18b2-7342-481b-8055-d1e7f509e751
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-f5febc9a-cad9-48dd-a4b2-0f9ef4ab0d43
+      - req-6b4c18b2-7342-481b-8055-d1e7f509e751
       Date:
-      - Mon, 06 Aug 2018 17:01:41 GMT
+      - Mon, 24 Sep 2018 20:30:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -4053,7 +4055,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:41 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4068,7 +4070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4081,12 +4083,12 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-7b2cbe4d-10c7-46e1-84cc-ac16a443923b
+      - req-1ee11546-c8e4-40f0-a273-c1074f332352
       Date:
-      - Mon, 06 Aug 2018 17:01:42 GMT
+      - Mon, 24 Sep 2018 20:30:09 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"server": {"status": "ACTIVE", "updated": "2018-06-19T16:44:04Z",
+      string: '{"server": {"status": "ACTIVE", "updated": "2018-08-27T20:24:35Z",
         "hostId": "bb5e57f091d4c5737235b6ea23cd3cf06921fdb1ff1e90c2eb3098a9", "OS-EXT-SRV-ATTR:host":
         "11.22.33.44", "addresses": {"EmsRefreshSpec-NetworkPrivate":
         [{"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:e1:0b:2c", "version": 4, "addr": "192.168.0.5",
@@ -4110,7 +4112,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -4125,7 +4127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4138,9 +4140,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-da57e7a4-cb55-4dd8-bf58-261c425f199f
+      - req-46c7848c-8381-4051-855b-33e694450096
       Date:
-      - Mon, 06 Aug 2018 17:01:42 GMT
+      - Mon, 24 Sep 2018 20:30:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -4148,7 +4150,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -4163,7 +4165,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4176,9 +4178,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-682cf67f-49cb-4eb9-8dcd-2c830094fcc2
+      - req-2aeed32c-417a-4e90-843d-eb65d73cc2cf
       Date:
-      - Mon, 06 Aug 2018 17:01:42 GMT
+      - Mon, 24 Sep 2018 20:30:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -4230,7 +4232,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:42 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4245,7 +4247,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4258,14 +4260,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b7db218b-f6fa-45e7-9978-bd9b1df28ecd
+      - req-3e6bb46a-cb10-4f93-bd88-20bb94e4f2c5
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -4280,7 +4282,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -4291,9 +4293,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-934a595a-e0de-4f40-9d00-785da2e9fb90
+      - req-49ae5c01-9c31-4a5c-9915-5928d58d35cf
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -4302,7 +4304,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
@@ -4317,7 +4319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -4328,9 +4330,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Openstack-Request-Id:
-      - req-045b7c5c-c2a4-4702-8300-7d0187c3c624
+      - req-c7e2ca61-52a2-45ad-96f5-3f7d7415cfc5
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -4339,7 +4341,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -4354,20 +4356,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321e7dc3f9ad44d38d10a1c9793c7244
+      - 33efe8fd523e465384311437bb0fec61
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-69c8e713-1df0-4347-acc5-4afd76387483
+      - req-cdb8cfce-ba41-4166-a1e4-5192c3c3d184
       Content-Length:
       - '500'
       Connection:
@@ -4384,7 +4386,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -4399,7 +4401,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4412,9 +4414,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-dd71635b-666d-426b-99a2-c8d3c30c8a41
+      - req-7939cf7a-0672-4942-9ae3-eb5621cc7339
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -4423,7 +4425,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -4438,7 +4440,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 748be19a274448b0b87ca06c1225d378
+      - 376a69d4472c485fb9f1371f3682ee7f
   response:
     status:
       code: 200
@@ -4449,9 +4451,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-05f93e1e-7943-4b28-bec9-be4afb967b04
+      - req-644f96a5-03de-4b85-acde-54b73bf0063d
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -4462,7 +4464,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -4477,7 +4479,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 472274e41a3649caa8929e0848b3de4b
+      - d67e5bdae7b944e280e497590316ca4c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4490,9 +4492,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-21b4eae6-a551-4cf9-840b-144582221fd4
+      - req-8e603b35-52c7-4f2b-8a0d-e22a8e376d8a
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4502,7 +4504,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4517,7 +4519,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 472274e41a3649caa8929e0848b3de4b
+      - d67e5bdae7b944e280e497590316ca4c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4530,9 +4532,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-74ef3999-f207-4099-9b95-397d3d425d3b
+      - req-8317c465-c266-47cc-9823-16d967d20982
       Date:
-      - Mon, 06 Aug 2018 17:01:43 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4542,7 +4544,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:43 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -4557,7 +4559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d0edf8d676b46229afdbce9d3627a0c
+      - bcefaa71c8154a53b88973736ba50443
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4570,9 +4572,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-ad0508ff-1b8f-419e-b890-3b24e8b77479
+      - req-f79d1a39-ecbd-4bda-a5c2-38acafdff5f8
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4582,7 +4584,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4597,7 +4599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4d0edf8d676b46229afdbce9d3627a0c
+      - bcefaa71c8154a53b88973736ba50443
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4610,9 +4612,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-18fad80f-354b-4e6c-8d6e-9d561c038987
+      - req-a105eebd-c3da-4251-9f82-430b2e5df818
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4622,7 +4624,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -4637,7 +4639,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4650,9 +4652,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1ee5d7a9-6e6e-412f-9868-500cf73740bf
+      - req-f0c68e3e-b5ca-489e-a8fc-1a9e812fa376
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4662,7 +4664,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4677,7 +4679,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4690,9 +4692,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-1e4ebe93-8c72-4dc8-b5a9-c001ab7466c6
+      - req-652c67c4-9eeb-4349-8349-30ed0ab20776
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4702,7 +4704,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -4717,7 +4719,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8434b7e4079f46a3bbce4aaf55c5c541
+      - 5ae0db44c0e9486396c6399517ee9181
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4730,9 +4732,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-64d1aadb-3427-4853-9bd0-041f925a2a8a
+      - req-9615f3f6-8fb1-416f-9702-902643f66b25
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4742,7 +4744,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4757,7 +4759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8434b7e4079f46a3bbce4aaf55c5c541
+      - 5ae0db44c0e9486396c6399517ee9181
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4770,9 +4772,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-9de4fdc7-2766-4433-9d7a-c61eef78d5ab
+      - req-b1857dd2-aa22-49b6-9bed-7c9af517217c
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4782,7 +4784,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -4797,7 +4799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4810,9 +4812,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-34281c21-0b61-4816-b6c4-86ed7b26a3ed
+      - req-a2da1255-f91f-4e11-8162-2a06e4303ed3
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -4821,7 +4823,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4836,7 +4838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1013e719859748ada14555f11a0435b5
+      - 1a04ed2436024247a404b8bd8ed3442f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4849,15 +4851,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-2a75a0e9-1f30-421f-86df-e8138b911edf
+      - req-bb2be0f6-bb08-42d9-a04e-5349f6c9c97f
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:44 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -4872,7 +4874,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -4883,9 +4885,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-835c6826-e37a-4c50-b0a8-925f5c0507e6
+      - req-dbdb61ee-e74d-4f29-a2c9-cc4097230e83
       Date:
-      - Mon, 06 Aug 2018 17:01:44 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
@@ -4895,7 +4897,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -4910,7 +4912,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -4921,9 +4923,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-c26750d8-c34b-499c-9116-9fb06bc0db15
+      - req-8e2492e3-fdb2-4d51-9994-5ff0d81086b0
       Date:
-      - Mon, 06 Aug 2018 17:01:45 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -4933,7 +4935,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -4948,7 +4950,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -4959,53 +4961,277 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-45ddb394-813e-498e-8d0f-caca10ffcef9
+      - req-eb211f6c-eae6-4216-8256-abd109e07785
       Date:
-      - Mon, 06 Aug 2018 17:01:45 GMT
+      - Mon, 24 Sep 2018 20:30:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 22a5e367267440e6ae1ed7bf75aedbd1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-687b7d4d-29d3-4557-85a1-120ffdc26e86
+      Date:
+      - Mon, 24 Sep 2018 20:30:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a2bd21f783be4d8ab8265878b8bd4ee1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7b35f182-6b82-4330-a491-428077998887
+      Date:
+      - Mon, 24 Sep 2018 20:30:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -5052,74 +5278,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0b669053-0bb4-48d9-9796-8bff49a38ded
-      Date:
-      - Mon, 06 Aug 2018 17:01:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -5161,29 +5319,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5197,7 +5332,139 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a2bd21f783be4d8ab8265878b8bd4ee1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-12fbd3cd-73a1-4a8e-acd6-48e1b94325ea
+      Date:
+      - Mon, 24 Sep 2018 20:30:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -5212,7 +5479,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -5223,185 +5490,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-22207b93-bd2f-4e7e-b2c7-c9b6b4be218e
+      - req-fa131af9-9f66-47ba-beb8-1a231859d6dc
       Date:
-      - Mon, 06 Aug 2018 17:01:45 GMT
+      - Mon, 24 Sep 2018 20:30:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:45 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ce904637-fcd8-4da9-932f-f5a3d824f278
-      Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -5448,74 +5542,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4278874f-3eb3-4a24-8ba7-a09a2fa50592
-      Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -5557,29 +5583,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5593,7 +5596,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -5608,7 +5611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -5619,53 +5622,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9e0e10bd-0a32-41d2-96ff-77eefdf4aa29
+      - req-555eb2c3-a0c6-4d0f-9f8c-10ca79542cb3
       Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
+      - Mon, 24 Sep 2018 20:30:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
-        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
@@ -5712,20 +5674,61 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -5740,7 +5743,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -5751,12 +5754,35 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-57a8549c-8048-4e12-8482-84da5d348404
+      - req-9afedb40-2e48-47ec-9c19-cc50ca4874a0
       Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
+      - Mon, 24 Sep 2018 20:30:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
         false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
@@ -5821,29 +5847,6 @@ http_interactions:
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5857,7 +5860,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -5872,7 +5875,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -5883,113 +5886,114 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-308eb5b7-f000-4ce7-bc8b-dc3dfbda6ff8
+      - req-0f7258c4-4867-4970-a7b2-66975f2a17bf
       Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
         "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_2", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.50.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.50.2", "end": "192.168.50.2"}, {"start":
+        "192.168.50.4", "end": "192.168.50.4"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24", "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
         true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
         "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
         "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_1",
+        "enable_dhcp": true, "network_id": "560b4210-2b5a-4439-8d24-203e09478f48",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.40.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.40.2",
+        "end": "192.168.40.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.40.0/24", "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.2", "end": "192.168.3.6"}, {"start":
+        "192.168.3.8", "end": "192.168.3.10"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:46 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -6004,7 +6008,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6015,9 +6019,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-e4add033-fba0-4578-a3f1-a4fe93864412
+      - req-b7efccde-b23a-422a-914c-def53d629a94
       Date:
-      - Mon, 06 Aug 2018 17:01:46 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6032,7 +6036,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -6047,7 +6051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -6058,9 +6062,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-8c1ce982-503d-4ca4-a63d-67c8382bc2b6
+      - req-8b1eafd8-0f3f-4654-8e9e-8246a65396fc
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6096,7 +6100,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -6111,7 +6115,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 02e15f58164b485c99de220dbbdbc03b
+      - 22a5e367267440e6ae1ed7bf75aedbd1
   response:
     status:
       code: 200
@@ -6122,9 +6126,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-bb8a89d8-bd8b-41a7-ad21-1b0380fba8c6
+      - req-4c6536f1-a395-4a0b-b42e-faf98b368e62
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6160,7 +6164,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -6175,7 +6179,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -6186,9 +6190,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-d090734d-91b6-4be3-b650-e3a637b5954d
+      - req-9950f88b-76ac-40b8-a4e2-ab8ab0f37feb
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6224,7 +6228,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -6239,7 +6243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c39416231ba4f76920e66025b1198eb
+      - a2bd21f783be4d8ab8265878b8bd4ee1
   response:
     status:
       code: 200
@@ -6250,9 +6254,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-2f831344-76b6-4491-b29e-22883ed22f70
+      - req-e8739afb-465b-4a7b-ab93-8b420c50aba0
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6288,7 +6292,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -6303,7 +6307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6314,9 +6318,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-73d7f486-4adc-43e5-84b5-cd3dcc7b7e9f
+      - req-660f207a-0a9a-40f1-bea6-b0a52585ccfd
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6352,7 +6356,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -6367,7 +6371,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6378,9 +6382,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-2f1a4566-f5c9-400f-9ddc-318699059e84
+      - req-117ac908-7884-4374-b24c-0c963c0761b1
       Date:
-      - Mon, 06 Aug 2018 17:01:47 GMT
+      - Mon, 24 Sep 2018 20:30:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6416,7 +6420,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:47 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -6431,7 +6435,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -6442,9 +6446,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-b214df4f-29fd-461a-af5c-7b3e99bc8743
+      - req-981020a7-2ffd-4dcb-87c0-ff2351e737e8
       Date:
-      - Mon, 06 Aug 2018 17:01:48 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6480,7 +6484,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -6495,7 +6499,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62c051c02683488ba9cc0a197d945652
+      - 3e75589e8f53458995447dc574d57b1f
   response:
     status:
       code: 200
@@ -6506,9 +6510,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a1e414bd-1656-4aef-bcea-f2a091fd83cb
+      - req-954ba656-cd64-4dfc-a169-4b2a8b5719f7
       Date:
-      - Mon, 06 Aug 2018 17:01:48 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6544,7 +6548,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -6559,7 +6563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6570,9 +6574,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-41f45717-2caa-40b7-b1fe-8c12d66cdd91
+      - req-d65007d3-3219-4634-a55e-bc5fcdbfd08f
       Date:
-      - Mon, 06 Aug 2018 17:01:48 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -6581,7 +6585,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -6596,7 +6600,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6607,9 +6611,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-d94a4019-03bf-4d84-a63c-71fd2d296eca
+      - req-f605d358-b905-4119-873b-a40df8097adc
       Date:
-      - Mon, 06 Aug 2018 17:01:48 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -6695,7 +6699,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -6710,7 +6714,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e186ce13f156403197449ac3a94fd48c
+      - fa2722f6e91d4d1c9999f070612397dd
   response:
     status:
       code: 200
@@ -6721,9 +6725,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-db8bcc28-6fdf-4e3d-a6d9-62a65f0fb96c
+      - req-1ac3e8ff-3df2-4810-a6c4-d5ce08e88e3d
       Date:
-      - Mon, 06 Aug 2018 17:01:48 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -6737,7 +6741,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:48 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -6752,22 +6756,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4392a5fbcdd45d6aa5f6223a63b03dc
+      - e62fa2666d014e48ac2a912d71f358af
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bea0a8ef-3652-4b8c-b7fe-b327680a59ff
+      - req-ddb2243b-dcd5-4681-9bcb-7c8bb7f6e9d4
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-bea0a8ef-3652-4b8c-b7fe-b327680a59ff
+      - req-ddb2243b-dcd5-4681-9bcb-7c8bb7f6e9d4
       Date:
-      - Mon, 06 Aug 2018 17:01:49 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -6788,7 +6792,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -6803,22 +6807,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c4392a5fbcdd45d6aa5f6223a63b03dc
+      - e62fa2666d014e48ac2a912d71f358af
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ad5062a-1e83-4d2b-8075-ca244f4f85f1
+      - req-40d860dc-5d9d-460d-a990-6332e09bd135
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-3ad5062a-1e83-4d2b-8075-ca244f4f85f1
+      - req-40d860dc-5d9d-460d-a990-6332e09bd135
       Date:
-      - Mon, 06 Aug 2018 17:01:49 GMT
+      - Mon, 24 Sep 2018 20:30:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -6839,5 +6843,5 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Mon, 06 Aug 2018 17:01:49 GMT
+  recorded_at: Mon, 24 Sep 2018 20:30:14 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds missing `openstack_admin?` to the Cloud Manager's volume snapshot templates collection.