### PR TITLE
Direct attribute access for `cloud_volume_types` via cloud_tenants API

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
   virtual_has_one :default_security_group, :uses => :security_groups
+  virtual_delegate :cloud_volume_types, :to => "ext_management_system.cloud_volume_types", :allow_nil => true, :default => []
 
   include ManageIQ::Providers::Openstack::HelperMethods
   has_and_belongs_to_many :miq_templates,


### PR DESCRIPTION
The changes in this PR allow us to gain direct attribute access to `cloud_volume_types` via the `cloud_tenants` API, as shown below - 

```
api/cloud_tenants/20000000000001?attributes=cloud_volume_types
```


```
{
  "href": "http://0.0.0.0:8080/api/cloud_tenants/20000000000001",
  "id": "20000000000001",
  "name": "fdupont-prj-1",
  "description": "",
  "enabled": true,
  "ems_ref": "0898f6eef46c4f17a79db2f9d73a3a40",
  "ems_id": "20000000000006",
  "created_at": "2018-09-26T22:26:37Z",
  "updated_at": "2018-09-26T22:26:37Z",
  "type": "ManageIQ::Providers::Openstack::CloudManager::CloudTenant",
  "parent_id": null,
  "cloud_volume_types": [
    {
      "href": "http://0.0.0.0:8080/api/cloud_volume_types/20000000000001",
      "id": "20000000000001",
      "description": null,
      "name": "default",
      "type": "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType",
      "backend_name": null,
      "ems_ref": "da2d83b0-43f4-4f16-ac85-799b6396e279",
      "ems_id": "20000000000004",
      "public": true,
      "created_at": "2018-09-26T22:25:53Z",
      "updated_at": "2018-09-26T22:25:53Z"
    }
  ]
}

 
```