### PR TITLE
User-friendly message for creating Routers

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -41,7 +41,14 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     {:ems_ref => router['id'], :name => options[:name]}
   rescue => e
     _log.error "router=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqNetworkRouterCreateError, parse_error_message_from_neutron_response(e), e.backtrace
+    parsed_error = parse_error_message_from_neutron_response(e)
+    error_message = case parsed_error
+                    when /Quota exceeded for resources/
+                      _("Quota exceeded for routers.")
+                    else
+                      parsed_error
+                    end
+    raise MiqException::MiqNetworkRouterCreateError, error_message, e.backtrace
   end
 
   def raw_delete_network_router


### PR DESCRIPTION
PR adds a user-friendly message appearing during the creation of the Network Router when the quota for resources is exceeded.

https://bugzilla.redhat.com/show_bug.cgi?id=1638390

Before:
![screenshot from 2018-10-16 14-10-09](https://user-images.githubusercontent.com/26881797/47020058-d1ae7a00-d158-11e8-8ce3-5c51e7a1b1c4.png)

After:
![screenshot from 2018-10-16 15-32-15](https://user-images.githubusercontent.com/26881797/47020077-db37e200-d158-11e8-9eb9-541c0fb2c100.png)

@aufi 
@mansam 