### PR TITLE
Check if host create event exists and assign host to it

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
@@ -20,6 +20,7 @@ module ManageIQ::Providers::Openstack::InfraManager::EventParser
 
     if payload.key? "instance_id"
       event_hash[:host_id] = Host.find_by("ems_ref_obj" => YAML.dump(payload["instance_id"])).try(:id)
+      event_hash[:host_name] = payload["instance_id"]
     end
     event_hash[:message]                   = payload["message"]           if payload.key? "message"
     event_hash[:host_ems_ref]              = payload["node"]              if payload.key? "node"

--- a/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
@@ -13,7 +13,7 @@ module ManageIQ
       end
 
       def post_process_refresh_classes
-        [::Vm]
+        [::Vm, ManageIQ::Providers::Openstack::InfraManager::Host]
       end
     end
   end

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -578,4 +578,28 @@ describe ManageIQ::Providers::Openstack::InfraManager::Host do
       expect(MiqQueue.where(:method_name => "refresh").count).to eq(1)
     end
   end
+
+  describe 'after create callback' do
+    let(:ext_management_system) { FactoryGirl.create(:ems_openstack_infra) }
+
+    it "assigns scale out event fot host" do
+      payload = { "instance_id" => "openstack-perf-host-nova-instance" }
+
+      event_hash = {
+        :event_type => "compute.instance.create.end",
+        :source     => "OPENSTACK",
+        :message    => payload,
+        :timestamp  => "2016-03-13T16:59:01.760000",
+        :username   => "",
+        :full_data  => {:content => {'payload' => payload}},
+        :ems_id     => ext_management_system.id,
+        :host_name  => "openstack-perf-host-nova-instance"
+      }
+
+      EmsEvent.add(ext_management_system.id, event_hash)
+      host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ext_management_system)
+      host.update_create_event
+      expect(ext_management_system.ems_events.first.host_id).to eq(host.id)
+    end
+  end
 end


### PR DESCRIPTION
After creating host check if `compute.instance.create.end` event exists and assign host to it.
I don't know if there is a better way to assign a host, querying all events and then selecting hosts doesn't look very efficient, but I didn't came up with something better.

@mansam  Can you review it? :)

https://bugzilla.redhat.com/show_bug.cgi?id=1584770